### PR TITLE
Bugfix bigdecimal to string strangeness

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -900,7 +900,7 @@ class Money
   # @example
   #   Money.ca_dollar(100).to_s #=> "1.00"
   def to_s
-    unit, subunit  = cents.abs.divmod(currency.subunit_to_unit).map{|o| o.to_s}
+    unit, subunit  = cents.abs.divmod(currency.subunit_to_unit).map{|o| o.to_i.to_s}
     if currency.decimal_places == 0
       return "-#{unit}" if cents < 0
       return unit

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -644,6 +644,9 @@ describe Money do
     it "returns the monetary value as a string" do
       Money.ca_dollar(100).format.should == "$1.00"
       Money.new(40008).format.should == "$400.08"
+      1.to_money.format.should == "$1.00"
+      1.01.to_money.format.should == "$1.01"
+      BigDecimal.new("1.01").to_money.format.should == "$1.01"
     end
 
     it "should respect :subunit_to_unit currency property" do


### PR DESCRIPTION
During an upgrade from 2.x to 3.x I noticed this an error in the way `Money#to_s` now works. 

```
BigDecimal#divmod(Fixnum) => [BigDecimal, BigDecimal]
```

This is expected but when a to_s is called on a BigDecimal, the output is incorrect. In this case, `#to_i` makes sense.
