### PR TITLE
Incorrect settings for Swedish (SEK) currency

### DIFF
--- a/config/currency.json
+++ b/config/currency.json
@@ -1592,10 +1592,10 @@
     "symbol": "kr",
     "subunit": "Öre",
     "subunit_to_unit": 100,
-    "symbol_first": true,
+    "symbol_first": false,
     "html_entity": "",
-    "decimal_mark": ".",
-    "thousands_separator": ",",
+    "decimal_mark": ",",
+    "thousands_separator": ".",
     "iso_numeric": "752"
   },
   "sgd": {

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -132,7 +132,7 @@ describe Money, "formatting" do
       one_thousand["BRL"].should == "R$ 1.000,00"
 
       # Other
-      one_thousand["SEK"].should == "kr1,000.00"
+      one_thousand["SEK"].should == "1.000,00 kr"
       one_thousand["GHC"].should == "₵1,000.00"
     end
 
@@ -231,7 +231,7 @@ describe Money, "formatting" do
         one["BRL"].should == "R$ 1,00"
 
         # Other
-        one["SEK"].should == "kr1.00"
+        one["SEK"].should == "1,00 kr"
         one["GHC"].should == "₵1.00"
       end
 
@@ -244,7 +244,7 @@ describe Money, "formatting" do
       specify "(:symbol => some non-Boolean value that evaluates to true) returns symbol based on the given currency code" do
         Money.new(100, "GBP").format(:symbol => true).should == "£1.00"
         Money.new(100, "EUR").format(:symbol => true).should == "€1,00"
-        Money.new(100, "SEK").format(:symbol => true).should == "kr1.00"
+        Money.new(100, "SEK").format(:symbol => true).should == "1,00 kr"
       end
 
       specify "(:symbol => "", nil or false) returns the amount without a symbol" do


### PR DESCRIPTION
This PR just corrects a few config settings for Swedish currency. For comparison see:

[the Apple Store](http://store.apple.com/se)

and

[the Rails sv-SE locale](https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/sv-SE.yml#L135)
