### PR TITLE
Fix formatting nok

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -104,3 +104,4 @@ Yuusuke Takizawa
 Tien Nguyen
 Wei Zhu
 Zubin Henner
+Troels Knak-Nielsen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
  - Performance Improvements (1.99x faster on MRI, 1.85x on Rubinius, 41.4x faster on JRuby)
  - Money can now add and subtract Fixnum 0
  - Money#new uses Money.default_currency if currency arg is nil (GH-410)
+ - Fixed formatting of NOK, putting the symbol after numbers
 
 ## 6.1.1
  - Remove lingering Monetize call

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -1448,7 +1448,7 @@
     "alternate_symbols": [",-"],
     "subunit": "Øre",
     "subunit_to_unit": 100,
-    "symbol_first": true,
+    "symbol_first": false,
     "html_entity": "kr",
     "decimal_mark": ",",
     "thousands_separator": ".",


### PR DESCRIPTION
I made two changes: NOK is a straight fix. For SEK, the existing is technically not incorrect as both styles are valid, but using a dot is more common, as far as I can tell. It is also consistent with NOK and DKK.
