### PR TITLE
Fix for issue #407

### DIFF
--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -212,6 +212,8 @@ class Money
         formatted = "#{formatted.to_i}"
       end
 
+      apply_decimal_mark_from_rules(formatted, rules)
+
       thousands_separator_value = thousands_separator
       # Determine thousands_separator
       if rules.has_key?(:thousands_separator)
@@ -246,8 +248,6 @@ class Money
       else
         formatted="#{sign_before}#{sign}#{formatted}"
       end
-
-      apply_decimal_mark_from_rules(formatted, rules)
 
       if rules[:with_currency]
         formatted << " "


### PR DESCRIPTION
https://github.com/RubyMoney/money/issues/407

Currently, if my default locale is "en_US" and I do something like:
pry(main)> Money.new(123456789, "EUR").format
=> "€1,234,567.89"

It is supposed to be "€1.234.567,89".
