### PR TITLE
Performance improvements

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Mateusz Wolsza
 Matias Korhonen
 Matt Jankowski
 Matthew McEachen
+Michael J. Cohen
 Michael Irwin
 Michael Reinsch
 Mikael Wikman

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - Fix output on Ukrainian Hryvnia symbol in HTML.
  - Add documentation about i18n in README.
  - Update iso code, symbol, subunit for the new Turkmenistani manat (GH-181)
+ - Performance Improvements (1.99x faster on MRI, 1.85x on Rubinius, 41.4x faster on JRuby)
 
 ## 6.1.1
  - Remove lingering Monetize call

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -71,7 +71,9 @@ class Money
       #   Money::Currency.wrap(c1)    #=> #<Money::Currency id: usd ...>
       #   Money::Currency.wrap("usd") #=> #<Money::Currency id: usd ...>
       def wrap(object)
-        if object.nil? || object.is_a?(Currency)
+        if object.nil?
+          nil
+        elsif object.is_a?(Currency)
           object
         else
           Currency.new(object)
@@ -125,7 +127,7 @@ class Money
       private
 
       def stringify_keys
-        table.keys.map{|k| k.to_s.downcase}
+        table.keys.each_with_object(Set.new) { |k, set| set.add(k.to_s.downcase) }
       end
     end
 
@@ -172,9 +174,18 @@ class Money
       if self.class.stringified_keys.include?(id)
         @id = id.to_sym
         data = self.class.table[@id]
-        data.each_pair do |key, value|
-          instance_variable_set(:"@#{key}", value)
-        end
+        @priority = data[:priority]
+        @iso_code = data[:iso_code]
+        @name = data[:name]
+        @symbol = data[:symbol]
+        @alternate_symbols = data[:alternate_symbols]
+        @subunit = data[:subunit]
+        @subunit_to_unit = data[:subunit_to_unit]
+        @symbol_first = data[:symbol_first]
+        @html_entity = data[:html_entity]
+        @decimal_mark = data[:decimal_mark]
+        @thousands_separator = data[:thousands_separator]
+        @iso_numeric = data[:iso_numeric]
       else
         raise UnknownCurrency, "Unknown currency '#{id}'"
       end

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -238,13 +238,9 @@ class Money
   #   Money.new(100, "EUR") #=> #<Money @fractional=100 @currency="EUR">
   #
   def initialize(obj, currency = Money.default_currency, bank = Money.default_bank)
-    @fractional = obj.fractional
-    @currency   = obj.currency
-    @bank       = obj.bank
-  rescue NoMethodError
-    @fractional = as_d(obj)
-    @currency   = Currency.wrap(currency)
-    @bank       = bank
+    @fractional = obj.respond_to?(:fractional) ? obj.fractional : as_d(obj)
+    @currency   = obj.respond_to?(:currency) ? obj.currency : Currency.wrap(currency)
+    @bank       = obj.respond_to?(:bank) ? obj.bank : bank
   end
 
   # Assuming using a currency using dollars:
@@ -531,13 +527,11 @@ class Money
   private
 
   def as_d(num)
-    if num.is_a?(Rational)
-      num.to_d(self.class.conversion_precision)
+    if num.respond_to?(:to_d)
+      num.is_a?(Rational) ? num.to_d(self.class.conversion_precision) : num.to_d
     else
-      num.to_d
+      BigDecimal.new(num.to_s)
     end
-  rescue NoMethodError
-    BigDecimal.new(num.to_s)
   end
 
   def strings_from_fractional

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -23,10 +23,12 @@ class Money
     #   Money.new(100) == Money.new(101) #=> false
     #   Money.new(100) == Money.new(100) #=> true
     def ==(other_money)
-      other_money = other_money.to_money
-      fractional == other_money.fractional && currency == other_money.currency
-    rescue NoMethodError
-      false
+      if other_money.respond_to?(:to_money)
+        other_money = other_money.to_money
+        fractional == other_money.fractional && currency == other_money.currency
+      else
+        false
+      end
     end
 
     # Synonymous with +#==+.
