### PR TITLE
Fix for #245 (no thousand separator in format output)

### DIFF
--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -223,7 +223,8 @@ class Money
       end
 
       # Apply thousands_separator
-      formatted.gsub!(regexp_format(formatted, rules, decimal_mark), "\\1#{thousands_separator_value}")
+      formatted.gsub!(regexp_format(formatted, rules, decimal_mark, symbol_value),
+                      "\\1#{thousands_separator_value}")
 
       if rules[:with_currency]
         formatted << " "
@@ -259,12 +260,13 @@ class Money
     end
   end
 
-  def regexp_format(formatted, rules, decimal_mark)
+  def regexp_format(formatted, rules, decimal_mark, symbol_value)
     regexp_decimal = Regexp.escape(decimal_mark)
     if rules[:south_asian_number_formatting]
       /(\d+?)(?=(\d\d)+(\d)(?:\.))/
     else
-      if formatted =~ /#{regexp_decimal}/
+      # Symbols may contain decimal marks (E.g "դր.")
+      if formatted.sub(symbol_value, "") =~ /#{regexp_decimal}/
         /(\d)(?=(?:\d{3})+(?:#{regexp_decimal}))/
       else
         /(\d)(?=(?:\d{3})+(?:[^\d]{1}|$))/

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -165,6 +165,12 @@ describe Money, "formatting" do
       it "respects :subunit_to_unit currency property" do
         Money.new(10_00, "BHD").format(:no_cents => true).should == "ب.د1"
       end
+
+      it "inserts thousand separators if symbol contains decimal mark and no_cents is true" do
+        Money.new(100000000, "AMD").format(no_cents: true).should == "1,000,000 դր."
+        Money.new(100000000, "USD").format(no_cents: true).should == "$1,000,000"
+        Money.new(100000000, "RUB").format(no_cents: true).should == "1.000.000 р."
+      end
     end
 
     describe ":no_cents_if_whole option" do


### PR DESCRIPTION
Fixes format output for currencies with decimal mark in the
symbol string. E.g. "р." or "դր.". 

This is related and fixes issue #245.
