### PR TITLE
Enable Rubinius 2 on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - rbx-2
 script: bundle exec rspec spec
 notifications:
   recipients:


### PR DESCRIPTION
The specs pass for me locally on Rubinius 2.2.7.

If they fail on Travis, I'll fix the issues in the 2.2.8 release.
