### PR TITLE
Additional input parsing

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -1077,13 +1077,23 @@ class Money
   #
   def self.extract_cents(input, currency = Money.default_currency)
     # remove anything that's not a number, potential thousands_separator, or minus sign
-    num = input.gsub(/[^\d|\.|,|\'|\s|\-]/, '').strip
+    num = input.gsub(/[^\d|\.|,|\'|\-]/, '').strip
 
     # set a boolean flag for if the number is negative or not
     negative = num.split(//).first == "-"
 
     # if negative, remove the minus sign from the number
-    num = num.gsub(/^-/, '') if negative
+    # if it's not negative, the hyphen makes the value invalid
+    if negative
+      num = num.gsub(/^-/, '')
+    else
+      raise ArgumentError, "Invalid currency amount (hyphen)" if num.include?('-')
+    end
+
+    #if the number ends with punctuation, just throw it out.  If it means decimal,
+    #it won't hurt anything.  If it means a literal period or comma, this will
+    #save it from being mis-interpreted as a decimal.
+    num.chop! if num.match /[\.|,]$/
 
     # gather all decimal_marks within the result number
     used_decimal_marks = num.scan /[^\d]/

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -1201,5 +1201,55 @@ describe "Actions involving two Money objects" do
       (Money.new(10_00, "USD") / other).should == 0.1
     end
   end
+end
 
+
+describe "Money.parse" do
+
+    it "should be able to parse european-formatted inputs under 10EUR" do
+      five_ninety_five = Money.new(595, 'EUR')
+
+      Money.parse('EUR 5,95').should    == five_ninety_five
+      #TODO: try and handle these
+      #Money.parse('€5,95').should       == five_ninety_five
+      #Money.parse('&#036;5.95').should  == five_ninety_five
+    end
+
+    it "should be able to parse european-formatted inputs with multiple thousands-seperators" do
+      Money.parse('EUR 1.234.567,89').should     == Money.new(123456789, 'EUR')
+      Money.parse('EUR 1.111.234.567,89').should == Money.new(111123456789, 'EUR')
+    end
+
+    it "should be able to parse USD-formatted inputs under $10" do
+      five_ninety_five = Money.new(595, 'USD')
+
+      Money.parse(5.95).should          == five_ninety_five
+      Money.parse('5.95').should        == five_ninety_five
+      Money.parse('$5.95').should       == five_ninety_five
+      Money.parse("\n $5.95 \n").should == five_ninety_five
+      Money.parse('$ 5.95').should      == five_ninety_five
+      Money.parse('$5.95 ea.').should   == five_ninety_five
+      Money.parse('$5.95, each').should == five_ninety_five
+    end
+
+    it "should be able to parse USD-formatted inputs with multiple thousands-seperators" do
+      Money.parse('1,234,567.89').should     == Money.new(123456789, 'USD')
+      Money.parse('1,111,234,567.89').should == Money.new(111123456789, 'USD')
+    end
+
+    it "should not return a price if there is a price range" do
+      lambda {Money.parse('$5.95-10.95')}.should    raise_error ArgumentError
+      lambda {Money.parse('$5.95 - 10.95')}.should  raise_error ArgumentError
+      lambda {Money.parse('$5.95 - $10.95')}.should raise_error ArgumentError
+    end
+
+    it "should not return a price for completely invalid input" do
+      # TODO: shouldn't these throw an error instead of being considered
+      # equal to $0.0?
+      empty_price = Money.new(0, 'USD')
+      
+      Money.parse(nil).should             == empty_price
+      Money.parse('hellothere').should    == empty_price
+      Money.parse('').should              == empty_price
+    end
 end


### PR DESCRIPTION
Per the discussion we had here: https://github.com/RubyMoney/money/issues/#issue/46

I added some tests for money parsing, as well as made two code changes:

1) If the inputted money ends in punctuation, throw it out (ex. "5.99." or "5.99,") to avoid accidentally considering the trailing punctuation part of the input, which can cause the function to think it's a thousands-separator by accident.  If it is a decimal separator, removing it won't hurt anything (since cents = 0).  If it is not, then it's a mistake to parse it as one.

2) If the input comes in as "5.99 - 10.99" (a price range) throw an error instead of treating it as some kind of hybrid-negative-misparsed number.

I didn't change any of the existing tests - they all still pass.  I only added new tests.
