### PR TITLE
parsing amounts with a trailing minus sign

### DIFF
--- a/lib/money/money/parsing.rb
+++ b/lib/money/money/parsing.rb
@@ -230,15 +230,15 @@ class Money
         num = input.gsub(/[^\d|\.|,|\'|\-]/, '').strip
 
         # set a boolean flag for if the number is negative or not
-        negative = num.split(//).first == "-"
+        negative = num =~ /^-|-$/ ? true : false
 
         # if negative, remove the minus sign from the number
         # if it's not negative, the hyphen makes the value invalid
         if negative
-          num = num.gsub(/^-/, '')
-        else
-          raise ArgumentError, "Invalid currency amount (hyphen)" if num.include?('-')
+          num = num.sub(/^-|-$/, '')
         end
+
+        raise ArgumentError, "Invalid currency amount (hyphen)" if num.include?('-')
 
         #if the number ends with punctuation, just throw it out.  If it means decimal,
         #it won't hurt anything.  If it means a literal period or comma, this will

--- a/spec/money/parsing_spec.rb
+++ b/spec/money/parsing_spec.rb
@@ -51,6 +51,18 @@ describe Money, "parsing" do
       Money.parse('hellothere').should    == empty_price
       Money.parse('').should              == empty_price
     end
+
+    it "handles negative inputs" do
+      five_ninety_five = Money.new(595, 'USD')
+
+      Money.parse("$-5.95").should == -five_ninety_five
+      Money.parse("-$5.95").should == -five_ninety_five
+      Money.parse("$5.95-").should == -five_ninety_five
+    end
+
+    it "raises ArgumentError when unable to detect polarity" do
+      lambda { Money.parse('-$5.95-') }.should raise_error ArgumentError
+    end
   end
 
   describe ".from_string" do


### PR DESCRIPTION
In accounting, it is not uncommon to see the minus sign after the amount rather than before.  For example: "$500.42-" instead of "-$500.42" or "$-500.42".  Currently, this raises an error: "ArgumentError: Invalid currency amount (hyphen)" but I don't see why it would not be an allowable input.
