### PR TITLE
add a format option :no_cents_if_whole

### DIFF
--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -62,7 +62,8 @@ class Money
     #   Money.ca_dollar(100).format(:no_cents => true) #=> "$1"
     #   Money.ca_dollar(599).format(:no_cents => true) #=> "$5"
     #
-    # @option *rules [Boolean] :no_cents_if_whole (false) Whether cents should be omitted if the cent value is zero
+    # @option *rules [Boolean] :no_cents_if_whole (false) Whether cents should be 
+    #  omitted if the cent value is zero
     #
     # @example
     #   Money.ca_dollar(10000).format(:no_cents_if_whole => true) #=> "$100"

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -196,6 +196,16 @@ describe Money do
       Money.ca_dollar(10000).format(:no_cents_if_whole => true).should == "$100"
       Money.ca_dollar(10034).format(:no_cents_if_whole => true).should == "$100.34"
     end
+    
+    specify "#format(:no_cents_if_whole => false) works as documented" do
+      Money.ca_dollar(10000).format(:no_cents_if_whole => false).should == "$100.00"
+      Money.ca_dollar(10034).format(:no_cents_if_whole => false).should == "$100.34"
+    end
+
+    specify "#format(:no_cents_if_whole => true) should respect :subunit_to_unit currency property" do
+      Money.new(10_00, "BHD").format(:no_cents_if_whole => true).should == "ب.د1"
+      Money.new(10_50, "BHD").format(:no_cents_if_whole => true).should == "ب.د1.050"
+    end
 
     specify "#format(:symbol => a symbol string) uses the given value as the money symbol" do
       Money.new(100, "GBP").format(:symbol => "£").should == "£1.00"


### PR DESCRIPTION
Hello. 
Please consider this pull request for adding a new format option, :no_cents_if_whole
When set to true, 10000 gets formatted to $100 and 10034 gets formatted to $100.34