@@ -41,13 +43,15 @@ class Money
     end
 
     def <=>(val)
-      val = val.to_money
-      unless fractional == 0 || val.fractional == 0 || currency == val.currency
-        val = val.exchange_to(currency)
+      if val.respond_to?(:to_money)
+        val = val.to_money unless val.respond_to?(:fractional)
+        if fractional != 0 && val.fractional != 0 && currency != val.currency
+          val = val.exchange_to(currency)
+        end
+        fractional <=> val.fractional
+      else
+        raise ArgumentError, "Comparison of #{self.class} with #{val.inspect} failed"
       end
-      fractional <=> val.fractional
-    rescue NoMethodError
-      raise ArgumentError, "Comparison of #{self.class} with #{val.inspect} failed"
     end
 
     # Test if the amount is positive. Returns +true+ if the money amount is


### PR DESCRIPTION
After finding that this gem is an order of magnitude slower on JRuby than MRI, I sat down with a profiler.

This patch offers about 1.99x improvement on MRI, 1.85x on RBX, and makes JRuby 2.6x faster than MRI (for a total improvement of 41.4x!)

Further gains could be had from switching to strings from symbols or at least reducing the number of .to_s and .to_sym calls, but this is enough for me for now, and I couldn't easily get such a conversion to pass the specs.

I can squash these commits if necessary.
## MRI 2.1.2 Before

```
Benchmark.ips { |x| x.report('String#to_money') { '$1,234.56'.to_money } }
Calculating -------------------------------------
     String#to_money      2474 i/100ms
-------------------------------------------------
     String#to_money    27583.9 (±7.0%) i/s -     138544 in   5.051407s
```
## MRI 2.1.2 After

```
Benchmark.ips { |x| x.report('String#to_money') { '$1,234.56'.to_money } }
Calculating -------------------------------------
     String#to_money      4515 i/100ms
-------------------------------------------------
     String#to_money    55149.0 (±4.5%) i/s -     275415 in   5.003928s
```
## Rubinius e8990e6b (warm JIT) Before

```
Benchmark.ips { |x| x.report('String#to_money') { '$1,234.56'.to_money } }
Calculating -------------------------------------
     String#to_money      2027 i/100ms
-------------------------------------------------
     String#to_money    22651.9 (±2.4%) i/s -     113512 in   5.014017s
```
## Rubinius e8990e6b (warm JIT) After

```
Benchmark.ips { |x| x.report('String#to_money') { '$1,234.56'.to_money } }
Calculating -------------------------------------
     String#to_money      3347 i/100ms
-------------------------------------------------
     String#to_money    41777.7 (±2.5%) i/s -     210861 in   5.050445s
```
## JRuby 1.7.12 (Warm JIT, indy off) Before

```
Benchmark.ips { |x| x.report('String#to_money') { '$1,234.56'.to_money } }
Calculating -------------------------------------
     String#to_money       345 i/100ms
-------------------------------------------------
     String#to_money     3450.7 (±3.1%) i/s -      17250 in   5.004000s
```
## JRuby 1.7.12 (Warm JIT, indy off) After

```
Benchmark.ips { |x| x.report('String#to_money') { '$1,234.56'.to_money } }
Calculating -------------------------------------
     String#to_money     12341 i/100ms
-------------------------------------------------
     String#to_money   142865.7 (±1.9%) i/s -     715778 in   5.012000s
```
## JRuby 9k rev 9228157 (Warm JIT, indy off) Before

```
Benchmark.ips { |x| x.report('String#to_money') { '$1,234.56'.to_money } }
Calculating -------------------------------------
     String#to_money       342 i/100ms
-------------------------------------------------
     String#to_money     3465.0 (±1.6%) i/s -      17442 in   5.035000s
```
## JRuby 9k rev 9228157 (Warm JIT, indy off) After

```
Calculating -------------------------------------
     String#to_money     12976 i/100ms
-------------------------------------------------
     String#to_money   147934.4 (±3.2%) i/s -     739632 in   5.005000s
```
