### PR TITLE
Corrected html_entity for Chilean Peso

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -413,7 +413,7 @@
     "subunit": "Peso",
     "subunit_to_unit": 1,
     "symbol_first": true,
-    "html_entity": "&#x20B1;",
+    "html_entity": "&#36;",
     "decimal_mark": ",",
     "thousands_separator": ".",
     "iso_numeric": "152"


### PR DESCRIPTION
 In Chile we use the $ symbol for our currency, not the ₱ symbol.
