### PR TITLE
go back to base json

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     money (5.0.0)
       i18n (~> 0.6.0)
-      multi_json (~> 1.3.6)
+      json
 
 GEM
   remote: http://rubygems.org/
@@ -19,12 +19,12 @@ GEM
       guard (>= 1.1)
       spork (>= 0.8.4)
     i18n (0.6.0)
+    json (1.7.3)
     kramdown (0.13.7)
     listen (0.4.7)
       rb-fchange (~> 0.0.5)
       rb-fsevent (~> 0.9.1)
       rb-inotify (~> 0.8.8)
-    multi_json (1.3.6)
     rake (0.9.2.2)
     rb-fchange (0.0.5)
       ffi

--- a/lib/money/bank/variable_exchange.rb
+++ b/lib/money/bank/variable_exchange.rb
@@ -1,7 +1,7 @@
 require 'money/bank/base'
 
-autoload :MultiJson, 'multi_json'
-autoload :YAML, 'yaml'
+require "json"
+require "yaml"
 
 class Money
   module Bank
@@ -186,7 +186,7 @@ class Money
         @mutex.synchronize {
           s = case format
               when :json
-                MultiJson.dump(@rates)
+                JSON.dump(@rates)
               when :ruby
                 Marshal.dump(@rates)
               when :yaml
@@ -224,7 +224,7 @@ class Money
         @mutex.synchronize {
           @rates = case format
                    when :json
-                     MultiJson.load(s)
+                     JSON.load(s)
                    when :ruby
                      Marshal.load(s)
                    when :yaml

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'multi_json'
+require 'json'
 
 class Money
 

--- a/lib/money/currency_loader.rb
+++ b/lib/money/currency_loader.rb
@@ -16,6 +16,6 @@ module CurrencyLoader
   def parse_currency_file(filename)
     json = File.read("#{DATA_PATH}/#{filename}")
     json.force_encoding(::Encoding::UTF_8) if defined?(::Encoding)
-    MultiJson.load(json, :symbolize_keys => true)
+    JSON.parse(json, :symbolize_names => true)
   end
 end

--- a/money.gemspec
+++ b/money.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "i18n",       "~> 0.6.0"
-  s.add_dependency "multi_json", "~> 1.3.6"
+  s.add_dependency "i18n", "~> 0.6.0"
+  s.add_dependency "json"
 
   s.add_development_dependency "rspec",       "~> 2.10.0"
   s.add_development_dependency "yard",        "~> 0.8.1"

--- a/spec/bank/variable_exchange_spec.rb
+++ b/spec/bank/variable_exchange_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'multi_json'
+require 'json'
 require 'yaml'
 
 describe Money::Bank::VariableExchange do
@@ -120,7 +120,7 @@ describe Money::Bank::VariableExchange do
     context "with format == :json" do
       it "should return rates formatted as json" do
         json = subject.export_rates(:json)
-        MultiJson.load(json).should == @rates
+        JSON.load(json).should == @rates
       end
     end
 
@@ -147,7 +147,7 @@ describe Money::Bank::VariableExchange do
       it "writes rates to file" do
         f = mock('IO')
         File.should_receive(:open).with('null', 'w').and_yield(f)
-        f.should_receive(:write).with(MultiJson.dump(@rates))
+        f.should_receive(:write).with(JSON.dump(@rates))
 
         subject.export_rates(:json, 'null')
       end

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -8,7 +8,7 @@ describe Money::Currency do
 
   describe ".find" do
     it "returns currency matching given id" do
-      Money::Currency.register(MultiJson.load(FOO, :symbolize_keys => true))
+      Money::Currency.register(JSON.parse(FOO, :symbolize_names => true))
 
       expected = Money::Currency.new(:foo)
       Money::Currency.find(:foo).should  == expected
@@ -128,7 +128,7 @@ describe Money::Currency do
     end
 
     it "proper places for custom currency" do
-      Money::Currency.register(MultiJson.load(FOO, :symbolize_keys => true))
+      Money::Currency.register(JSON.parse(FOO, :symbolize_names => true))
       Money::Currency.new(:foo).decimal_places == 3
     end
   end

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -408,8 +408,8 @@ describe Money, "formatting" do
 
   context "custom currencies with 4 decimal places" do
     before :each do
-      Money::Currency.register(MultiJson.load(BAR, :symbolize_keys => true))
-      Money::Currency.register(MultiJson.load(EU4, :symbolize_keys => true))
+      Money::Currency.register(JSON.parse(BAR, :symbolize_names => true))
+      Money::Currency.register(JSON.parse(EU4, :symbolize_names => true))
     end
 
     it "respects custom subunit to unit, decimal and thousands separator" do

--- a/spec/money/parsing_spec.rb
+++ b/spec/money/parsing_spec.rb
@@ -105,8 +105,8 @@ describe Money, "parsing" do
 
     context "custom currencies with 4 decimal places" do
       before :each do
-        Money::Currency.register(MultiJson.load(bar, :symbolize_keys => true))
-        Money::Currency.register(MultiJson.load(eu4, :symbolize_keys => true))
+        Money::Currency.register(JSON.parse(bar, :symbolize_names => true))
+        Money::Currency.register(JSON.parse(eu4, :symbolize_names => true))
       end
 
       # String#to_money(Currency) is equivalent to Money.parse(String, Currency)


### PR DESCRIPTION
this replaces multi_json with the base json builtin/gem. Note we still need to have json as a dependency for versions of ruby < 1.9 that don't have json builtin.
