### PR TITLE
TypeError fix

### DIFF
--- a/lib/money/bank/variable_exchange.rb
+++ b/lib/money/bank/variable_exchange.rb
@@ -81,7 +81,7 @@ class Money
         end
         _to_currency_  = Currency.wrap(to_currency)
 
-        cents = from.cents / (BigDecimal.new(from.currency.subunit_to_unit.to_s) / BigDecimal.new(_to_currency_.subunit_to_unit.to_s))
+        cents = BigDecimal.new(from.cents.to_s) / (BigDecimal.new(from.currency.subunit_to_unit.to_s) / BigDecimal.new(_to_currency_.subunit_to_unit.to_s))
 
         ex = cents * BigDecimal.new(rate.to_s)
         ex = ex.to_f


### PR DESCRIPTION
Good morning,

Started using your gem with google_currency, tried to do a simple conversion:

n = 1.to_money(:USD)
n.exchange_to(:EUR)

and got
TypeError: can't convert Fixnum into String
        from /Users/cbillen/.rvm/gems/ree-1.8.7-2010.02/gems/money-3.5.4/lib/money/bank/variable_exchange.rb:84:in `new'
        from /Users/cbillen/.rvm/gems/ree-1.8.7-2010.02/gems/money-3.5.4/lib/money/bank/variable_exchange.rb:84:in`exchange_with'
        from /Users/cbillen/.rvm/gems/ree-1.8.7-2010.02/gems/money-3.5.4/lib/money/money.rb:937:in `exchange_to'
        from (irb):2

I'm on ree-1.8.7-2010.02

Doing this simple conversion solves the issue.

Have a good day
