### PR TITLE
Changed settings for Polish Złoty

### DIFF
--- a/config/currency.json
+++ b/config/currency.json
@@ -1451,8 +1451,8 @@
     "subunit_to_unit": 100,
     "symbol_first": false,
     "html_entity": "",
-    "decimal_mark": ".",
-    "thousands_separator": ",",
+    "decimal_mark": ",",
+    "thousands_separator": " ",
     "iso_numeric": "985"
   },
   "pyg": {


### PR DESCRIPTION
Hello,
I've changed settings for Polish Złoty because there were wrong - decimal point for PLN is "," and we do not have thousand separator (but could be space to be more readable).

Best Regards
