### PR TITLE
In Danish symbol is after amount

### DIFF
--- a/config/currency.json
+++ b/config/currency.json
@@ -487,7 +487,7 @@
     "symbol": "kr",
     "subunit": "Øre",
     "subunit_to_unit": 100,
-    "symbol_first": true,
+    "symbol_first": false,
     "html_entity": "",
     "decimal_mark": ",",
     "thousands_separator": ".",


### PR DESCRIPTION
In Danish we write 100 kr instead of kr100
