### PR TITLE
Add currency.code

### DIFF
--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -58,6 +58,13 @@ class Money
     # @return [String]
     attr_reader :symbol
 
+    # Returns currency symbol or iso code for currencies with no symbol.
+    #
+    # @return [String]
+    def code
+      symbol || iso_code
+    end
+
     # The html entity for the currency symbol
     #
     # @return [String]

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -66,6 +66,11 @@ describe Money::Currency do
     %Q{#<Money::Currency id: usd, priority: 1, symbol_first: true, thousands_separator: ,, html_entity: $, decimal_mark: ., name: United States Dollar, symbol: $, subunit_to_unit: 100, iso_code: USD, iso_numeric: 840, subunit: Cent>}
   end
 
+  specify "#code" do
+    Money::Currency.new(:usd).code.should == "$"
+    Money::Currency.new(:azn).code.should == "AZN"
+  end
+
 
   specify "#self.find should return currency matching given id" do
     with_custom_definitions do


### PR DESCRIPTION
I use Money::Currency to represent currencies and display them along the money amount in my apps. However not all currencies have symbols (e. g. AZN) so I always use `currency.symbol || currency.iso_code` to print them. I think this is a common pattern and should be included in the class. I've added `currency.code` method that does the same thing as `currency.symbol || currency.iso_code`. I'm not sure if this is a good method name but I don't have any more ideas. What do you think?
