### PR TITLE
Allow creation of new currencies

### DIFF
--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -26,6 +26,12 @@ class Money
 
     TABLE = load_currencies
 
+    # Default currency attributes used when creating new currencies from a block
+
+    DEFAULT_CURRENCY_ATTRIBUTES = {
+      :decimal_mark => ".",
+      :thousands_separator => ","
+    }
 
     # The symbol used to identify the currency, usually the lowercase
     # +iso_code+ attribute.
@@ -83,7 +89,7 @@ class Money
     #
     # @return [String]
     attr_reader :thousands_separator
-    alias :delimiter :thousands_separator 
+    alias :delimiter :thousands_separator
 
     # Should the currency symbol precede the amount, or should it come after?
     #
@@ -111,14 +117,21 @@ class Money
     #
     # @param [String, Symbol, #to_s] id Used to look into +TABLE+ and retrieve
     #  the applicable attributes.
+    # @param data An optional hash of currency parameters used to create a new currency
     #
     # @return [Money::Currency]
     #
     # @example
     #   Money::Currency.new(:usd) #=> #<Money::Currency id: usd ...>
-    def initialize(id)
+    def initialize(id, data = nil )
       @id  = id.to_s.downcase.to_sym
-      data = TABLE[@id] || raise(UnknownCurrency, "Unknown currency `#{id}'")
+
+      if data
+        data = DEFAULT_CURRENCY_ATTRIBUTES.merge( data )
+      else
+        data = TABLE[@id] || raise(UnknownCurrency, "Unknown currency `#{id}'")
+      end
+
       data.each_pair do |key, value|
         instance_variable_set(:"@#{key}", value)
       end

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -17,6 +17,27 @@ describe Money::Currency do
       currency.delimiter.should           == ","
   end
 
+  specify "#initialize should accept currency parameters for a new currency" do
+      currency = Money::Currency.new "gamepoints", {
+                                        :priority => 200,
+                                        :name  => "Game Points",
+                                        :subunit_to_unit => 1,
+                                        :symbol => '★'
+                                      }
+
+      currency.id.should                  == :gamepoints
+      currency.priority.should            == 200
+      currency.iso_code.should            == nil
+      currency.iso_numeric.should         == nil
+      currency.name.should                == "Game Points"
+      currency.decimal_mark.should        == "."
+      currency.separator.should           == "."
+      currency.thousands_separator.should == ","
+      currency.delimiter.should           == ","
+      currency.subunit_to_unit.should     == 1
+
+  end
+
   specify "#initialize should raise UnknownMoney::Currency with unknown currency" do
     lambda { Money::Currency.new("xxx") }.should raise_error(Money::Currency::UnknownCurrency, /xxx/)
   end


### PR DESCRIPTION
This pull request allows you to create a new currency by adding an optional hash of parameters to the constructor.

This is specifically useful when creating applications for non national currencies such as bitcoin, in app virtual currencies as well as local community currencies.
