### PR TITLE
Use I18n for delimiter and separator

### DIFF
--- a/lib/money.rb
+++ b/lib/money.rb
@@ -21,6 +21,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 require 'bigdecimal'
+require 'i18n' rescue LoadError
 require 'money/currency'
 require 'money/money'
 require 'money/defaults'

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -724,24 +724,40 @@ class Money
     currency.symbol || "¤"
   end
 
-  # Uses +Currency#delimiter+. If +nil+ is returned, default to ",".
+  # If I18n is loaded, looks up key +:number.format.delimiter+.
+  # Otherwise and as fallback it uses +Currency#delimiter+.
+  # If +nil+ is returned, default to ",".
   #
   # @return [String]
   #
   # @example
   #   Money.new(100, "USD").delimiter #=> ","
-  def delimiter
-    currency.delimiter || ","
+  if Object.const_defined?("I18n")
+    def delimiter
+      I18n.t(:"number.format.delimiter", :default => currency.delimiter || ",")
+    end
+  else
+    def delimiter
+      currency.delimiter || ","
+    end
   end
 
-  # Uses +Currency#separator+. If +nil+ is returned, default to ".".
+  # If I18n is loaded, looks up key +:number.format.seperator+.
+  # Otherwise and as fallback it uses +Currency#seperator+.
+  # If +nil+ is returned, default to ",".
   #
   # @return [String]
   #
   # @example
   #   Money.new(100, "USD").separator #=> "."
-  def separator
-    currency.separator || "."
+  if Object.const_defined?("I18n")
+    def separator
+      I18n.t(:"number.format.separator", :default => currency.separator || ".")
+    end
+  else
+    def separator
+      currency.separator || "."
+    end
   end
 
   # Creates a formatted price string according to several rules.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,3 +3,15 @@ require "rubygems"
 
 RSpec.configure do |config|
 end
+
+def reset_i18n()
+  I18n.backend = I18n::Backend::Simple.new
+end
+
+def store_number_formats(locale, translations)
+  I18n.backend.store_translations(locale, {
+    :number => {
+      :format => translations
+    }
+  })
+end


### PR DESCRIPTION
Delimiter and separator are not dependent on the curruncy but the users locale. In Germany you use always a dot as delimiter and a comma as separator. I added this behaviour to the delimiter and separator methods. Any comments or further suggestions? 
