### PR TITLE
Wrap the currency symbol in html

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -78,3 +78,4 @@ Tom Lianza
 Бродяной Александр
 Adrian Longley
 Daniel Sherson
+Clarke Brunsdon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master
+- Wrap the currency symbol in a span if :html is specified in the rules
 - Added Money::Currency.all method
 - Allow combined comparison operator to handle zero values without rates
 

--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -240,6 +240,8 @@ class Money
       end
 
       if symbol_value && !symbol_value.empty?
+        symbol_value = "<span class=\"currency_symbol\">#{symbol_value}</span>" if rules[:html]
+
         formatted = if symbol_position == :before
           symbol_space = rules[:symbol_before_without_space] === false ? " " : ""
           "#{sign}#{symbol_value}#{symbol_space}#{formatted}"

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -175,7 +175,7 @@ describe Money, "formatting" do
       it "doesn't incorrectly format HTML" do
         money = ::Money.new(1999, "RUB")
         output = money.format(:html => true, :no_cents => true)
-        output.should == "19 &#x0440;&#x0443;&#x0431;"
+        output.should == "19 <span class=\"currency_symbol\">&#x0440;&#x0443;&#x0431;</span>"
       end
     end
 
@@ -336,12 +336,12 @@ describe Money, "formatting" do
     describe ":html option" do
       specify "(:html => true) works as documented" do
         string = Money.ca_dollar(570).format(:html => true, :with_currency => true)
-        string.should == "$5.70 <span class=\"currency\">CAD</span>"
+        string.should == "<span class=\"currency_symbol\">$</span>5.70 <span class=\"currency\">CAD</span>"
       end
 
       specify "should fallback to symbol if entity is not available" do
         string = Money.new(570, 'DKK').format(:html => true)
-        string.should == "5,70 kr"
+        string.should == "5,70 <span class=\"currency_symbol\">kr</span>"
       end
     end
 


### PR DESCRIPTION
We use the existing option for :html, which will change existing markup, but unless people have a style already for currency_symbol, I can't imagine anyone will notice. 
