### PR TITLE
Fix typo in i18n example file

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,18 +272,19 @@ If you want thousands seperator and decimal mark to be same across all
 currencies this can be defined in your `I18n` translation files.
 
 In an rails application this may look like:
+
 ```yml
 # config/locale/en.yml
 en:
   number:
     format:
-      delimeter: ","
+      delimiter: ","
       separator: "."
   # or
   number:
     currency:
       format:
-        delimeter: ","
+        delimiter: ","
         separator: "."
 ```
 


### PR DESCRIPTION
The option is `delimiter`, and not `delimeter`. Also, the lack of an empty line before the opening of the code block messes up the formatting on http://www.rubydoc.info/gems/money/frames#I18n, so this PR should fix that as well.
