### PR TITLE
Improve BYR format. Delete subunit

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -357,15 +357,15 @@
     "name": "Belarusian Ruble",
     "symbol": "Br",
     "disambiguate_symbol": "BYR",
-    "alternate_symbols": [""],
-    "subunit": "Kapyeyka",
-    "subunit_to_unit": 100,
+    "alternate_symbols": ["бер. руб.","руб.", "р."],
+    "subunit": null,
+    "subunit_to_unit": 1,
     "symbol_first": false,
     "html_entity": "",
-    "decimal_mark": ".",
-    "thousands_separator": ",",
+    "decimal_mark": ",",
+    "thousands_separator": " ",
     "iso_numeric": "974",
-    "smallest_denomination": 5000
+    "smallest_denomination": 50
   },
   "bzd": {
     "priority": 100,


### PR DESCRIPTION
Hi, this is an update for currency iso value for BYR according to standart:
http://www.currency-iso.org/en/home/tables/table-a1.html