### PR TITLE
Don't always print deprecation on String#to_money

### DIFF
--- a/lib/money/core_extensions/numeric.rb
+++ b/lib/money/core_extensions/numeric.rb
@@ -1,9 +1,7 @@
 class Numeric
   alias_method :_to_money, :to_money
   def to_money(*args)
-    unless Money.silence_core_extensions_deprecations
-      Money.deprecate "as of Money 6.1.0 you must `require 'monetize/core_extensions'` to use Numeric#to_money. Please start using the Monetize gem from https://github.com/RubyMoney/monetize if you are not already doing so"
-    end
+    Money.deprecate "as of Money 6.1.0 you must `require 'monetize/core_extensions'` to use Numeric#to_money. Please start using the Monetize gem from https://github.com/RubyMoney/monetize if you are not already doing so"
     _to_money(*args)
   end
 end

--- a/lib/money/core_extensions/string.rb
+++ b/lib/money/core_extensions/string.rb
@@ -1,17 +1,13 @@
 class String
   alias_method :_to_money, :to_money
   def to_money(*args)
-    unless Money.silence_core_extensions_deprecations
-      Money.deprecate "as of Money 6.1.0 you must `require 'monetize/core_extensions'` to use String#to_money. Please start using the Monetize gem from https://github.com/RubyMoney/monetize if you are not already doing so"
-    end
+    Money.deprecate "as of Money 6.1.0 you must `require 'monetize/core_extensions'` to use String#to_money. Please start using the Monetize gem from https://github.com/RubyMoney/monetize if you are not already doing so"
     _to_money(*args)
   end
 
   alias_method :_to_currency, :to_currency
   def to_currency(*args)
-    unless Money.silence_core_extensions_deprecations
-      Money.deprecate "as of Money 6.1.0 you must `require 'monetize/core_extensions'` to use String#to_currency. Please start using the Monetize gem from https://github.com/RubyMoney/monetize if you are not already doing so"
-    end
+    Money.deprecate "as of Money 6.1.0 you must `require 'monetize/core_extensions'` to use String#to_currency. Please start using the Monetize gem from https://github.com/RubyMoney/monetize if you are not already doing so"
     _to_currency(*args)
   end
 end

--- a/lib/money/core_extensions/symbol.rb
+++ b/lib/money/core_extensions/symbol.rb
@@ -1,9 +1,7 @@
 class Symbol
   alias_method :_to_currency, :to_currency
   def to_currency(*args)
-    unless Money.silence_core_extensions_deprecations
-      Money.deprecate "as of Money 6.1.0 you must `require 'monetize/core_extensions'` to use Symbol#to_currency. Please start using the Monetize gem from https://github.com/RubyMoney/monetize if you are not already doing so"
-    end
+    Money.deprecate "as of Money 6.1.0 you must `require 'monetize/core_extensions'` to use Symbol#to_currency. Please start using the Monetize gem from https://github.com/RubyMoney/monetize if you are not already doing so"
     _to_currency(*args)
   end
 end

--- a/lib/money/deprecations.rb
+++ b/lib/money/deprecations.rb
@@ -5,9 +5,11 @@ class Money
   #
   # @return [nil]
   def self.deprecate(message)
-    file, line = caller(2).first.split(':', 2)
-    line = line.to_i
+    unless Money.silence_core_extensions_deprecations
+      file, line = caller(2).first.split(':', 2)
+      line = line.to_i
 
-    warn "DEPRECATION WARNING: #{message} (called from: #{file}:#{line})"
+      warn "DEPRECATION WARNING: #{message} (called from: #{file}:#{line})"
+    end
   end
 end

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -25,7 +25,7 @@ class Money
     def ==(other_money)
       if other_money.respond_to?(:to_money)
         unless other_money.is_a?(Money)
-          Money.deprecate "as of Money 6.1.0 you must `require 'monetize/core_extensions'` to compare Money to core classes. Please start using the Monetize gem from https://github.com/RubyMoney/monetize if you are not already doing so" unless Money.silence_core_extensions_deprecations
+          Money.deprecate "as of Money 6.1.0 you must `require 'monetize/core_extensions'` to compare Money to core classes. Please start using the Monetize gem from https://github.com/RubyMoney/monetize if you are not already doing so"
         end
         other_money = other_money.to_money
         fractional == other_money.fractional && currency == other_money.currency
@@ -58,7 +58,7 @@ class Money
     end
 
     def check_compare_deprecate(val)
-      unless val.is_a?(Money) || Money.silence_core_extensions_deprecations
+      unless val.is_a?(Money)
         Money.deprecate "as of Money 6.1.0 you must `require 'monetize/core_extensions'` to compare Money to core classes. Please start using the Monetize gem from https://github.com/RubyMoney/monetize if you are not already doing so"
       end
     end

--- a/spec/money/deprecations_spec.rb
+++ b/spec/money/deprecations_spec.rb
@@ -13,21 +13,39 @@ describe Money do
 
       Money.deprecate(error_message)
     end
-  end
-end
 
-describe "core extensions" do
-  it "does not print deprecations when silenced" do
-    Money.silence_core_extensions_deprecations = true
+    context "when silenced" do
+      it "should not warn" do
+        Money.should_not_receive(:warn)
 
-    expect_no_deprecation_for { "$1.00".to_money }
-    expect_no_deprecation_for { "USD".to_currency }
-    expect_no_deprecation_for { 1.to_money }
-    expect_no_deprecation_for { :USD.to_currency }
+        while_silenced { Money.deprecate("anything") }
+      end
+    end
   end
 
-  def expect_no_deprecation_for(&block)
-    Money.should_not_receive(:deprecate)
-    yield
+  describe "core extensions" do
+    it "does not print deprecations when silenced" do
+      while_silenced do
+        expect_no_deprecation_for { "$1.00".to_money }
+        expect_no_deprecation_for { "USD".to_currency }
+        expect_no_deprecation_for { 1.to_money }
+        expect_no_deprecation_for { :USD.to_currency }
+      end
+    end
+
+    def expect_no_deprecation_for(&block)
+      Money.should_not_receive(:warn)
+      yield
+    end
+  end
+
+  def while_silenced(&block)
+    begin
+      old_setting = Money.silence_core_extensions_deprecations
+      Money.silence_core_extensions_deprecations = true
+      yield
+    ensure
+      Money.silence_core_extensions_deprecations = old_setting
+    end
   end
 end


### PR DESCRIPTION
Other `to_money` methods are not printing the deprecation warning when
`Money.silence_core_extensions_deprecations` is true, so this brings the 
behavior of Strings in line with Numeric objects.
