### PR TITLE
Currency extends Enumerable, and is more robust when sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+ - `Currency` implements `Enumerable`.
  - `Currency#<=>` sorts alphabetically by `id` if the `priority`s are the same,
    and no longer raises an error if one of the priorities is missing.
  - `Money::Currency.unregister` can take an ISO code argument in addition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Next release
+
+ - `Currency#<=>` sorts alphabetically by `id` if the `priority`s are the same,
+   and no longer raises an error if one of the priorities is missing.
  - `Money::Currency.unregister` can take an ISO code argument in addition
    to a hash.
  - `Money::Currency.unregister` returns `true` if the given currency

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -240,7 +240,14 @@ class Money
     #   c2 <=> c1 #=> -1
     #   c1 <=> c1 #=> 0
     def <=>(other_currency)
-      self.priority <=> other_currency.priority
+      # <=> returns nil when one of the values is nil
+      comparison = self.priority <=> other_currency.priority || 0
+
+      if comparison == 0
+        self.id <=> other_currency.id
+      else
+        comparison
+      end
     end
 
     # Compares +self+ with +other_currency+ and returns +true+ if the are the

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -12,6 +12,7 @@ class Money
   # @see http://iso4217.net/
   class Currency
     include Comparable
+    extend Enumerable
     extend Money::Currency::Loader
     extend Money::Currency::Heuristics
 
@@ -156,6 +157,12 @@ class Money
         @stringified_keys = stringify_keys
         existed ? true : false
       end
+
+
+      def each
+        all.each { |c| yield(c) }
+      end
+
 
       private
 

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -132,6 +132,31 @@ describe Money::Currency do
   end
 
 
+  describe ".each" do
+    it "yields each currency to the block" do
+      expect(Money::Currency).to respond_to(:each)
+      currencies = []
+      Money::Currency.each do |currency|
+        currencies.push(currency)
+      end
+
+      # Don't bother testing every single currency
+      expect(currencies[0]).to eq Money::Currency.all[0]
+      expect(currencies[1]).to eq Money::Currency.all[1]
+      expect(currencies[-1]).to eq Money::Currency.all[-1]
+    end
+  end
+
+
+  it "implements Enumerable" do
+    expect(Money::Currency).to respond_to(:all?)
+    expect(Money::Currency).to respond_to(:each_with_index)
+    expect(Money::Currency).to respond_to(:map)
+    expect(Money::Currency).to respond_to(:select)
+    expect(Money::Currency).to respond_to(:reject)
+  end
+
+
   describe "#initialize" do
     it "lookups data from loaded config" do
       currency = Money::Currency.new("USD")

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -157,6 +157,30 @@ describe Money::Currency do
       expect(Money::Currency.new(:cad)).to be > Money::Currency.new(:usd)
       expect(Money::Currency.new(:usd)).to be < Money::Currency.new(:eur)
     end
+
+    it "compares by id when priority is the same" do
+      Money::Currency.register(iso_code: "ABD", priority: 15)
+      Money::Currency.register(iso_code: "ABC", priority: 15)
+      Money::Currency.register(iso_code: "ABE", priority: 15)
+      abd = Money::Currency.find("ABD")
+      abc = Money::Currency.find("ABC")
+      abe = Money::Currency.find("ABE")
+      expect(abd).to be > abc
+      expect(abe).to be > abd
+      Money::Currency.unregister("ABD")
+      Money::Currency.unregister("ABC")
+      Money::Currency.unregister("ABE")
+    end
+
+    context "when one of the currencies has no 'priority' set" do
+      it "compares by id" do
+        Money::Currency.register(iso_code: "ABD") # No priority
+        abd = Money::Currency.find(:abd)
+        usd = Money::Currency.find(:usd)
+        expect(abd).to be < usd
+        Money::Currency.unregister(iso_code: "ABD")
+      end
+    end
   end
 
   describe "#==" do


### PR DESCRIPTION
- `Currency#<=>` sorts alphabetically by `id` if the `priority`s are the same, and no longer raises an error if one of the priorities is missing. (This also fixes one type of error described at #479)
- `Currency` implements `Enumerable`. 