### PR TITLE
Officially, the Euro symbol ought to come before the amount.

### DIFF
--- a/config/currency.json
+++ b/config/currency.json
@@ -565,7 +565,7 @@
     "symbol": "€",
     "subunit": "Cent",
     "subunit_to_unit": 100,
-    "symbol_first": false,
+    "symbol_first": true,
     "html_entity": "&#x20AC;",
     "decimal_mark": ",",
     "thousands_separator": ".",


### PR DESCRIPTION
- http://ec.europa.eu/economy_finance/euro/cash/coins/index_en.htm
