### PR TITLE
Force json file to be UTF8

### DIFF
--- a/lib/money/currency_loader.rb
+++ b/lib/money/currency_loader.rb
@@ -10,10 +10,12 @@ module CurrencyLoader
   # @return [Hash]
   def load_currencies
     json = File.read(DATA_PATH + 'currency.json')
+    json.force_encoding(::Encoding::UTF_8) if defined?(::Encoding)
     currencies = JSON.parse(json, :symbolize_names => true)
 
     # merge the currencies kept for backwards compatibility
     json = File.read(DATA_PATH + 'currency_bc.json')
+    json.force_encoding(::Encoding::UTF_8) if defined?(::Encoding)
     currencies.merge!(JSON.parse(json, :symbolize_names => true))
   end
 end


### PR DESCRIPTION
When running ruby using the LANG flag set to something like C (LANG=C
rake test) parsing the json file would fail in ruby 1.9. By setting the
encoding on the file before parsing we avoid these issues.

This is possibly a bug in the json gem, but doing this gets around the issue.
