### PR TITLE
Fix bug in block form of Money.rounding_mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,6 +43,7 @@ Jérémy Lecour
 Jesse Cooke
 John Duff
 John Gakos
+Jonathon M. Abbott
 Josh Delsman
 Joshua Clayton
 Josh Hepworth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 6.1.0
  - Remove deprecated methods.
+ - Fix issue with block form of rounding_mode.
 
 ## 6.0.1
  - Deprecated methods lists caller on print out for easier updating.

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -163,11 +163,13 @@ class Money
     if mode.nil?
       Thread.current[:money_rounding_mode] || @rounding_mode
     else
-      Thread.current[:money_rounding_mode] = mode
-      yield
+      begin
+        Thread.current[:money_rounding_mode] = mode
+        yield
+      ensure
+        Thread.current[:money_rounding_mode] = nil
+      end
     end
-  ensure
-    Thread.current[:money_rounding_mode] = nil
   end
 
   # Creates a new Money object of the given value, using the Canadian

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -235,6 +235,18 @@ YAML
 
           Money.rounding_mode.should == BigDecimal::ROUND_HALF_EVEN
         end
+
+        it "works for multiplication within a block" do
+          Money.rounding_mode(BigDecimal::ROUND_DOWN) do
+            (Money.new(1_00) * "0.019".to_d).fractional.should == 1
+          end
+
+          Money.rounding_mode(BigDecimal::ROUND_UP) do
+            (Money.new(1_00) * "0.011".to_d).fractional.should == 2
+          end
+
+          Money.rounding_mode.should == BigDecimal::ROUND_HALF_EVEN
+        end
       end
     end
 


### PR DESCRIPTION
The ensure block was triggering when the rounding mode was queried for the first time within the block, which reset the rounding mode for all further operations within the block.
