### PR TITLE
Make sure collaborators don't somehow modify empty

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -92,7 +92,7 @@ class Money
     #   Money.empty #=> #<Money @fractional=0>
     def empty(currency = default_currency)
       @empty ||= {}
-      @empty[currency] ||= Money.new(0, currency)
+      @empty[currency] ||= Money.new(0, currency).freeze
     end
     alias_method :zero, :empty
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -88,6 +88,10 @@ describe Money do
     it "memoizes a result for each currency" do
       Money.empty(:cad).object_id.should == Money.empty(:cad).object_id
     end
+
+    it "doesn't allow money to be modified for a currency" do
+      Money.empty.should be_frozen
+    end
   end
 
   describe ".zero" do


### PR DESCRIPTION
![](http://i.cr3ation.co.uk/dl/s1/gif/2b2b34238cf8cc58e522c62cf6cd2bcb_pondefloor.gif)

There is a long story behind this, but the ultimate lesson is that Money.empty should either return a cloned or frozen object. If some collaborating class modifies the memoized 0 value, then every call to Money.empty in that thread will be compared to an altered version of 0. Leading to infinite craziness.
