### PR TITLE
Fix bug for :symbol => false with jpy/ja

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Works on Ruby 1.8.7
 - Update deps
 - Depreciate Money.parse
+- Passing :symbol => false when formatting 'JPY' currency in :ja locale
+  will work as expected
 
 ## 5.1.1
 

--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -306,7 +306,7 @@ class Money
 
   def localize_formatting_rules(rules)
     if currency.iso_code == "JPY" && I18n.locale == :ja
-      rules[:symbol] = "円"
+      rules[:symbol] = "円" unless rules[:symbol] == false
       rules[:symbol_position] = :after
       rules[:symbol_after_without_space] = true
     end

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -82,7 +82,9 @@ describe Money, "formatting" do
       before { @_locale = I18n.locale; I18n.locale = :ja }
 
       it "formats Japanese currency in Japanese properly" do
-        Money.new(1000, "JPY").format.should == "1,000円"
+        money = Money.new(1000, "JPY")
+        money.format.should == "1,000円"
+        money.format(:symbol => false).should == "1,000"
       end
 
       after  { I18n.locale = @_locale }
@@ -265,6 +267,9 @@ describe Money, "formatting" do
         money.format(:symbol => "").should == "1.00"
         money.format(:symbol => nil).should == "1.00"
         money.format(:symbol => false).should == "1.00"
+
+        money = Money.new(100, "JPY")
+        money.format(:symbol => false).should == "100"
       end
 
       it "defaults :symbol to true" do


### PR DESCRIPTION
Could not turn off the symbol in this one, special case, and this pull request is to fix that.
