### PR TITLE
I18n should use currency translations

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -712,7 +712,7 @@ class Money
     currency.symbol || "¤"
   end
 
-  # If I18n is loaded, looks up key +:number.format.delimiter+.
+  # If I18n is loaded, looks up key +:number.currency.format.separator+.
   # Otherwise and as fallback it uses +Currency#thousands_separator+.
   # If +nil+ is returned, default to ",".
   #
@@ -722,7 +722,7 @@ class Money
   #   Money.new(100, "USD").thousands_separator #=> ","
   if Object.const_defined?("I18n")
     def thousands_separator
-      I18n.t(:"number.format.thousands_separator", :default => currency.thousands_separator || ",")
+      I18n.t(:"number.currency.format.separator", :default => currency.thousands_separator || ",")
     end
   else
     def thousands_separator
@@ -731,8 +731,8 @@ class Money
   end
   alias :delimiter :thousands_separator
 
-  # If I18n is loaded, looks up key +:number.format.seperator+.
-  # Otherwise and as fallback it uses +Currency#seperator+.
+  # If I18n is loaded, looks up key +:number.currency.format.delimiter+.
+  # Otherwise and as fallback it uses +Currency#decimal_mark+.
   # If +nil+ is returned, default to ",".
   #
   # @return [String]
@@ -741,7 +741,7 @@ class Money
   #   Money.new(100, "USD").decimal_mark #=> "."
   if Object.const_defined?("I18n")
     def decimal_mark
-      I18n.t(:"number.format.decimal_mark", :default => currency.decimal_mark || ".")
+      I18n.t(:"number.currency.format.delimiter", :default => currency.decimal_mark || ".")
     end
   else
     def decimal_mark

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -619,11 +619,10 @@ describe Money do
         context "with I18n" do
           before :all do
             reset_i18n
-            store_number_formats(:en, method => options[:default])
-            store_number_formats(:de, method => options[:other])
+            store_number_currency_formats(:de)
           end
 
-          it "looks up #{method} for current locale" do
+          it "looks up current locale as documented" do
             I18n.locale = :en
             Money.empty("USD").send(method).should == options[:default]
             I18n.locale = :de

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,10 +8,14 @@ def reset_i18n()
   I18n.backend = I18n::Backend::Simple.new
 end
 
-def store_number_formats(locale, translations)
-  I18n.backend.store_translations(locale, {
-    :number => {
-      :format => translations
-    }
-  })
+def store_number_currency_formats(locale)
+  I18n.backend.store_translations(locale,
+                                  :number => {
+                                    :currency => {
+                                      :format => {
+                                        :delimiter => ",",
+                                        :separator => "."
+                                      }
+                                    }
+                                  })
 end


### PR DESCRIPTION
I18n was not working for me, I found that it uses thousand_separator, and number format instead of currency "delimiter" and "separator" formats (the defaults in Rails at least).

Sorry for my English.
Sorry for not make specs (I really don't know how to test it).
