### PR TITLE
Add russian_central_bank to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ implementations.
 - [nbrb_currency](https://github.com/slbug/nbrb_currency)
 - [money-open-exchange-rates](https://github.com/spk/money-open-exchange-rates)
 - [money-historical-bank](https://github.com/atwam/money-historical-bank)
+- [russian_central_bank](https://github.com/rmustafin/russian_central_bank)
 
 ## Ruby on Rails
 


### PR DESCRIPTION
Add russian_central_bank to the list of compatible currency exchange rate implementations in README. Tested with money 5.x and 6.0.0.pre2 versions.
