### PR TITLE
Add to_d conversion method

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -263,7 +263,7 @@ class Money
   # @example
   #   Money.us_dollar(100).to_d => BigDecimal.new("1.0")
   def to_d
-    (BigDecimal.new(cents.to_s) / currency.subunit_to_unit)
+    BigDecimal.new(cents.to_s) / BigDecimal.new(currency.subunit_to_unit.to_s)
   end
 
   # Return the amount of money as a float. Floating points cannot guarantee

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -132,6 +132,15 @@ describe Money do
     decimal.should == 1.0
   end
 
+  specify "Money.to_d should work with float :subunit_to_unit currency property" do
+    money = Money.new(10_00, "BHD")
+    money.currency.stub(:subunit_to_unit).and_return(1000.0)
+
+    decimal = money.to_d
+    decimal.should be_instance_of(BigDecimal)
+    decimal.should == 1.0
+  end
+
   specify "Money.to_f works" do
     Money.new(10_00).to_f.should == 10.0
   end


### PR DESCRIPTION
Add a to_d method to match the utility methods in:
http://www.ruby-doc.org/stdlib/libdoc/bigdecimal/rdoc/files/bigdecimal/lib/bigdecimal/util_rb.html
