### PR TITLE
Remove platform/editor/app specific entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,30 +1,16 @@
-## MAC OS
-.DS_Store
+# Bundler
+.bundle
+Gemfile.lock
+pkg/*
 
-## TEXTMATE
-*.tmproj
-tmtags
-
-## EMACS
-*~
-\#*
-.\#*
-
-## VIM
-*.swp
-
-## Rubymine
-.idea
-
-## PROJECT::GENERAL
-coverage
-rdoc
-pkg
+# Rubinius
 *.rbc
-.rvmrc
 
-## PROJECT::SPECIFIC
+# YARD
 .yardoc
-doc
+yardoc/
+
+# Project
 .rbenv-version
 .rbx
+.rvmrc


### PR DESCRIPTION
Such entries should stay in the global `.gitignore` file.

Let me know what do you think.
