### PR TITLE
Money.default_currency=() accepts a lambda.

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -110,6 +110,14 @@ class Money
     alias_method :zero, :empty
   end
 
+  def self.default_currency
+    if @default_currency.respond_to?(:call)
+      Money::Currency.new(@default_currency.call)
+    else
+      Money::Currency.new(@default_currency)
+    end
+  end
+
   def self.setup_defaults
     # Set the default bank for creating new +Money+ objects.
     self.default_bank = Bank::VariableExchange.instance

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -680,4 +680,24 @@ YAML
       obj.as_euro.should == Money.new(1, "EUR")
     end
   end
+
+  describe ".default_currency" do
+    before do
+      @default_currency = Money.default_currency
+    end
+
+    it "accepts a lambda" do
+      Money.default_currency = lambda { :eur }
+      Money.default_currency.should == Money::Currency.new(:eur)
+    end
+
+    it "accepts a symbol" do
+      Money.default_currency = :eur
+      Money.default_currency.should == Money::Currency.new(:eur)
+    end
+
+    after do
+      Money.default_currency = @default_currency
+    end
+  end
 end


### PR DESCRIPTION
Hi,

This pull request modifies Money to accept a lambda when setting a default_currency. 

This is useful for multithreaded environments, like a Ruby on Rails application running on Puma. I am using it like this:

``` ruby
MoneyRails.configure do |config|

  # To set the default currency
  config.default_currency = lambda { RequestStore.store[:default_currency] || :eur }
end
```

``` ruby
class ApplicationController < ActionController::Base

  before_filter :set_currency

  def set_currency
    RequestStore.store[:default_currency] = current_clinic.currency
  end
end
```

There are some minor changes to do on money-rails for this to work. I will make PR too in that repo if this gets merged in.
