### PR TITLE
Math.log10(subunit_to_unit).to_s not guaranteed to provide integral value

### DIFF
--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -263,17 +263,19 @@ class Money
       !!@symbol_first
     end
 
+    DECIMAL_PLACES_MAP = {
+      1 => 0,
+      5 => 1,
+      10 => 1,
+      100 => 2,
+      1000 => 3
+    }
+
     # The number of decimal places needed.
     #
     # @return [Integer]
     def decimal_places
-      if subunit_to_unit == 1
-        0
-      elsif subunit_to_unit % 10 == 0
-        Math.log10(subunit_to_unit).to_s.to_i
-      else
-        Math.log10(subunit_to_unit).to_s.to_i+1
-      end
+      DECIMAL_PLACES_MAP[subunit_to_unit]
     end
 
   end


### PR DESCRIPTION
decimal_places breaks in JRuby in 1.9 mode since 1.9 mode provides more digits (precision) when performing to_s.  I suspect this is more of a happy accident this works at all on any Ruby impl since we are dealing with base 2 values deep down and Ruby does not specify rounding in printing base 10 values of floats (in MRI 1.8.7 and current 1.9.3 just happens to work IMHO).

The second possible breakage might be any 64-bit builds of Ruby since it inevitably may or may not return the expected to_s value.

The solution provided is simpler at the cost of new undiscovered currency systems not listed in the table will need a new entry.  It will also be faster if anyone cares about that.
