### PR TITLE
Fix deprecation warning under Ruby 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.2
+  - 2.2.0
   - rbx-2
 script: bundle exec rspec spec
 notifications:

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -14,7 +14,7 @@ require "money/money/formatting"
 #
 # @see http://en.wikipedia.org/wiki/Money
 class Money
-  include Comparable, Money::Arithmetic, Money::Formatting
+  include Money::Arithmetic, Money::Formatting, Comparable
 
   # Raised when smallest denomination of a currency is not defined
   class UndefinedSmallestDenomination < StandardError; end

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -30,17 +30,7 @@ class Money
         false
       end
     end
-
-    # Synonymous with +#==+.
-    #
-    # @param [Money] other_money Value to compare with.
-    #
-    # @return [Money]
-    #
-    # @see #==
-    def eql?(other_money)
-      self == other_money
-    end
+    alias_method :eql?, :==
 
     def <=>(val)
       if val.respond_to?(:to_money)


### PR DESCRIPTION
- Arithmetic#== was not being used, Comparable#== was instead, so it was
  using <=> for comparison but swallowing any exceptions
- Fixes #469 

This changes the behavior of == if you have exchange set up, so maybe this should only go into a new major release to keep semantic versioning?
