### PR TITLE
String#to_money! function which raises exception

### DIFF
--- a/lib/money/core_extensions.rb
+++ b/lib/money/core_extensions.rb
@@ -46,6 +46,31 @@ class String
     Money.parse(self, currency)
   end
 
+  # Parses the current string and converts it to a +Money+ object.
+  # Excess characters will be discarded. If no numeric characters are given
+  # it raises an ArgumentError.
+  #
+  # @param [Currency, String, Symbol] currency
+  #   The currency to set the resulting +Money+ object to.
+  #
+  # @return [Money]
+  #
+  # @raise [ArgumentError] If this String does not contain any numeric character.
+  #
+  # @example
+  #   '100'.to_money                #=> #<Money @cents=10000>
+  #   '100.37'.to_money             #=> #<Money @cents=10037>
+  #   '100 USD'.to_money            #=> #<Money @cents=10000, @currency=#<Money::Currency id: usd>>
+  #   'USD 100'.to_money            #=> #<Money @cents=10000, @currency=#<Money::Currency id: usd>>
+  #   '$100 USD'.to_money           #=> #<Money @cents=10000, @currency=#<Money::Currency id: usd>>
+  #   'hello 2000 world'.to_money   #=> #<Money @cents=200000 @currency=#<Money::Currency id: usd>>
+  #
+  # @see Money.from_string
+  #
+  def to_money!(currency = nil)
+    Money.parse!(self, currency)
+  end
+
   # Converts the current string into a +Currency+ object.
   #
   # @return [Money::Currency]

--- a/lib/money/money/parsing.rb
+++ b/lib/money/money/parsing.rb
@@ -68,6 +68,40 @@ class Money
         new(cents, currency)
       end
 
+      # Parses the current string and converts it to a +Money+ object.
+      # Excess characters will be discarded. If no numeric characters are
+      # given, an ArgumentError is being raised.
+      #
+      # @param [String, #to_s] input The input to parse.
+      # @param [Currency, String, Symbol] currency The currency format.
+      #   The currency to set the resulting +Money+ object to.
+      #
+      # @return [Money]
+      #
+      # @raise [ArgumentError] If +input+ string does not contain any numbers
+      #   or if any +currency+ is supplied and given value doesn't match the
+      #   one extracted from the +input+ string.
+      #
+      # @example
+      #   '100'.to_money                #=> #<Money @cents=10000>
+      #   '100.37'.to_money             #=> #<Money @cents=10037>
+      #   '100 USD'.to_money            #=> #<Money @cents=10000, @currency=#<Money::Currency id: usd>>
+      #   'USD 100'.to_money            #=> #<Money @cents=10000, @currency=#<Money::Currency id: usd>>
+      #   '$100 USD'.to_money           #=> #<Money @cents=10000, @currency=#<Money::Currency id: usd>>
+      #   'hello 2000 world'.to_money   #=> #<Money @cents=200000 @currency=#<Money::Currency id: usd>>
+      #
+      # @example Mismatching currencies
+      #   'USD 2000'.to_money("EUR")    #=> ArgumentError
+      #
+      # @see Money.from_string
+      #
+      def parse!(input, currency=nil)
+        unless input =~ /[0-9]/
+          raise ArgumentError, "`input' should contain a numeric character"
+        end
+        parse(input, currency)
+      end
+
       # Converts a String into a Money object treating the +value+
       # as dollars and converting them to the corresponding cents value,
       # according to +currency+ subunit property,


### PR DESCRIPTION
There are cases in which an exception should be raised to notify higher level handlers.
For example, suppose we have set the following in a `Product` model:

```
composed_of :price,
  :class_name => "Money",
  :mapping => [%w(price_cents cents), %w(currency currency_as_string)],
  :constructor => Proc.new { |cents, currency| Money.new(cents || 0, currency || Money.default_currency) },
  :converter => Proc.new { |value| value.respond_to?(:to_money) ? value.to_money : raise(ArgumentError, "Can't convert #{value.class} to Money") }
```

when we use an assignment like the following:

```
product.price = "no_numeric_character"
product.save
```

this would wrongly result `price_cents` set to `0`

In this case the correct way would be to use `to_money!` instead of `to_money` in the converter:

```
composed_of :price,
  :class_name => "Money",
  :mapping => [%w(price_cents cents), %w(currency currency_as_string)],
  :constructor => Proc.new { |cents, currency| Money.new(cents || 0, currency || Money.default_currency) },
  :converter => Proc.new { |value| 
    if value.respond_to?(:to_money!) 
      value.to_money!
    elsif value.respond_to?(:to_money) 
      value.to_money
    else
      raise(ArgumentError, "Can't convert #{value.class} to Money")
    end
 }
```

This way we can ensure that an ArgumentError will be raised when a non numeric string is given.
