### PR TITLE
Add a symbol position option for Money#format

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -871,7 +871,19 @@ class Money
                 else
                   "#{self.to_s}"
                 end
-    formatted = (currency.symbol_first? ? "#{symbol_value}#{formatted}" : "#{formatted} #{symbol_value}") unless symbol_value.nil? or symbol_value.empty?
+
+    symbol_position =
+      if rules.has_key?(:symbol_position)
+        rules[:symbol_position]
+      elsif currency.symbol_first?
+        :before
+      else
+        :after
+      end
+
+    if symbol_value && !symbol_value.empty?
+      formatted = (symbol_position == :before ? "#{symbol_value}#{formatted}" : "#{formatted} #{symbol_value}")
+    end
 
     if rules.has_key?(:decimal_mark) and rules[:decimal_mark] and
       rules[:decimal_mark] != decimal_mark

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -853,6 +853,14 @@ describe Money do
       Money.euro(1_234_567_12).format.should == "1.234.567,12 €"
       Money.euro(1_234_567_12).format(:no_cents => true).should == "1.234.567 €"
     end
+
+    it "inserts currency symbol before the amount when :symbol_position is set to :before" do
+      Money.euro(1_234_567_12).format(:symbol_position => :before).should == "€1.234.567,12"
+    end
+
+    it "inserts currency symbol after the amount when :symbol_position is set to :after" do
+      Money.us_dollar(1_000_000_000_12).format(:symbol_position => :after).should == "1,000,000,000.12 $"
+    end
   end
 
 


### PR DESCRIPTION
Hi there,

We added a :symbol_position option for Money#format in order to answer a specific need for our application.
We think that other people might find this useful for some design purposes.
This is totally backward compatible and tested.

```
Money.euro(1234).format(:symbol_position => :before) #=> €1.234
Money.us_dollar(1234).format(:symbol_position => :after) #=> 1,234 $
```

Thank you.

Romain, Gil and Julien
