### PR TITLE
Extracting 'constructor' functions to a module, adding aliases and GBP

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -2,6 +2,7 @@
 require "money/bank/variable_exchange"
 require "money/bank/single_currency"
 require "money/money/arithmetic"
+require "money/money/constructors"
 require "money/money/formatting"
 
 # "Money is any object or record that is generally accepted as payment for
@@ -15,6 +16,7 @@ require "money/money/formatting"
 # @see http://en.wikipedia.org/wiki/Money
 class Money
   include Money::Arithmetic, Money::Formatting, Comparable
+  extend Constructors
 
   # Raised when smallest denomination of a currency is not defined
   class UndefinedSmallestDenomination < StandardError; end
@@ -118,72 +120,6 @@ class Money
     # @attr_writer rounding_mode Use this to specify the rounding mode
     attr_writer :rounding_mode
 
-    # Create a new money object with value 0.
-    #
-    # @param [Currency, String, Symbol] currency The currency to use.
-    #
-    # @return [Money]
-    #
-    # @example
-    #   Money.empty #=> #<Money @fractional=0>
-    def empty(currency = default_currency)
-      @empty ||= {}
-      @empty[currency] ||= Money.new(0, currency).freeze
-    end
-    alias_method :zero, :empty
-
-
-    # Creates a new Money object of the given value, using the Canadian
-    # dollar currency.
-    #
-    # @param [Integer] cents The cents value.
-    #
-    # @return [Money]
-    #
-    # @example
-    #   n = Money.ca_dollar(100)
-    #   n.cents    #=> 100
-    #   n.currency #=> #<Money::Currency id: cad>
-    def ca_dollar(cents)
-      Money.new(cents, "CAD")
-    end
-
-    alias_method :cad, :ca_dollar
-
-
-    # Creates a new Money object of the given value, using the American dollar
-    # currency.
-    #
-    # @param [Integer] cents The cents value.
-    #
-    # @return [Money]
-    #
-    # @example
-    #   n = Money.us_dollar(100)
-    #   n.cents    #=> 100
-    #   n.currency #=> #<Money::Currency id: usd>
-    def us_dollar(cents)
-      Money.new(cents, "USD")
-    end
-
-    alias_method :usd, :us_dollar
-
-
-    # Creates a new Money object of the given value, using the Euro currency.
-    #
-    # @param [Integer] cents The cents value.
-    #
-    # @return [Money]
-    #
-    # @example
-    #   n = Money.euro(100)
-    #   n.cents    #=> 100
-    #   n.currency #=> #<Money::Currency id: eur>
-    def euro(cents)
-      Money.new(cents, "EUR")
-    end
-
-    alias_method :eur, :euro
   end
 
   def self.default_currency

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -131,6 +131,59 @@ class Money
       @empty[currency] ||= Money.new(0, currency).freeze
     end
     alias_method :zero, :empty
+
+
+    # Creates a new Money object of the given value, using the Canadian
+    # dollar currency.
+    #
+    # @param [Integer] cents The cents value.
+    #
+    # @return [Money]
+    #
+    # @example
+    #   n = Money.ca_dollar(100)
+    #   n.cents    #=> 100
+    #   n.currency #=> #<Money::Currency id: cad>
+    def ca_dollar(cents)
+      Money.new(cents, "CAD")
+    end
+
+    alias_method :cad, :ca_dollar
+
+
+    # Creates a new Money object of the given value, using the American dollar
+    # currency.
+    #
+    # @param [Integer] cents The cents value.
+    #
+    # @return [Money]
+    #
+    # @example
+    #   n = Money.us_dollar(100)
+    #   n.cents    #=> 100
+    #   n.currency #=> #<Money::Currency id: usd>
+    def us_dollar(cents)
+      Money.new(cents, "USD")
+    end
+
+    alias_method :usd, :us_dollar
+
+
+    # Creates a new Money object of the given value, using the Euro currency.
+    #
+    # @param [Integer] cents The cents value.
+    #
+    # @return [Money]
+    #
+    # @example
+    #   n = Money.euro(100)
+    #   n.cents    #=> 100
+    #   n.currency #=> #<Money::Currency id: eur>
+    def euro(cents)
+      Money.new(cents, "EUR")
+    end
+
+    alias_method :eur, :euro
   end
 
   def self.default_currency
@@ -192,49 +245,6 @@ class Money
     end
   end
 
