### PR TITLE
Thousands separator fix for currencies with symbol last when :no_cents is set to true

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -889,7 +889,7 @@ class Money
     end
 
     # Apply thousands_separator
-    formatted.gsub!(/(\d)(?=(?:\d{3})+(?:\.|,|$))(\d{3}\..*)?/, "\\1#{thousands_separator_value}\\2")
+    formatted.gsub!(/(\d)(?=(?:\d{3})+(?:[^\d]|$))/, "\\1#{thousands_separator_value}")
 
     if rules[:with_currency]
       formatted << " "
@@ -994,7 +994,7 @@ class Money
     "#<Money cents:#{cents} currency:#{currency}>"
   end
 
-  # Allocates money between different parties without loosing pennies. 
+  # Allocates money between different parties without loosing pennies.
   # After the mathmatically split has been performed, left over pennies will
   # be distributed round-robin amongst the parties. This means that parties
   # listed first will likely recieve more pennies then ones that are listed later
@@ -1004,7 +1004,7 @@ class Money
   # @return [Array<Money, Money, Money>]
   #
   # @example
-  #   Money.new(5, "USD").allocate([0.3,0.7)) #=> [Money.new(2), Money.new(3)]  
+  #   Money.new(5, "USD").allocate([0.3,0.7)) #=> [Money.new(2), Money.new(3)]
   #   Money.new(100, "USD").allocate([0.33,0.33,0.33]) #=> [Money.new(34), Money.new(33), Money.new(33)]
   def allocate(splits)
     allocations = splits.inject(0.0) {|sum, i| sum += i }
@@ -1061,7 +1061,7 @@ class Money
       rules = { rules => true } if rules.is_a?(Symbol)
     end
     if not rules.include?(:decimal_mark) and rules.include?(:separator)
-      rules[:decimal_mark] = rules[:separator] 
+      rules[:decimal_mark] = rules[:separator]
     end
     if not rules.include?(:thousands_separator) and rules.include?(:delimiter)
       rules[:thousands_separator] = rules[:delimiter]

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -848,6 +848,11 @@ describe Money do
       Money.us_dollar(1_000_000_000_12).format.should == "$1,000,000,000.12"
       Money.us_dollar(1_000_000_000_12).format(:no_cents => true).should == "$1,000,000,000"
     end
+
+    it "inserts thousands separator into the result if the amount is sufficiently large and the currency symbol is at the end" do
+      Money.euro(1_234_567_12).format.should == "1.234.567,12 €"
+      Money.euro(1_234_567_12).format(:no_cents => true).should == "1.234.567 €"
+    end
   end
 
 
@@ -1071,7 +1076,7 @@ describe Money do
     specify "#gives 1 cent to both people if we start with 2" do
       Money.us_dollar(2).split(2).should == [Money.us_dollar(1), Money.us_dollar(1)]
     end
-    
+
     specify "#split may distribute no money to some parties if there isnt enough to go around" do
       Money.us_dollar(2).split(3).should == [Money.us_dollar(1), Money.us_dollar(1), Money.us_dollar(0)]
     end
@@ -1092,11 +1097,11 @@ describe Money do
     specify "#allocate takes no action when one gets all" do
       Money.us_dollar(005).allocate([1]).should == [Money.us_dollar(5)]
     end
-    
+
     specify "#allocate keeps currencies intact" do
       Money.ca_dollar(005).allocate([1]).should == [Money.ca_dollar(5)]
     end
-    
+
     specify "#allocate does not loose pennies" do
       moneys = Money.us_dollar(5).allocate([0.3,0.7])
       moneys[0].should == Money.us_dollar(2)
@@ -1109,7 +1114,7 @@ describe Money do
       moneys[1].cents.should == 33
       moneys[2].cents.should == 33
     end
-    
+
     specify "#allocate requires total to be less then 1" do
       lambda { Money.us_dollar(0.05).allocate([0.5,0.6]) }.should raise_error(ArgumentError)
     end
@@ -1247,7 +1252,7 @@ describe "Money.parse" do
       # TODO: shouldn't these throw an error instead of being considered
       # equal to $0.0?
       empty_price = Money.new(0, 'USD')
-      
+
       Money.parse(nil).should             == empty_price
       Money.parse('hellothere').should    == empty_price
       Money.parse('').should              == empty_price


### PR DESCRIPTION
Hi!

Here is a fix (and its spec) for a little issue we encountered. 

```
Money.euro(123412).format(:no_cents => true)
```

Was expected to return "1.234 €" but we received "1234 €". We fixed the thousands separator insertion regex. We actually slightly improved it by removing the useless second capturing group. All specs are green.

Thank you!

Romain & Julien.
