### PR TITLE
Money.add_rate spec should not impact default_bank

### DIFF
--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -118,6 +118,15 @@ describe Money do
   end
 
   describe ".add_rate" do
+    before do
+      @default_bank = Money.default_bank
+      Money.default_bank = Money::Bank::VariableExchange.new
+    end
+
+    after do
+      Money.default_bank = @default_bank
+    end
+
     it "saves rate into current bank" do
       Money.add_rate("EUR", "USD", 10)
       Money.new(10_00, "EUR").exchange_to("USD").should == Money.new(100_00, "USD")


### PR DESCRIPTION
Otherwise other specs that do not expect a EUR -> USD rate to exist may get unexpected behavior

If we don't isolate the changes to the default_bank's rates, another spec with the following assertion may intermittently fail (based on the order specs are run):

```
expect { Money.new(10_00, "EUR").exchange_to("USD") }.to raise_error(Money::Bank::UnknownRate)
```