-  # Creates a new Money object of the given value, using the Canadian
-  # dollar currency.
-  #
-  # @param [Integer] cents The cents value.
-  #
-  # @return [Money]
-  #
-  # @example
-  #   n = Money.ca_dollar(100)
-  #   n.cents    #=> 100
-  #   n.currency #=> #<Money::Currency id: cad>
-  def self.ca_dollar(cents)
-    Money.new(cents, "CAD")
-  end
-
-  # Creates a new Money object of the given value, using the American dollar
-  # currency.
-  #
-  # @param [Integer] cents The cents value.
-  #
-  # @return [Money]
-  #
-  # @example
-  #   n = Money.us_dollar(100)
-  #   n.cents    #=> 100
-  #   n.currency #=> #<Money::Currency id: usd>
-  def self.us_dollar(cents)
-    Money.new(cents, "USD")
-  end
-
-  # Creates a new Money object of the given value, using the Euro currency.
-  #
-  # @param [Integer] cents The cents value.
-  #
-  # @return [Money]
-  #
-  # @example
-  #   n = Money.euro(100)
-  #   n.cents    #=> 100
-  #   n.currency #=> #<Money::Currency id: eur>
-  def self.euro(cents)
-    Money.new(cents, "EUR")
-  end
 
   # Adds a new exchange rate to the default bank and return the rate.
   #

--- a/lib/money/money/constructors.rb
+++ b/lib/money/money/constructors.rb
@@ -1,0 +1,69 @@
+class Money
+  module Constructors
+
+    # Create a new money object with value 0.
+    #
+    # @param [Currency, String, Symbol] currency The currency to use.
+    #
+    # @return [Money]
+    #
+    # @example
+    #   Money.empty #=> #<Money @fractional=0>
+    def empty(currency = default_currency)
+      @empty ||= {}
+      @empty[currency] ||= Money.new(0, currency).freeze
+    end
+    alias_method :zero, :empty
+
+
+    # Creates a new Money object of the given value, using the Canadian
+    # dollar currency.
+    #
+    # @param [Integer] cents The cents value.
+    #
+    # @return [Money]
+    #
+    # @example
+    #   n = Money.ca_dollar(100)
+    #   n.cents    #=> 100
+    #   n.currency #=> #<Money::Currency id: cad>
+    def ca_dollar(cents)
+      Money.new(cents, "CAD")
+    end
+    alias_method :cad, :ca_dollar
+
+
+    # Creates a new Money object of the given value, using the American dollar
+    # currency.
+    #
+    # @param [Integer] cents The cents value.
+    #
+    # @return [Money]
+    #
+    # @example
+    #   n = Money.us_dollar(100)
+    #   n.cents    #=> 100
+    #   n.currency #=> #<Money::Currency id: usd>
+    def us_dollar(cents)
+      Money.new(cents, "USD")
+    end
+    alias_method :usd, :us_dollar
+
+
+    # Creates a new Money object of the given value, using the Euro currency.
+    #
+    # @param [Integer] cents The cents value.
+    #
+    # @return [Money]
+    #
+    # @example
+    #   n = Money.euro(100)
+    #   n.cents    #=> 100
+    #   n.currency #=> #<Money::Currency id: eur>
+    def euro(cents)
+      Money.new(cents, "EUR")
+    end
+    alias_method :eur, :euro
+
+  end
+end

--- a/lib/money/money/constructors.rb
+++ b/lib/money/money/constructors.rb
@@ -65,5 +65,21 @@ class Money
     end
     alias_method :eur, :euro
 
+
+    # Creates a new Money object of the given value, in British pounds.
+    #
+    # @param [Integer] pence The pence value.
+    #
+    # @return [Money]
+    #
+    # @example
+    #   n = Money.pound_sterling(100)
+    #   n.fractional    #=> 100
+    #   n.currency #=> #<Money::Currency id: gbp>
+    def pound_sterling(pence)
+      Money.new(pence, "GBP")
+    end
+    alias_method :gbp, :pound_sterling
+
   end
 end

--- a/spec/money/constructors_spec.rb
+++ b/spec/money/constructors_spec.rb
@@ -62,4 +62,14 @@ describe Money::Constructors do
   end
 
 
+  describe "::pound_sterling" do
+    it "creates a new Money object of the given value in GBP" do
+      expect(Money.pound_sterling(50)).to eq Money.new(50, "GBP")
+    end
+
+    it "is aliased to ::gbp" do
+      expect(Money.gbp(50)).to eq Money.pound_sterling(50)
+    end
+  end
+
 end

