### PR TITLE
Correct smallest denomination for Vietnamese dong

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -2312,7 +2312,7 @@
     "decimal_mark": ",",
     "thousands_separator": ".",
     "iso_numeric": "704",
-    "smallest_denomination": 2000
+    "smallest_denomination": 100
   },
   "vuv": {
     "priority": 100,


### PR DESCRIPTION
After having changed `subunit_to_unit` to 1 for VND in [PR #441](https://github.com/RubyMoney/money/pull/441), we have to correct the value for `smallest_denomination`as well, since this value is given in the subunit of the currency.

Furthermore, after having read the [Wikipedia article about VND](http://en.wikipedia.org/wiki/Vietnamese_dong) one more time, I realized that there are actually bank notes worth 100 VND. Therefore, the smallest denomination is actually 100 VND, not 200 VND as previously thought.
