### PR TITLE
fall back to symbol if there is no html_entity present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ tmtags
 ## VIM
 *.swp
 
+## Rubymine
+.idea
+
 ## PROJECT::GENERAL
 coverage
 rdoc

--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -163,7 +163,7 @@ class Money
             ""
           end
         elsif rules[:html]
-          currency.html_entity
+          currency.html_entity == '' ? currency.symbol : currency.html_entity
         else
           symbol
         end

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -310,6 +310,11 @@ describe Money, "formatting" do
         string = Money.ca_dollar(570).format(:html => true, :with_currency => true)
         string.should == "$5.70 <span class=\"currency\">CAD</span>"
       end
+
+      specify "should fallback to symbol if entity is not available" do
+        string = Money.new(570, 'DKK').format(:html => true)
+        string.should == "5,70 kr"
+      end
     end
 
     describe ":symbol_position option" do


### PR DESCRIPTION
When there is no html_entity associated with a currency, this will fallback to the currency symbol.
