### PR TITLE
Money division should obey the specified rounding mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@ Alex Speller
 Andreas Loupasakis
 Andrew White
 Anthony Hristov
+Anthony Sellitti
 banjerluke
 Bartosz Dz
 Benjamin Grössing
@@ -46,6 +47,7 @@ Mike Połétyn
 Musannif Zahir
 Neil Middleton
 Olek Janiszewski
+Orien Madgwick
 Paul McMahon
 Pavel Gabriel
 Pavan Sudarshan

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -164,7 +164,7 @@ class Money
           (fractional / BigDecimal(value.exchange_to(currency).fractional.to_s)).to_f
         end
       else
-        Money.new(fractional / value, currency)
+        Money.new(fractional / BigDecimal.new(value.to_s), currency)
       end
     end
 

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -241,12 +241,50 @@ describe Money do
     it "divides Money by Fixnum and returns Money" do
       ts = [
         {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 3, :USD)},
-        {:a => Money.new( 13, :USD), :b => -4, :c => Money.new(-4, :USD)},
-        {:a => Money.new(-13, :USD), :b =>  4, :c => Money.new(-4, :USD)},
+        {:a => Money.new( 13, :USD), :b => -4, :c => Money.new(-3, :USD)},
+        {:a => Money.new(-13, :USD), :b =>  4, :c => Money.new(-3, :USD)},
         {:a => Money.new(-13, :USD), :b => -4, :c => Money.new( 3, :USD)},
       ]
       ts.each do |t|
         (t[:a] / t[:b]).should == t[:c]
+      end
+    end
+
+    context 'rounding preference' do
+      before do
+        Money.stub(:rounding_mode => rounding_mode)
+      end
+
+      after do
+        Money.unstub(:rounding_mode)
+      end
+
+      context 'ceiling rounding' do
+        let(:rounding_mode) { BigDecimal::ROUND_CEILING }
+        it "obeys the rounding preference" do
+          (Money.new(10) / 3).should == Money.new(4)
+        end
+      end
+
+      context 'floor rounding' do
+        let(:rounding_mode) { BigDecimal::ROUND_FLOOR }
+        it "obeys the rounding preference" do
+          (Money.new(10) / 6).should == Money.new(1)
+        end
+      end
+
+      context 'half up rounding' do
+        let(:rounding_mode) { BigDecimal::ROUND_HALF_UP }
+        it "obeys the rounding preference" do
+          (Money.new(10) / 4).should == Money.new(3)
+        end
+      end
+
+      context 'half down rounding' do
+        let(:rounding_mode) { BigDecimal::ROUND_HALF_DOWN }
+        it "obeys the rounding preference" do
+          (Money.new(10) / 4).should == Money.new(2)
+        end
       end
     end
 
@@ -302,8 +340,8 @@ describe Money do
     it "divides Money by Fixnum and returns Money" do
       ts = [
           {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 3, :USD)},
-          {:a => Money.new( 13, :USD), :b => -4, :c => Money.new(-4, :USD)},
-          {:a => Money.new(-13, :USD), :b =>  4, :c => Money.new(-4, :USD)},
+          {:a => Money.new( 13, :USD), :b => -4, :c => Money.new(-3, :USD)},
+          {:a => Money.new(-13, :USD), :b =>  4, :c => Money.new(-3, :USD)},
           {:a => Money.new(-13, :USD), :b => -4, :c => Money.new( 3, :USD)},
       ]
       ts.each do |t|
@@ -363,8 +401,8 @@ describe Money do
     it "calculates division and modulo with Fixnum" do
       ts = [
           {:a => Money.new( 13, :USD), :b =>  4, :c => [Money.new( 3, :USD), Money.new( 1, :USD)]},
-          {:a => Money.new( 13, :USD), :b => -4, :c => [Money.new(-4, :USD), Money.new(-3, :USD)]},
-          {:a => Money.new(-13, :USD), :b =>  4, :c => [Money.new(-4, :USD), Money.new( 3, :USD)]},
+          {:a => Money.new( 13, :USD), :b => -4, :c => [Money.new(-3, :USD), Money.new(-3, :USD)]},
+          {:a => Money.new(-13, :USD), :b =>  4, :c => [Money.new(-3, :USD), Money.new( 3, :USD)]},
           {:a => Money.new(-13, :USD), :b => -4, :c => [Money.new( 3, :USD), Money.new(-1, :USD)]},
       ]
       ts.each do |t|


### PR DESCRIPTION
We ran into a problem when using this gem to calculate tax rates, where the value returned was unexpected, and did not match the rounding mode we had explicitly set.

We discovered that this was due to a case of integer division (the fractional is rounded, as per the specified mode, then cast to a Fixnum) and the value we divided by (also an integer) caused the result to be floored (as per integer division).

For example: Given $10, 10% of this is $0.91 (10.00/11 = 0.9091)
Money's / method calculated this as 90 ($0.90).

This change ensures that the division method actually respects the rounding method.

There is an issue discussing this problem (see https://github.com/RubyMoney/money/issues/270), however the answer implies that the consumer of this gem should have an understanding of the underlying implementation.
