### PR TITLE
Add exponent to currency

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@ banjerluke
 Bartosz Dz
 Bodaniel Jeanes
 bUg.
+Casper Thomsen
 Choongmin Lee
 Chris Kampmeier
 Christian Billen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Ensure BigDecimal.new always receives a string - compatibility fix for ruby-1.9.2-p320
 - Update Maldivian Currency to MVR and fix ރ. to be ރ
+- Add exponent to currency
 
 ## 5.1.0
 

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -139,6 +139,11 @@ class Money
     # @return [Integer]
     attr_reader :subunit_to_unit
 
+    # The number of digits after the decimal separator.
+    #
+    # @return [Float]
+    attr_reader :exponent
+
     # The decimal mark, or character used to separate the whole unit from the subunit.
     #
     # @return [String]
@@ -244,7 +249,7 @@ class Money
     # @example
     #   Money::Currency.new(:usd) #=> #<Currency id: usd ...>
     def inspect
-      "#<#{self.class.name} id: #{id}, priority: #{priority}, symbol_first: #{symbol_first}, thousands_separator: #{thousands_separator}, html_entity: #{html_entity}, decimal_mark: #{decimal_mark}, name: #{name}, symbol: #{symbol}, subunit_to_unit: #{subunit_to_unit}, iso_code: #{iso_code}, iso_numeric: #{iso_numeric}, subunit: #{subunit}>"
+      "#<#{self.class.name} id: #{id}, priority: #{priority}, symbol_first: #{symbol_first}, thousands_separator: #{thousands_separator}, html_entity: #{html_entity}, decimal_mark: #{decimal_mark}, name: #{name}, symbol: #{symbol}, subunit_to_unit: #{subunit_to_unit}, exponent: #{exponent}, iso_code: #{iso_code}, iso_numeric: #{iso_numeric}, subunit: #{subunit}>"
     end
 
     # Returns a string representation corresponding to the upcase +id+
@@ -279,6 +284,13 @@ class Money
 
     def symbol_first?
       !!@symbol_first
+    end
+
+    # Returns the number of digits after the decimal separator.
+    #
+    # @return [Float]
+    def exponent
+      Math.log10(@subunit_to_unit)
     end
 
     # Cache decimal places for subunit_to_unit values.  Common ones pre-cached.

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -91,7 +91,7 @@ describe Money::Currency do
   describe "#inspect" do
     it "works as documented" do
       Money::Currency.new(:usd).inspect.should ==
-          %Q{#<Money::Currency id: usd, priority: 1, symbol_first: true, thousands_separator: ,, html_entity: $, decimal_mark: ., name: United States Dollar, symbol: $, subunit_to_unit: 100, iso_code: USD, iso_numeric: 840, subunit: Cent>}
+          %Q{#<Money::Currency id: usd, priority: 1, symbol_first: true, thousands_separator: ,, html_entity: $, decimal_mark: ., name: United States Dollar, symbol: $, subunit_to_unit: 100, exponent: 2.0, iso_code: USD, iso_numeric: 840, subunit: Cent>}
     end
   end
 
@@ -118,6 +118,14 @@ describe Money::Currency do
     it "works as documented" do
       Money::Currency.new(:usd).code.should == "$"
       Money::Currency.new(:azn).code.should == "AZN"
+    end
+  end
+
+  describe "#exponent" do
+    it "conforms to iso 4217" do
+      Money::Currency.new(:jpy).exponent == 0
+      Money::Currency.new(:usd).exponent == 2
+      Money::Currency.new(:iqd).exponent == 3
     end
   end
 


### PR DESCRIPTION
The exponent of a money value is the number of digits after the decimal separator (that separates the major unit from the minor unit). See e.g. Section http://en.wikipedia.org/wiki/ISO_4217#Code_formation and the tables.

It's just the simple method Money::Currency#exponent that does the logarithmic calculation.
