### PR TITLE
Allow combined comparison operator to handle zero values without rates

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Eloy
 Exoth
 François Beausoleil
 Francisco Trindade
+Gee-Hsien Chuang
 Hakan Ensari
 Hongli Lai
 Ilia Lobsanov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+- Allow combined comparison operator to handle zero values without rates
+
 ## 5.1.1
 
 - Added :sign_before_symbol option to format negative numbers as -£1 rather than £-1

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -46,7 +46,7 @@ class Money
     def <=>(other_money)
       if other_money.respond_to?(:to_money)
         other_money = other_money.to_money
-        if self.currency == other_money.currency
+        if fractional == 0 || other_money.fractional == 0 || currency == other_money.currency
           fractional <=> other_money.fractional
         else
           fractional <=> other_money.exchange_to(currency).fractional

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -126,16 +126,40 @@ describe Money do
       (Money.new(100_00, "USD") <=> target).should > 0
     end
 
-    it "can be used to compare with a String money value" do
+    it "cannot compare objects with different currencies when no rate exists, unless one of the amounts is zero" do
+      expect { Money.new(100_00, "EUR") <=> Money.new(100_00, "USD") }.to raise_error(Money::Bank::UnknownRate)
+
+      (Money.new(100_00, "EUR") <=> Money.new(0, "USD")).should > 0
+      (Money.new(0, "EUR") <=> Money.new(100_00, "USD")).should < 0
+      (Money.new(0, "EUR") <=> Money.new(0, "USD")).should == 0
+    end
+
+    it "can be used to compare with a String money value when Money object is in default currency" do
       (Money.new(1_00) <=> "1.00").should == 0
       (Money.new(1_00) <=> ".99").should > 0
       (Money.new(1_00) <=> "2.00").should < 0
     end
 
-    it "can be used to compare with a Numeric money value" do
+    it "can be used to compare with a String money value when Money object is not in default currency if String evaluates to zero" do
+      expect { Money.new(1_00, "EUR") <=> "1.00" }.to raise_error(Money::Bank::UnknownRate)
+
+      (Money.new(1_00, "EUR") <=> "0.00").should > 0
+      (Money.new(0_00, "EUR") <=> "0.00").should == 0
+      (Money.new(-1_00, "EUR") <=> "0.00").should < 0
+    end
+
+    it "can be used to compare with a Numeric money value when Money object is in default currency" do
       (Money.new(1_00) <=> 1).should == 0
       (Money.new(1_00) <=> 0.99).should > 0
       (Money.new(1_00) <=> 2.00).should < 0
+    end
+
+    it "can be used to compare with a Numeric money value when Money object is not in default currency if String evaluates to zero" do
+      expect { Money.new(1_00, "EUR") <=> 1 }.to raise_error(Money::Bank::UnknownRate)
+
+      (Money.new(1_00, "EUR") <=> 0).should > 0
+      (Money.new(0_00, "EUR") <=> 0).should == 0
+      (Money.new(-1_00, "EUR") <=> 0).should < 0
     end
 
     it "can be used to compare with an object that responds to #to_money" do


### PR DESCRIPTION
When values are equivalent to 0, currency rates are not needed.

Issue:
https://github.com/RubyMoney/money/issues/261