--- a/spec/money/constructors_spec.rb
+++ b/spec/money/constructors_spec.rb
@@ -1,0 +1,65 @@
+# encoding: utf-8
+
+require "spec_helper"
+
+describe Money::Constructors do
+
+  describe "::empty" do
+    it "creates a new Money object of 0 cents" do
+      expect(Money.empty).to eq Money.new(0)
+    end
+
+    it "memoizes the result" do
+      expect(Money.empty.object_id).to eq Money.empty.object_id
+    end
+
+    it "memoizes a result for each currency" do
+      expect(Money.empty(:cad).object_id).to eq Money.empty(:cad).object_id
+    end
+
+    it "doesn't allow money to be modified for a currency" do
+      expect(Money.empty).to be_frozen
+    end
+  end
+
+
+  describe "::zero" do
+    subject { Money.zero }
+    it { is_expected.to eq Money.empty }
+  end
+
+
+  describe "::ca_dollar" do
+    it "creates a new Money object of the given value in CAD" do
+      expect(Money.ca_dollar(50)).to eq Money.new(50, "CAD")
+    end
+
+    it "is aliased to ::cad" do
+      expect(Money.cad(50)).to eq Money.ca_dollar(50)
+    end
+  end
+
+
+  describe "::us_dollar" do
+    it "creates a new Money object of the given value in USD" do
+      expect(Money.us_dollar(50)).to eq Money.new(50, "USD")
+    end
+
+    it "is aliased to ::usd" do
+      expect(Money.usd(50)).to eq Money.us_dollar(50)
+    end
+  end
+
+
+  describe "::euro" do
+    it "creates a new Money object of the given value in EUR" do
+      expect(Money.euro(50)).to eq Money.new(50, "EUR")
+    end
+
+    it "is aliased to ::eur" do
+      expect(Money.eur(50)).to eq Money.euro(50)
+    end
+  end
+
+
+end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -117,17 +117,29 @@ describe Money do
     it "creates a new Money object of the given value in CAD" do
       expect(Money.ca_dollar(50)).to eq Money.new(50, "CAD")
     end
+
+    it "is aliased to .cad" do
+      expect(Money.cad(50)).to eq Money.ca_dollar(50)
+    end
   end
 
   describe ".us_dollar" do
     it "creates a new Money object of the given value in USD" do
       expect(Money.us_dollar(50)).to eq Money.new(50, "USD")
     end
+
+    it "is aliased to .usd" do
+      expect(Money.usd(50)).to eq Money.us_dollar(50)
+    end
   end
 
   describe ".euro" do
     it "creates a new Money object of the given value in EUR" do
       expect(Money.euro(50)).to eq Money.new(50, "EUR")
+    end
+
+    it "is aliased to .eur" do
+      expect(Money.eur(50)).to eq Money.euro(50)
     end
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -90,59 +90,6 @@ describe Money do
     end
   end
 
-  describe ".empty" do
-    it "creates a new Money object of 0 cents" do
-      expect(Money.empty).to eq Money.new(0)
-    end
-
-    it "memoizes the result" do
-      expect(Money.empty.object_id).to eq Money.empty.object_id
-    end
-
-    it "memoizes a result for each currency" do
-      expect(Money.empty(:cad).object_id).to eq Money.empty(:cad).object_id
-    end
-
-    it "doesn't allow money to be modified for a currency" do
-      expect(Money.empty).to be_frozen
-    end
-  end
-
-  describe ".zero" do
-    subject { Money.zero }
-    it { is_expected.to eq Money.empty }
-  end
-
-  describe ".ca_dollar" do
-    it "creates a new Money object of the given value in CAD" do
-      expect(Money.ca_dollar(50)).to eq Money.new(50, "CAD")
-    end
-
-    it "is aliased to .cad" do
-      expect(Money.cad(50)).to eq Money.ca_dollar(50)
-    end
-  end
-
-  describe ".us_dollar" do
-    it "creates a new Money object of the given value in USD" do
-      expect(Money.us_dollar(50)).to eq Money.new(50, "USD")
-    end
-
-    it "is aliased to .usd" do
-      expect(Money.usd(50)).to eq Money.us_dollar(50)
-    end
-  end
-
-  describe ".euro" do
-    it "creates a new Money object of the given value in EUR" do
-      expect(Money.euro(50)).to eq Money.new(50, "EUR")
-    end
-
-    it "is aliased to .eur" do
-      expect(Money.eur(50)).to eq Money.euro(50)
-    end
-  end
-
   describe ".add_rate" do
     before do
       @default_bank = Money.default_bank

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -121,13 +121,15 @@ describe Money do
     end
   end
 
-  describe "#cents" do
-    it "is a synonym of #fractional" do
-      expectation = Money.new(0)
-      def expectation.fractional
-        "expectation"
+  %w[cents pence].each do |units|
+    describe "##{units}" do
+      it "is a synonym of #fractional" do
+        expectation = Money.new(0)
+        def expectation.fractional
+          "expectation"
+        end
+        expect(expectation.cents).to eq "expectation"
       end
-      expect(expectation.cents).to eq "expectation"
     end
   end
 


### PR DESCRIPTION
First commit: aliases constructor methods like "Money.usd_dollar" to their 3-letter ISO codes (e.g. Money.usd).

Second commit: extracted these functions to a module as they're closely related and modular (and the parent 'money.rb' file is huge.)

Third commit: added similar methods for British pounds (if we're going to include CAD then it only makes sense to include GBP too).