### PR TITLE
Improved comparison of currencies

### DIFF
--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -234,7 +234,7 @@ class Money
     #   c1 == c2 #=> false
     def ==(other_currency)
       self.equal?(other_currency) ||
-      self.id.downcase == other_currency.id.downcase
+      self.id.to_s.downcase == (other_currency.is_a?(Currency) ? other_currency.id.to_s.downcase : other_currency.to_s.downcase)
     end
 
     # Compares +self+ with +other_currency+ and returns +true+ if the are the

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -101,6 +101,12 @@ describe Money::Currency do
       Money::Currency.new(:eur).should     == Money::Currency.new(:EUR)
       Money::Currency.new(:eur).should_not == Money::Currency.new(:usd)
     end
+    
+    it "allows direct comparison of currencies and symbols/strings" do
+      Money::Currency.new(:eur).should     == 'eur'
+      Money::Currency.new(:eur).should     == :EUR
+      Money::Currency.new(:eur).should_not == 'usd'
+    end
   end
 
   describe "#eql?" do


### PR DESCRIPTION
- ignore case of currency code
- allow comparison of currencies with strings/symbols (as currency ISO code is the only thing that's relevant for comparison anyways)
