### PR TITLE
Remove Money::Currency::TABLE. Add Money::Currency.register for adding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 4.0.3
-
+## 5.0.0
+- Money::Currency::TABLE removed. Use Money::Currency.register to add
+  additional currencies (GH-143)
 - Fix rounding error in Numeric.to_money (GH-145)
 
 ## 4.0.2

--- a/README.md
+++ b/README.md
@@ -89,12 +89,11 @@ currency.iso_code #=> "USD"
 currency.name     #=> "United States Dollar"
 ```
 
-To define a new `Money::Currency` simply add a new item to the
-`Money::Currency::TABLE` hash, where the key is the identifier for the currency
-object and the value is a hash containing all the currency attributes.
+To define a new `Money::Currency` use `Money::Currency.register` as shown
+below.
 
 ``` ruby
- Money::Currency::TABLE[:usd] = {
+curr = {
   :priority        => 1,
   :iso_code        => "USD",
   :iso_numeric     => "840",
@@ -105,6 +104,8 @@ object and the value is a hash containing all the currency attributes.
   :separator       => ".",
   :delimiter       => ","
 }
+
+Money::Currency.register(curr)
 ```
 
 The pre-defined set of attributes includes:
@@ -154,10 +155,10 @@ def all_currencies(hash)
   hash.keys
 end
 
-major_currencies(Money::Currency::TABLE)
+major_currencies(Money::Currency.table)
 # => [ :usd, :eur, :bgp, :cad ]
 
-all_currencies(Money::Currency::TABLE)
+all_currencies(Money::Currency.table)
 # => [ :aed, :afn, all, ... ]
 ```
 

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -4,18 +4,17 @@ require "spec_helper"
 
 describe Money::Currency do
 
+  FOO = '{ "priority": 1, "iso_code": "FOO", "iso_numeric": "840", "name": "United States Dollar", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 100, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": "," }'
+
   describe ".find" do
     it "returns currency matching given id" do
-      with_custom_definitions do
-        Money::Currency::TABLE[:usd] = JSON.parse(%Q({ "priority": 1, "iso_code": "USD", "iso_numeric": "840", "name": "United States Dollar", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 100, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": "," }))
-        Money::Currency::TABLE[:eur] = JSON.parse(%Q({ "priority": 2, "iso_code": "EUR", "iso_numeric": "978", "name": "Euro", "symbol": "€", "subunit": "Cent", "subunit_to_unit": 100, "symbol_first": false, "html_entity": "&#x20AC;", "decimal_mark": ",", "thousands_separator": "." }))
+      Money::Currency.register(JSON.parse(FOO, :symbolize_names => true))
 
-        expected = Money::Currency.new(:eur)
-        Money::Currency.find(:eur).should  == expected
-        Money::Currency.find(:EUR).should  == expected
-        Money::Currency.find("eur").should == expected
-        Money::Currency.find("EUR").should == expected
-      end
+      expected = Money::Currency.new(:foo)
+      Money::Currency.find(:foo).should  == expected
+      Money::Currency.find(:FOO).should  == expected
+      Money::Currency.find("foo").should == expected
+      Money::Currency.find("FOO").should == expected
     end
 
     it "returns nil unless currency matching given id" do
@@ -122,18 +121,4 @@ describe Money::Currency do
       Money::Currency.new(:azn).code.should == "AZN"
     end
   end
-
-
-  def with_custom_definitions(&block)
-    begin
-      old = Money::Currency::TABLE.dup
-      Money::Currency::TABLE.clear
-      yield
-    ensure
-      silence_warnings do
-        Money::Currency.const_set("TABLE", old)
-      end
-    end
-  end
-
 end


### PR DESCRIPTION
new currencies. These are backwards incompatible changes and will require
a version bump to 5.0.0. Addresses issue #143.
