### PR TITLE
Always return the default_currency

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -184,7 +184,7 @@ class Money
   #
   def initialize(cents, currency = Money.default_currency, bank = Money.default_bank)
     @cents = cents.round.to_i
-    @currency = Currency.wrap(currency)
+    @currency = Currency.wrap(currency) || Money.default_currency
     @bank = bank
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -15,6 +15,11 @@ describe Money do
       Money.new(0).bank.should be_equal(Money::Bank::VariableExchange.instance)
     end
 
+    it "should assign the default currency" do
+      Money.default_currency = Money::Currency.new("USD")
+      Money.new(1.00, nil).currency.should == Money.default_currency
+    end
+
   end
 
   describe "#cents" do


### PR DESCRIPTION
So, I was working on an old project, and recently upgraded the app. I've been getting tons of error (formatting, etc..) Looks like the records I was using has an amount field saved using an old gem (can't recall anymore the last one used, maybe 1.x? i dunno) and returning a nil currency everytime I do a query, like below

```
ruby-1.9.2-p180 :002 > Bid.find(109).amount
 => #<Money cents:25000 currency:> 
```

Anyway, this commit fixed it for now by ensuring it assigns the default currency. Just like as intended.

Unfortunately the solution only works with a single currency and i'm not sure if it will make sense for old records to be assigned everything w/ the default currency. But that's a different story :D
