### PR TITLE
Register

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ The pre-defined set of attributes includes:
 - `:separator` character between the whole and fraction amounts
 - `:delimiter` character between each thousands place
 
-All attributes are optional. Some attributes, such as `:symbol`, are used by
-the Money class to print out a representation of the object. Other attributes,
-such as `:name` or `:priority`, exist to provide a basic API you can take
-advantage of to build your application.
+All attributes except `:iso_code` are optional. Some attributes, such as
+`:symbol`, are used by the Money class to print out a representation of the
+object. Other attributes, such as `:name` or `:priority`, exist to provide a
+basic API you can take advantage of to build your application.
 
 ### :priority
 

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -113,13 +113,13 @@ class Money
       end
 
       def register(curr)
-        key = curr[:iso_code].downcase.to_sym
+        key = curr.fetch(:iso_code).downcase.to_sym
         @table[key] = curr
         @stringified_keys = stringify_keys
       end
 
       def unregister(curr)
-        key = curr[:iso_code].downcase.to_sym
+        key = curr.fetch(:iso_code).downcase.to_sym
         @table.delete(key)
         @stringified_keys = stringify_keys
       end

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -112,6 +112,23 @@ class Money
         @stringified_keys ||= stringify_keys
       end
 
+      # Register a new currency
+      #
+      # @param curr [Hash] information about the currency
+      # @option priority [Numeric] a numerical value you can use to sort/group
+      #   the currency list
+      # @option iso_code [String] the international 3-letter code as defined
+      #   by the ISO 4217 standard
+      # @option iso_numeric [Integer] the international 3-digit code as
+      #   defined by the ISO 4217 standard
+      # @option name [String] the currency name
+      # @option symbol [String] the currency symbol (UTF-8 encoded)
+      # @option subunit [String] the name of the fractional monetary unit
+      # @option subunit_to_unit [Numeric] the proportion between the unit and
+      #   the subunit
+      # @option separator [String] character between the whole and fraction
+      #   amounts
+      # @option delimiter [String] character between each thousands place
       def register(curr)
         key = curr.fetch(:iso_code).downcase.to_sym
         @table[key] = curr

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -97,6 +97,11 @@ describe Money::Currency do
       expect(new_currency.symbol).to eq "%"
     end
 
+    specify ":iso_code must be present" do
+      expect {
+        Money::Currency.register(name: "New Currency")
+      }.to raise_error(KeyError)
+    end
   end
 
 

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -6,6 +6,13 @@ describe Money::Currency do
 
   FOO = '{ "priority": 1, "iso_code": "FOO", "iso_numeric": "840", "name": "United States Dollar", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 450, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "smallest_denomination": 1 }'
 
+  def register_foo
+    Money::Currency.register(JSON.parse(FOO, :symbolize_names => true))
+  end
+
+  def unregister_foo
+    Money::Currency.unregister(JSON.parse(FOO, :symbolize_names => true))
+  end
 
   describe "UnknownMoney::Currency" do
     it "is a subclass of ArgumentError" do
@@ -14,16 +21,10 @@ describe Money::Currency do
   end
 
   describe ".find" do
-    before :each do
-      Money::Currency.register(JSON.parse(FOO, :symbolize_names => true))
-    end
-
-    after :each do
-      Money::Currency.unregister(JSON.parse(FOO, :symbolize_names => true))
-    end
+    before { register_foo }
+    after  { unregister_foo }
 
     it "returns currency matching given id" do
-
       expected = Money::Currency.new(:foo)
       expect(Money::Currency.find(:foo)).to eq  expected
       expect(Money::Currency.find(:FOO)).to eq  expected
@@ -70,9 +71,9 @@ describe Money::Currency do
       expect(Money::Currency.all).to include Money::Currency.new(:usd)
     end
     it "includes registered currencies" do
-      Money::Currency.register(JSON.parse(FOO, :symbolize_names => true))
+      register_foo
       expect(Money::Currency.all).to include Money::Currency.new(:foo)
-      Money::Currency.unregister(JSON.parse(FOO, :symbolize_names => true))
+      unregister_foo
     end
     it 'is sorted by priority' do
       expect(Money::Currency.all.first.priority).to eq 1
@@ -211,9 +212,9 @@ describe Money::Currency do
     end
 
     it "proper places for custom currency" do
-      Money::Currency.register(JSON.parse(FOO, :symbolize_names => true))
+      register_foo
       Money::Currency.new(:foo).decimal_places == 3
-      Money::Currency.unregister(JSON.parse(FOO, :symbolize_names => true))
+      unregister_foo
     end
   end
 end

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -80,6 +80,26 @@ describe Money::Currency do
     end
   end
 
+
+  describe ".register" do
+    after { Money::Currency.unregister(iso_code: "XXX") if Money::Currency.find("XXX") }
+
+    it "registers a new currency" do
+      Money::Currency.register(
+        iso_code: "XXX",
+        name: "Golden Doubloon",
+        symbol: "%",
+        subunit_to_unit: 100
+      )
+      new_currency = Money::Currency.find("XXX")
+      expect(new_currency).not_to be_nil
+      expect(new_currency.name).to eq "Golden Doubloon"
+      expect(new_currency.symbol).to eq "%"
+    end
+
+  end
+
+
   describe "#initialize" do
     it "lookups data from loaded config" do
       currency = Money::Currency.new("USD")


### PR DESCRIPTION
1) DRYing currency_spec.

2) Adding tests and documentation for the untested method `Money::Currency.register`.

3) Updating the README - `:iso_code` isn't optional, `register` will fail if it's not provided. I've changed `register` to use `Hash#fetch` so that, if iso_code isn't provided, the method will raise `KeyError: key not found: :iso_code` rather than the unhelpful message `NoMethodError: undefined method `downcase' for nil:NilClass`.