### PR TITLE
adding more documentation for Money#format [ci skip]

### DIFF
--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -189,10 +189,23 @@ class Money
     #   Money.new(100, "USD").format(:disambiguate => true)    #=> "$100.00"
     #   Money.new(100, "CAD").format(:disambiguate => true)    #=> "C$100.00"
     #
+    # @option *rules [Boolean] :html_wrap_symbol (false) Wraps the currency symbol
+    #  in a html <span> tag.
+    #
+    # @example
+    #   Money.new(100, "USD").format(:disambiguate => false)
+    #   #=> "<span class=\"currency_symbol\">$100.00</span>
+    #
+    # @option *rules [Symbol] :symbol_position (:before) `:before` if the currency
+    #   symbol goes before the amount, `:after` if it goes after.
+    #
+    # @example
+    #   Money.new(100, "USD").format(:symbol_position => :before) #=> "$100.00"
+    #   Money.new(100, "USD").format(:symbol_position => :after)  #=> "100.00 $"
+    #
     # Note that the default rules can be defined through +Money.default_formatting_rules+ hash.
     #
     # @see +Money.default_formatting_rules+ for more information.
-
     def format(*rules)
       # support for old format parameters
       rules = normalize_formatting_rules(rules)


### PR DESCRIPTION
docs for ':html_wrap_symbol' and ':symbol_position' options.