### PR TITLE
Fix symbol_first for CZK (Czech Koruna)

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -562,7 +562,7 @@
     "alternate_symbols": [],
     "subunit": "Haléř",
     "subunit_to_unit": 100,
-    "symbol_first": true,
+    "symbol_first": false,
     "html_entity": "",
     "decimal_mark": ",",
     "thousands_separator": ".",


### PR DESCRIPTION
From [wiki](http://en.wikipedia.org/wiki/Czech_koruna):

> The ISO 4217 code is CZK and the local acronym is Kč, which is placed **after** the numeric value (e.g., "50 Kč")
