### PR TITLE
Fixed typo in deprecation warning.

### DIFF
--- a/lib/money/core_extensions.rb
+++ b/lib/money/core_extensions.rb
@@ -15,7 +15,7 @@ class Numeric
   # @see Money.from_numeric
   #
   def to_money(currency = nil)
-    Money.deprecate "as of Money 6.1.0 you must `require 'money/core_extension'` to use Numeric#to_money."
+    Money.deprecate "as of Money 6.1.0 you must `require 'money/core_extensions'` to use Numeric#to_money."
     Money.from_numeric(self, currency || Money.default_currency)
   end
 end
@@ -56,7 +56,7 @@ class String
   #   "USD".to_currency #=> #<Money::Currency id: usd>
   #
   def to_currency
-    Money.deprecate "as of Money 6.1.0 you must `require 'money/core_extension'` to use String#to_currency."
+    Money.deprecate "as of Money 6.1.0 you must `require 'money/core_extensions'` to use String#to_currency."
     Money::Currency.new(self)
   end
 end
@@ -74,7 +74,7 @@ class Symbol
   #   :ars.to_currency #=> #<Money::Currency id: ars>
   #
   def to_currency
-    Money.deprecate "as of Money 6.1.0 you must `require 'money/core_extension'` to use Symbol#to_currency."
+    Money.deprecate "as of Money 6.1.0 you must `require 'money/core_extensions'` to use Symbol#to_currency."
     Money::Currency.new(self)
   end
 end

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -25,7 +25,7 @@ class Money
     #   Money.new(100) == Money.new(100) #=> true
     def ==(other_money)
       if other_money.respond_to?(:to_money)
-        Money.deprecate "as of Money 6.1.0 you must `require 'money/core_extension'` to compare Money to core classes." unless other_money.is_a? Money
+        Money.deprecate "as of Money 6.1.0 you must `require 'money/core_extensions'` to compare Money to core classes." unless other_money.is_a? Money
         other_money = other_money.to_money
         fractional == other_money.fractional && currency == other_money.currency
       else
@@ -46,7 +46,7 @@ class Money
 
     def <=>(other_money)
       if other_money.respond_to?(:to_money)
-        Money.deprecate "as of Money 6.1.0 you must `require 'money/core_extension'` to compare Money to core classes." unless other_money.is_a? Money
+        Money.deprecate "as of Money 6.1.0 you must `require 'money/core_extensions'` to compare Money to core classes." unless other_money.is_a? Money
         other_money = other_money.to_money
         if fractional == 0 || other_money.fractional == 0 || currency == other_money.currency
           fractional <=> other_money.fractional


### PR DESCRIPTION
See https://github.com/RubyMoney/money/issues/333.
