### PR TITLE
Gemspec

### DIFF
--- a/money.gemspec
+++ b/money.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name        = "money"
-  s.version     = "3.7.0"
+  s.version     = "3.7.1"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Tobias Luetke", "Hongli Lai", "Jeremy McNevin",
                    "Shane Emmons", "Simone Carletti", "Jean-Louis Giordano",


### PR DESCRIPTION
i18n bites again. The Gemspec now has non-ASCII characters. Added character encoding to top of file so Bundler under Ruby 1.9.2 does not throw `'normalize_yaml_input': invalid byte sequence in US-ASCII (ArgumentError)`. (happened when deploying to the Cedar stack on Heroku)
