### PR TITLE
change the value of html_entity of CNY currency

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -427,7 +427,7 @@
     "subunit": "Fen",
     "subunit_to_unit": 100,
     "symbol_first": true,
-    "html_entity": "&#x5713;",
+    "html_entity": "&#20803;",
     "decimal_mark": ".",
     "thousands_separator": ",",
     "iso_numeric": "156"


### PR DESCRIPTION
The value is originally "&#x5713;", which will be rendered as "圓", but
the correct one should be "元", and its corresponding html entity value
should be "&#20803;"
