### PR TITLE
HTML entities incorrectly escaped with RUB currency + :no_cents option

### DIFF
--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -214,6 +214,16 @@ class Money
         formatted = "#{self.to_s.to_i}"
       end
 
+      thousands_separator_value = thousands_separator
+      # Determine thousands_separator
+      if rules.has_key?(:thousands_separator)
+        thousands_separator_value = rules[:thousands_separator] || ''
+      end
+
+      # Apply thousands_separator
+      formatted.gsub!(regexp_format(formatted, rules, decimal_mark, symbol_value),
+                      "\\1#{thousands_separator_value}")
+
       symbol_position =
         if rules.has_key?(:symbol_position)
           rules[:symbol_position]
@@ -243,16 +253,6 @@ class Money
         rules[:decimal_mark] != decimal_mark
         formatted.sub!(decimal_mark, rules[:decimal_mark])
       end
-
-      thousands_separator_value = thousands_separator
-      # Determine thousands_separator
-      if rules.has_key?(:thousands_separator)
-        thousands_separator_value = rules[:thousands_separator] || ''
-      end
-
-      # Apply thousands_separator
-      formatted.gsub!(regexp_format(formatted, rules, decimal_mark, symbol_value),
-                      "\\1#{thousands_separator_value}")
 
       if rules[:with_currency]
         formatted << " "

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -171,6 +171,12 @@ describe Money, "formatting" do
         Money.new(100000000, "USD").format(no_cents: true).should == "$1,000,000"
         Money.new(100000000, "RUB").format(no_cents: true).should == "1.000.000 р."
       end
+
+      it "doesn't incorrectly format HTML" do
+        money = ::Money.new(1999, "RUB")
+        output = money.format(:html => true, :no_cents => true)
+        output.should == "19 &#x0440;&#x0443;&#x0431;"
+      end
     end
 
     describe ":no_cents_if_whole option" do


### PR DESCRIPTION
This is similar to my other issue, #271, but unlike that one, I'm actually running the latest code.

Steps to reproduce the problem are pretty simple:

```
require 'money'
money = ::Money.new(1999, "RUB")
money.format(:html => true, :no_cents => true)
```

I've even got a spec written for this (see attached). I'll look into why this is happening and see if I can figure it out.
