### PR TITLE
Add `Money.default_formatting_rules` config hash

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,7 @@ kirillian
 Laurynas Butkus
 Marcel Scherf
 Marco Otte-Witte
+Mateus Gomes
 Mateusz Wolsza
 Matias Korhonen
 Matt Jankowski

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  - Fix formatting of NGN - show symbol before amount
  - Switch default and alternate symbols for RUB currency
  - Fix symbol for TRY currency
+ - Add `Money.default_formatting_rules` hash, meant to define default rules for everytime `Money#format` is called. They can be overwritten if provided on method call
 
 ## 6.2.1
  - Ensure set is loaded

--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ If you wish to disable this feature:
 Money.use_i18n = false
 ```
 
+*Note: There are several formatting rules for when `Money#format` is called. For more information, check out the [formatting module](https://github.com/RubyMoney/money/blob/master/lib/money/money/formatting.rb).*
+
 ## Migration Notes
 
 #### Version 6.0.0

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -15,7 +15,7 @@ require "money/money/formatting"
 # @see http://en.wikipedia.org/wiki/Money
 class Money
   include Comparable, Money::Arithmetic, Money::Formatting
-  
+
   # Raised when smallest denomination of a currency is not defined
   class UndefinedSmallestDenomination < StandardError; end
 
@@ -52,7 +52,7 @@ class Money
 
     return_value(fractional)
   end
-  
+
   # Round a given amount of money to the nearest possible amount in cash value. For
   # example, in Swiss francs (CHF), the smallest possible amount of cash value is
   # CHF 0.05. Therefore, this method rounds CHF 0.07 to CHF 0.05, and CHF 0.08 to
@@ -66,11 +66,11 @@ class Money
     unless self.currency.smallest_denomination
       raise UndefinedSmallestDenomination, 'Smallest denomination of this currency is not defined'
     end
-    
+
     fractional = as_d(@fractional)
     smallest_denomination = as_d(self.currency.smallest_denomination)
     rounded_value = (fractional / smallest_denomination).round(0, self.class.rounding_mode) * smallest_denomination
-    
+
     return_value(rounded_value)
   end
 
@@ -86,18 +86,34 @@ class Money
     # This property allows you to specify the default bank object. The default
     # value for this property is an instance of +Bank::VariableExchange.+ It
     # allows one to specify custom exchange rates.
+    #
     # @attr_accessor [Money::Currency] default_currency The default currency,
     # which is used when +Money.new+ is called without an explicit currency
     # argument. The default value is Currency.new("USD"). The value must be a
     # valid +Money::Currency+ instance.
+    #
+    # @attr_accessor [Hash] default_formatting_rules Use this to define a default
+    # hash of rules for everytime +Money#format+ is called.
+    # Rules provided on method call will be merged with the default ones.
+    # To overwrite a rule, just provide the intended value while calling +format+.
+    #
+    # @see +Money::Formatting#format+ for more details.
+    #
+    # @example
+    #   Money.default_formatting_rules = { :display_free => true }
+    #   Money.new(0, "USD").format                          # => "free"
+    #   Money.new(0, "USD").format(:display_free => false)  # => "$0.00"
+    #
     # @attr_accessor [true, false] use_i18n Use this to disable i18n even if
     # it's used by other objects in your app.
+    #
     # @attr_accessor [true, false] infinite_precision Use this to enable
     # infinite precision cents
+    #
     # @attr_accessor [Integer] conversion_precision Use this to specify
     # precision for converting Rational to BigDecimal
-    attr_accessor :default_bank, :default_currency, :use_i18n,
-      :infinite_precision, :conversion_precision
+    attr_accessor :default_bank, :default_currency, :default_formatting_rules,
+      :use_i18n, :infinite_precision, :conversion_precision
 
     # @attr_writer rounding_mode Use this to specify the rounding mode
     attr_writer :rounding_mode
@@ -260,7 +276,7 @@ class Money
   def initialize(obj, currency = Money.default_currency, bank = Money.default_bank)
     @fractional = obj.respond_to?(:fractional) ? obj.fractional : as_d(obj)
     @currency   = obj.respond_to?(:currency) ? obj.currency : Currency.wrap(currency)
-    @currency ||= Money.default_currency 
+    @currency ||= Money.default_currency
     @bank       = obj.respond_to?(:bank) ? obj.bank : bank
   end
 
@@ -618,7 +634,7 @@ class Money
       index < remainder ? high : low
     end
   end
-  
+
   def return_value(value)
     if self.class.infinite_precision
       value

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -169,6 +169,40 @@ describe Money, "formatting" do
       expect(Money.euro(1_234_567_12).format(:no_cents => true)).to eq "€1.234.567"
     end
 
+    context 'when default_formatting_rules defines (display_free: true)' do
+      before do
+        Money.default_formatting_rules = { :display_free => "you won't pay a thing" }
+      end
+
+      after do
+        Money.default_formatting_rules = nil
+      end
+
+      context 'with no rule provided' do
+        it 'acknowledges default rule' do
+          expect(Money.new(0, 'USD').format).to eq "you won't pay a thing"
+        end
+      end
+
+      context 'with rule (display_free: false) provided' do
+        it 'acknowledges provided rule' do
+          expect(Money.new(0, 'USD').format(:display_free => false)).to eq '$0.00'
+        end
+      end
+    end
+
+    context 'when default_formatting_rules is not defined' do
+      before do
+        Money.default_formatting_rules = nil
+      end
+
+      context 'acknowledges provided rule' do
+        it 'acknowledges provided rule' do
+          expect(Money.new(100, 'USD').format(:with_currency => true)).to eq '$1.00 USD'
+        end
+      end
+    end
+
     describe ":with_currency option" do
       specify "(:with_currency option => true) works as documented" do
         expect(Money.ca_dollar(100).format(:with_currency => true)).to eq "$1.00 CAD"


### PR DESCRIPTION
I think having a way to define default rules for everytime `Money#format` is called is a pretty useful feature.

This is basically how it works:

``` ruby
Money.default_formatting_rules = { display_free: true }

Money.new(0, 'USD').format
# => "free"

# Default rules can be overwritten when provided on method call:
Money.new(0, 'USD').format(display_free: false)
# => "$0.00"
```
