### PR TITLE
wrapping spec files in the 'Money' class/modules

### DIFF
--- a/spec/bank/base_spec.rb
+++ b/spec/bank/base_spec.rb
@@ -1,77 +1,81 @@
 require 'spec_helper'
 
-describe Money::Bank::Base do
+class Money
+  module Bank
+    describe Base do
 
-  describe ".instance" do
-    it "is local to one class" do
-      klass = Money::Bank::Base
-      subclass = Class.new(Money::Bank::Base)
-      expect(klass.instance).not_to eq subclass.instance
-    end
-  end
-
-  describe "#initialize" do
-    it "accepts a block and stores @rounding_method" do
-      proc = Proc.new { |n| n.ceil }
-      bank = Money::Bank::Base.new(&proc)
-      expect(bank.rounding_method).to eq proc
-    end
-  end
-
-  describe "#setup" do
-    it "calls #setup after #initialize" do
-      class MyBank < Money::Bank::Base
-        attr_reader :setup_called
-
-        def setup
-          @setup_called = true
+      describe ".instance" do
+        it "is local to one class" do
+          klass = Base
+          subclass = Class.new(Base)
+          expect(klass.instance).not_to eq subclass.instance
         end
       end
 
-      bank = MyBank.new
-      expect(bank.setup_called).to eq true
-    end
-  end
+      describe "#initialize" do
+        it "accepts a block and stores @rounding_method" do
+          proc = Proc.new { |n| n.ceil }
+          bank = Base.new(&proc)
+          expect(bank.rounding_method).to eq proc
+        end
+      end
 
-  describe "#exchange_with" do
-    it "is not implemented" do
-      expect { subject.exchange_with(Money.new(100, 'USD'), 'EUR') }.to raise_exception(NotImplementedError)
-    end
-  end
+      describe "#setup" do
+        it "calls #setup after #initialize" do
+          class MyBank < Base
+            attr_reader :setup_called
 
-  describe "#same_currency?" do
-    it "accepts str/str" do
-      expect { subject.send(:same_currency?, 'USD', 'EUR') }.to_not raise_exception
-    end
+            def setup
+              @setup_called = true
+            end
+          end
 
-    it "accepts currency/str" do
-      expect { subject.send(:same_currency?, Money::Currency.wrap('USD'), 'EUR') }.to_not raise_exception
-    end
+          bank = MyBank.new
+          expect(bank.setup_called).to eq true
+        end
+      end
 
-    it "accepts str/currency" do
-      expect { subject.send(:same_currency?, 'USD', Money::Currency.wrap('EUR')) }.to_not raise_exception
-    end
+      describe "#exchange_with" do
+        it "is not implemented" do
+          expect { subject.exchange_with(Money.new(100, 'USD'), 'EUR') }.to raise_exception(NotImplementedError)
+        end
+      end
 
-    it "accepts currency/currency" do
-      expect { subject.send(:same_currency?, Money::Currency.wrap('USD'), Money::Currency.wrap('EUR')) }.to_not raise_exception
-    end
+      describe "#same_currency?" do
+        it "accepts str/str" do
+          expect { subject.send(:same_currency?, 'USD', 'EUR') }.to_not raise_exception
+        end
 
-    it "returns true when currencies match" do
-      expect(subject.send(:same_currency?, 'USD', 'USD')).to be true
-      expect(subject.send(:same_currency?, Money::Currency.wrap('USD'), 'USD')).to be true
-      expect(subject.send(:same_currency?, 'USD', Money::Currency.wrap('USD'))).to be true
-      expect(subject.send(:same_currency?, Money::Currency.wrap('USD'), Money::Currency.wrap('USD'))).to be true
-    end
+        it "accepts currency/str" do
+          expect { subject.send(:same_currency?, Currency.wrap('USD'), 'EUR') }.to_not raise_exception
+        end
 
-    it "returns false when currencies do not match" do
-      expect(subject.send(:same_currency?, 'USD', 'EUR')).to be false
-      expect(subject.send(:same_currency?, Money::Currency.wrap('USD'), 'EUR')).to be false
-      expect(subject.send(:same_currency?, 'USD', Money::Currency.wrap('EUR'))).to be false
-      expect(subject.send(:same_currency?, Money::Currency.wrap('USD'), Money::Currency.wrap('EUR'))).to be false
-    end
+        it "accepts str/currency" do
+          expect { subject.send(:same_currency?, 'USD', Currency.wrap('EUR')) }.to_not raise_exception
+        end
 
-    it "raises an UnknownCurrency exception when an unknown currency is passed" do
-      expect { subject.send(:same_currency?, 'AAA', 'BBB') }.to raise_exception(Money::Currency::UnknownCurrency)
+        it "accepts currency/currency" do
+          expect { subject.send(:same_currency?, Currency.wrap('USD'), Currency.wrap('EUR')) }.to_not raise_exception
+        end
+
+        it "returns true when currencies match" do
+          expect(subject.send(:same_currency?, 'USD', 'USD')).to be true
+          expect(subject.send(:same_currency?, Currency.wrap('USD'), 'USD')).to be true
+          expect(subject.send(:same_currency?, 'USD', Currency.wrap('USD'))).to be true
+          expect(subject.send(:same_currency?, Currency.wrap('USD'), Currency.wrap('USD'))).to be true
+        end
+
+        it "returns false when currencies do not match" do
+          expect(subject.send(:same_currency?, 'USD', 'EUR')).to be false
+          expect(subject.send(:same_currency?, Currency.wrap('USD'), 'EUR')).to be false
+          expect(subject.send(:same_currency?, 'USD', Currency.wrap('EUR'))).to be false
+          expect(subject.send(:same_currency?, Currency.wrap('USD'), Currency.wrap('EUR'))).to be false
+        end
+
+        it "raises an UnknownCurrency exception when an unknown currency is passed" do
+          expect { subject.send(:same_currency?, 'AAA', 'BBB') }.to raise_exception(Currency::UnknownCurrency)
+        end
+      end
     end
   end
 end

--- a/spec/bank/single_currency_spec.rb
+++ b/spec/bank/single_currency_spec.rb
@@ -1,11 +1,15 @@
 require 'spec_helper'
 
-describe Money::Bank::SingleCurrency do
-  describe "#exchange_with" do
-    it "raises when called" do
-      expect {
-        subject.exchange_with(Money.new(100, 'USD'), 'EUR')
-      }.to raise_exception(Money::Bank::DifferentCurrencyError, "No exchanging of currencies allowed: 1.00 USD to EUR")
+class Money
+  module Bank
+    describe SingleCurrency do
+      describe "#exchange_with" do
+        it "raises when called" do
+          expect {
+            subject.exchange_with(Money.new(100, 'USD'), 'EUR')
+          }.to raise_exception(DifferentCurrencyError, "No exchanging of currencies allowed: 1.00 USD to EUR")
+        end
+      end
     end
   end
 end

--- a/spec/bank/variable_exchange_spec.rb
+++ b/spec/bank/variable_exchange_spec.rb
@@ -2,274 +2,278 @@ require 'spec_helper'
 require 'json'
 require 'yaml'
 
-describe Money::Bank::VariableExchange do
+class Money
+  module Bank
+    describe VariableExchange do
 
-  describe "#initialize" do
-    context "without &block" do
-      let(:bank) {
-        Money::Bank::VariableExchange.new.tap do |bank|
-          bank.add_rate('USD', 'EUR', 1.33)
-        end
-      }
+      describe "#initialize" do
+        context "without &block" do
+          let(:bank) {
+            VariableExchange.new.tap do |bank|
+              bank.add_rate('USD', 'EUR', 1.33)
+            end
+          }
 
-      describe "#exchange_with" do
-        it "accepts str" do
-          expect { bank.exchange_with(Money.new(100, 'USD'), 'EUR') }.to_not raise_exception
-        end
+          describe "#exchange_with" do
+            it "accepts str" do
+              expect { bank.exchange_with(Money.new(100, 'USD'), 'EUR') }.to_not raise_exception
+            end
 
-        it "accepts currency" do
-          expect { bank.exchange_with(Money.new(100, 'USD'), Money::Currency.wrap('EUR')) }.to_not raise_exception
-        end
+            it "accepts currency" do
+              expect { bank.exchange_with(Money.new(100, 'USD'), Currency.wrap('EUR')) }.to_not raise_exception
+            end
 
-        it "exchanges one currency to another" do
-          expect(bank.exchange_with(Money.new(100, 'USD'), 'EUR')).to eq Money.new(133, 'EUR')
-        end
+            it "exchanges one currency to another" do
+              expect(bank.exchange_with(Money.new(100, 'USD'), 'EUR')).to eq Money.new(133, 'EUR')
+            end
 
-        it "truncates extra digits" do
-          expect(bank.exchange_with(Money.new(10, 'USD'), 'EUR')).to eq Money.new(13, 'EUR')
-        end
+            it "truncates extra digits" do
+              expect(bank.exchange_with(Money.new(10, 'USD'), 'EUR')).to eq Money.new(13, 'EUR')
+            end
 
-        it "raises an UnknownCurrency exception when an unknown currency is requested" do
-          expect { bank.exchange_with(Money.new(100, 'USD'), 'BBB') }.to raise_exception(Money::Currency::UnknownCurrency)
-        end
+            it "raises an UnknownCurrency exception when an unknown currency is requested" do
+              expect { bank.exchange_with(Money.new(100, 'USD'), 'BBB') }.to raise_exception(Currency::UnknownCurrency)
+            end
 
-        it "raises an UnknownRate exception when an unknown rate is requested" do
-          expect { bank.exchange_with(Money.new(100, 'USD'), 'JPY') }.to raise_exception(Money::Bank::UnknownRate)
-        end
+            it "raises an UnknownRate exception when an unknown rate is requested" do
+              expect { bank.exchange_with(Money.new(100, 'USD'), 'JPY') }.to raise_exception(UnknownRate)
+            end
 
-        #it "rounds the exchanged result down" do
-        #  bank.add_rate("USD", "EUR", 0.788332676)
-        #  bank.add_rate("EUR", "YEN", 122.631477)
-        #  expect(bank.exchange_with(Money.new(10_00,  "USD"), "EUR")).to eq Money.new(788, "EUR")
-        #  expect(bank.exchange_with(Money.new(500_00, "EUR"), "YEN")).to eq Money.new(6131573, "YEN")
-        #end
+            #it "rounds the exchanged result down" do
+            #  bank.add_rate("USD", "EUR", 0.788332676)
+            #  bank.add_rate("EUR", "YEN", 122.631477)
+            #  expect(bank.exchange_with(Money.new(10_00,  "USD"), "EUR")).to eq Money.new(788, "EUR")
+            #  expect(bank.exchange_with(Money.new(500_00, "EUR"), "YEN")).to eq Money.new(6131573, "YEN")
+            #end
 
-        it "accepts a custom truncation method" do
-          proc = Proc.new { |n| n.ceil }
-          expect(bank.exchange_with(Money.new(10, 'USD'), 'EUR', &proc)).to eq Money.new(14, 'EUR')
-        end
-      end
-    end
-
-    context "with &block" do
-      let(:bank) {
-        proc = Proc.new { |n| n.ceil }
-        Money::Bank::VariableExchange.new(&proc).tap do |bank|
-          bank.add_rate('USD', 'EUR', 1.33)
-        end
-      }
-
-      describe "#exchange_with" do
-        it "uses the stored truncation method" do
-          expect(bank.exchange_with(Money.new(10, 'USD'), 'EUR')).to eq Money.new(14, 'EUR')
+            it "accepts a custom truncation method" do
+              proc = Proc.new { |n| n.ceil }
+              expect(bank.exchange_with(Money.new(10, 'USD'), 'EUR', &proc)).to eq Money.new(14, 'EUR')
+            end
+          end
         end
 
-        it "accepts a custom truncation method" do
-          proc = Proc.new { |n| n.ceil + 1 }
-          expect(bank.exchange_with(Money.new(10, 'USD'), 'EUR', &proc)).to eq Money.new(15, 'EUR')
+        context "with &block" do
+          let(:bank) {
+            proc = Proc.new { |n| n.ceil }
+            VariableExchange.new(&proc).tap do |bank|
+              bank.add_rate('USD', 'EUR', 1.33)
+            end
+          }
+
+          describe "#exchange_with" do
+            it "uses the stored truncation method" do
+              expect(bank.exchange_with(Money.new(10, 'USD'), 'EUR')).to eq Money.new(14, 'EUR')
+            end
+
+            it "accepts a custom truncation method" do
+              proc = Proc.new { |n| n.ceil + 1 }
+              expect(bank.exchange_with(Money.new(10, 'USD'), 'EUR', &proc)).to eq Money.new(15, 'EUR')
+            end
+          end
         end
       end
-    end
-  end
 
-  describe "#add_rate" do
-    it "adds rates correctly" do
-      subject.add_rate("USD", "EUR", 0.788332676)
-      subject.add_rate("EUR", "YEN", 122.631477)
+      describe "#add_rate" do
+        it "adds rates correctly" do
+          subject.add_rate("USD", "EUR", 0.788332676)
+          subject.add_rate("EUR", "YEN", 122.631477)
 
-      expect(subject.instance_variable_get(:@rates)['USD_TO_EUR']).to eq 0.788332676
-      expect(subject.instance_variable_get(:@rates)['EUR_TO_JPY']).to eq 122.631477
-    end
+          expect(subject.instance_variable_get(:@rates)['USD_TO_EUR']).to eq 0.788332676
+          expect(subject.instance_variable_get(:@rates)['EUR_TO_JPY']).to eq 122.631477
+        end
 
-    it "treats currency names case-insensitively" do
-      subject.add_rate("usd", "eur", 1)
-      expect(subject.instance_variable_get(:@rates)['USD_TO_EUR']).to eq 1
-    end
-  end
-
-  describe "#set_rate" do
-    it "sets a rate" do
-      subject.set_rate('USD', 'EUR', 1.25)
-      expect(subject.instance_variable_get(:@rates)['USD_TO_EUR']).to eq 1.25
-    end
-
-    it "raises an UnknownCurrency exception when an unknown currency is passed" do
-      expect { subject.set_rate('AAA', 'BBB', 1.25) }.to raise_exception(Money::Currency::UnknownCurrency)
-    end
-
-    it "uses a mutex by default" do
-      expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
-      subject.set_rate('USD', 'EUR', 1.25)
-    end
-
-    it "doesn't use mutex if requested not to" do
-      expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
-      subject.set_rate('USD', 'EUR', 1.25, :without_mutex => true)
-    end
-  end
-
-  describe "#get_rate" do
-    it "returns a rate" do
-      subject.set_rate('USD', 'EUR', 1.25)
-      expect(subject.get_rate('USD', 'EUR')).to eq 1.25
-    end
-
-    it "raises an UnknownCurrency exception when an unknown currency is passed" do
-      expect { subject.get_rate('AAA', 'BBB') }.to raise_exception(Money::Currency::UnknownCurrency)
-    end
-
-    it "uses a mutex by default" do
-      expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
-      subject.get_rate('USD', 'EUR')
-    end
-
-    it "doesn't use mutex if requested not to" do
-      expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
-      subject.get_rate('USD', 'EUR', :without_mutex => true)
-    end
-  end
-
-  describe "#export_rates" do
-    before :each do
-      subject.set_rate('USD', 'EUR', 1.25)
-      subject.set_rate('USD', 'JPY', 2.55)
-
-      @rates = { "USD_TO_EUR" => 1.25, "USD_TO_JPY" => 2.55 }
-    end
-
-    context "with format == :json" do
-      it "should return rates formatted as json" do
-        json = subject.export_rates(:json)
-        expect(JSON.load(json)).to eq @rates
+        it "treats currency names case-insensitively" do
+          subject.add_rate("usd", "eur", 1)
+          expect(subject.instance_variable_get(:@rates)['USD_TO_EUR']).to eq 1
+        end
       end
-    end
 
-    context "with format == :ruby" do
-      it "should return rates formatted as ruby objects" do
-        expect(Marshal.load(subject.export_rates(:ruby))).to eq @rates
+      describe "#set_rate" do
+        it "sets a rate" do
+          subject.set_rate('USD', 'EUR', 1.25)
+          expect(subject.instance_variable_get(:@rates)['USD_TO_EUR']).to eq 1.25
+        end
+
+        it "raises an UnknownCurrency exception when an unknown currency is passed" do
+          expect { subject.set_rate('AAA', 'BBB', 1.25) }.to raise_exception(Currency::UnknownCurrency)
+        end
+
+        it "uses a mutex by default" do
+          expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
+          subject.set_rate('USD', 'EUR', 1.25)
+        end
+
+        it "doesn't use mutex if requested not to" do
+          expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
+          subject.set_rate('USD', 'EUR', 1.25, :without_mutex => true)
+        end
       end
-    end
 
-    context "with format == :yaml" do
-      it "should return rates formatted as yaml" do
-        yaml = subject.export_rates(:yaml)
-        expect(YAML.load(yaml)).to eq @rates
+      describe "#get_rate" do
+        it "returns a rate" do
+          subject.set_rate('USD', 'EUR', 1.25)
+          expect(subject.get_rate('USD', 'EUR')).to eq 1.25
+        end
+
+        it "raises an UnknownCurrency exception when an unknown currency is passed" do
+          expect { subject.get_rate('AAA', 'BBB') }.to raise_exception(Currency::UnknownCurrency)
+        end
+
+        it "uses a mutex by default" do
+          expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
+          subject.get_rate('USD', 'EUR')
+        end
+
+        it "doesn't use mutex if requested not to" do
+          expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
+          subject.get_rate('USD', 'EUR', :without_mutex => true)
+        end
       end
-    end
 
-    context "with unknown format" do
-      it "raises Money::Bank::UnknownRateFormat" do
-        expect { subject.export_rates(:foo)}.to raise_error Money::Bank::UnknownRateFormat
+      describe "#export_rates" do
+        before :each do
+          subject.set_rate('USD', 'EUR', 1.25)
+          subject.set_rate('USD', 'JPY', 2.55)
+
+          @rates = { "USD_TO_EUR" => 1.25, "USD_TO_JPY" => 2.55 }
+        end
+
+        context "with format == :json" do
+          it "should return rates formatted as json" do
+            json = subject.export_rates(:json)
+            expect(JSON.load(json)).to eq @rates
+          end
+        end
+
+        context "with format == :ruby" do
+          it "should return rates formatted as ruby objects" do
+            expect(Marshal.load(subject.export_rates(:ruby))).to eq @rates
+          end
+        end
+
+        context "with format == :yaml" do
+          it "should return rates formatted as yaml" do
+            yaml = subject.export_rates(:yaml)
+            expect(YAML.load(yaml)).to eq @rates
+          end
+        end
+
+        context "with unknown format" do
+          it "raises Money::Bank::UnknownRateFormat" do
+            expect { subject.export_rates(:foo)}.to raise_error UnknownRateFormat
+          end
+        end
+
+        context "with :file provided" do
+          it "writes rates to file" do
+            f = double('IO')
+            expect(File).to receive(:open).with('null', 'w').and_yield(f)
+            expect(f).to receive(:write).with(JSON.dump(@rates))
+
+            subject.export_rates(:json, 'null')
+          end
+        end
+
+        it "uses a mutex by default" do
+          expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
+          subject.export_rates(:yaml)
+        end
+
+        it "doesn't use mutex if requested not to" do
+          expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
+          subject.export_rates(:yaml, nil, :without_mutex => true)
+        end
       end
-    end
 
-    context "with :file provided" do
-      it "writes rates to file" do
-        f = double('IO')
-        expect(File).to receive(:open).with('null', 'w').and_yield(f)
-        expect(f).to receive(:write).with(JSON.dump(@rates))
+      describe "#import_rates" do
+        context "with format == :json" do
+          it "loads the rates provided" do
+            s = '{"USD_TO_EUR":1.25,"USD_TO_JPY":2.55}'
+            subject.import_rates(:json, s)
+            expect(subject.get_rate('USD', 'EUR')).to eq 1.25
+            expect(subject.get_rate('USD', 'JPY')).to eq 2.55
+          end
+        end
 
-        subject.export_rates(:json, 'null')
+        context "with format == :ruby" do
+          it "loads the rates provided" do
+            s = Marshal.dump({"USD_TO_EUR"=>1.25,"USD_TO_JPY"=>2.55})
+            subject.import_rates(:ruby, s)
+            expect(subject.get_rate('USD', 'EUR')).to eq 1.25
+            expect(subject.get_rate('USD', 'JPY')).to eq 2.55
+          end
+        end
+
+        context "with format == :yaml" do
+          it "loads the rates provided" do
+            s = "--- \nUSD_TO_EUR: 1.25\nUSD_TO_JPY: 2.55\n"
+            subject.import_rates(:yaml, s)
+            expect(subject.get_rate('USD', 'EUR')).to eq 1.25
+            expect(subject.get_rate('USD', 'JPY')).to eq 2.55
+          end
+        end
+
+        context "with unknown format" do
+          it "raises Money::Bank::UnknownRateFormat" do
+            expect { subject.import_rates(:foo, "")}.to raise_error UnknownRateFormat
+          end
+        end
+
+        it "uses a mutex by default" do
+          expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
+          s = "--- \nUSD_TO_EUR: 1.25\nUSD_TO_JPY: 2.55\n"
+          subject.import_rates(:yaml, s)
+        end
+
+        it "doesn't use mutex if requested not to" do
+          expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
+          s = "--- \nUSD_TO_EUR: 1.25\nUSD_TO_JPY: 2.55\n"
+          subject.import_rates(:yaml, s, :without_mutex => true)
+        end
       end
-    end
 
-    it "uses a mutex by default" do
-      expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
-      subject.export_rates(:yaml)
-    end
+      describe "#rate_key_for" do
+        it "accepts str/str" do
+          expect { subject.send(:rate_key_for, 'USD', 'EUR')}.to_not raise_exception
+        end
 
-    it "doesn't use mutex if requested not to" do
-      expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
-      subject.export_rates(:yaml, nil, :without_mutex => true)
-    end
-  end
+        it "accepts currency/str" do
+          expect { subject.send(:rate_key_for, Currency.wrap('USD'), 'EUR')}.to_not raise_exception
+        end
 
-  describe "#import_rates" do
-    context "with format == :json" do
-      it "loads the rates provided" do
-        s = '{"USD_TO_EUR":1.25,"USD_TO_JPY":2.55}'
-        subject.import_rates(:json, s)
-        expect(subject.get_rate('USD', 'EUR')).to eq 1.25
-        expect(subject.get_rate('USD', 'JPY')).to eq 2.55
+        it "accepts str/currency" do
+          expect { subject.send(:rate_key_for, 'USD', Currency.wrap('EUR'))}.to_not raise_exception
+        end
+
+        it "accepts currency/currency" do
+          expect { subject.send(:rate_key_for, Currency.wrap('USD'), Currency.wrap('EUR'))}.to_not raise_exception
+        end
+
+        it "returns a hashkey based on the passed arguments" do
+          expect(subject.send(:rate_key_for, 'USD', 'EUR')).to eq 'USD_TO_EUR'
+          expect(subject.send(:rate_key_for, Currency.wrap('USD'), 'EUR')).to eq 'USD_TO_EUR'
+          expect(subject.send(:rate_key_for, 'USD', Currency.wrap('EUR'))).to eq 'USD_TO_EUR'
+          expect(subject.send(:rate_key_for, Currency.wrap('USD'), Currency.wrap('EUR'))).to eq 'USD_TO_EUR'
+        end
+
+        it "raises a Money::Currency::UnknownCurrency exception when an unknown currency is passed" do
+          expect { subject.send(:rate_key_for, 'AAA', 'BBB')}.to raise_exception(Currency::UnknownCurrency)
+        end
       end
-    end
 
-    context "with format == :ruby" do
-      it "loads the rates provided" do
-        s = Marshal.dump({"USD_TO_EUR"=>1.25,"USD_TO_JPY"=>2.55})
-        subject.import_rates(:ruby, s)
-        expect(subject.get_rate('USD', 'EUR')).to eq 1.25
-        expect(subject.get_rate('USD', 'JPY')).to eq 2.55
+      describe "#marshal_dump" do
+        it "does not raise an error" do
+          expect {  Marshal.dump(subject) }.to_not raise_error
+        end
+
+        it "works with Marshal.load" do
+          bank = Marshal.load(Marshal.dump(subject))
+
+          expect(bank.rates).to           eq subject.rates
+          expect(bank.rounding_method).to eq subject.rounding_method
+        end
       end
-    end
-
-    context "with format == :yaml" do
-      it "loads the rates provided" do
-        s = "--- \nUSD_TO_EUR: 1.25\nUSD_TO_JPY: 2.55\n"
-        subject.import_rates(:yaml, s)
-        expect(subject.get_rate('USD', 'EUR')).to eq 1.25
-        expect(subject.get_rate('USD', 'JPY')).to eq 2.55
-      end
-    end
-
-    context "with unknown format" do
-      it "raises Money::Bank::UnknownRateFormat" do
-        expect { subject.import_rates(:foo, "")}.to raise_error Money::Bank::UnknownRateFormat
-      end
-    end
-
-    it "uses a mutex by default" do
-      expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
-      s = "--- \nUSD_TO_EUR: 1.25\nUSD_TO_JPY: 2.55\n"
-      subject.import_rates(:yaml, s)
-    end
-
-    it "doesn't use mutex if requested not to" do
-      expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
-      s = "--- \nUSD_TO_EUR: 1.25\nUSD_TO_JPY: 2.55\n"
-      subject.import_rates(:yaml, s, :without_mutex => true)
-    end
-  end
-
-  describe "#rate_key_for" do
-    it "accepts str/str" do
-      expect { subject.send(:rate_key_for, 'USD', 'EUR')}.to_not raise_exception
-    end
-
-    it "accepts currency/str" do
-      expect { subject.send(:rate_key_for, Money::Currency.wrap('USD'), 'EUR')}.to_not raise_exception
-    end
-
-    it "accepts str/currency" do
-      expect { subject.send(:rate_key_for, 'USD', Money::Currency.wrap('EUR'))}.to_not raise_exception
-    end
-
-    it "accepts currency/currency" do
-      expect { subject.send(:rate_key_for, Money::Currency.wrap('USD'), Money::Currency.wrap('EUR'))}.to_not raise_exception
-    end
-
-    it "returns a hashkey based on the passed arguments" do
-      expect(subject.send(:rate_key_for, 'USD', 'EUR')).to eq 'USD_TO_EUR'
-      expect(subject.send(:rate_key_for, Money::Currency.wrap('USD'), 'EUR')).to eq 'USD_TO_EUR'
-      expect(subject.send(:rate_key_for, 'USD', Money::Currency.wrap('EUR'))).to eq 'USD_TO_EUR'
-      expect(subject.send(:rate_key_for, Money::Currency.wrap('USD'), Money::Currency.wrap('EUR'))).to eq 'USD_TO_EUR'
-    end
-
-    it "raises a Money::Currency::UnknownCurrency exception when an unknown currency is passed" do
-      expect { subject.send(:rate_key_for, 'AAA', 'BBB')}.to raise_exception(Money::Currency::UnknownCurrency)
-    end
-  end
-
-  describe "#marshal_dump" do
-    it "does not raise an error" do
-      expect {  Marshal.dump(subject) }.to_not raise_error
-    end
-
-    it "works with Marshal.load" do
-      bank = Marshal.load(Marshal.dump(subject))
-
-      expect(bank.rates).to           eq subject.rates
-      expect(bank.rounding_method).to eq subject.rounding_method
     end
   end
 end

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -2,330 +2,332 @@
 
 require "spec_helper"
 
-describe Money::Currency do
+class Money
+  describe Currency do
 
-  FOO = '{ "priority": 1, "iso_code": "FOO", "iso_numeric": "840", "name": "United States Dollar", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 450, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "smallest_denomination": 1 }'
+    FOO = '{ "priority": 1, "iso_code": "FOO", "iso_numeric": "840", "name": "United States Dollar", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 450, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "smallest_denomination": 1 }'
 
-  def register_foo(opts={})
-    foo_attrs = JSON.parse(FOO, :symbolize_names => true)
-    # Pass an array of attribute names to 'skip' to remove them from the 'FOO'
-    # json before registering foo as a currency.
-    Array.wrap(opts[:skip]).each { |attr| foo_attrs.delete(attr) }
-    Money::Currency.register(foo_attrs)
-  end
-
-  def unregister_foo
-    Money::Currency.unregister(JSON.parse(FOO, :symbolize_names => true))
-  end
-
-  describe "UnknownMoney::Currency" do
-    it "is a subclass of ArgumentError" do
-      expect(Money::Currency::UnknownCurrency < ArgumentError).to be true
-    end
-  end
-
-  describe ".find" do
-    before { register_foo }
-    after  { unregister_foo }
-
-    it "returns currency matching given id" do
-      expected = Money::Currency.new(:foo)
-      expect(Money::Currency.find(:foo)).to eq  expected
-      expect(Money::Currency.find(:FOO)).to eq  expected
-      expect(Money::Currency.find("foo")).to eq expected
-      expect(Money::Currency.find("FOO")).to eq expected
+    def register_foo(opts={})
+      foo_attrs = JSON.parse(FOO, :symbolize_names => true)
+      # Pass an array of attribute names to 'skip' to remove them from the 'FOO'
+      # json before registering foo as a currency.
+      Array.wrap(opts[:skip]).each { |attr| foo_attrs.delete(attr) }
+      Money::Currency.register(foo_attrs)
     end
 
-    it "returns nil unless currency matching given id" do
-      expect(Money::Currency.find("ZZZ")).to be_nil
+    def unregister_foo
+      Currency.unregister(JSON.parse(FOO, :symbolize_names => true))
     end
-  end
 
-  describe ".find_by_iso_numeric" do
-    it "returns currency matching given numeric code" do
-      expect(Money::Currency.find_by_iso_numeric(978)).to eq          Money::Currency.new(:eur)
-      expect(Money::Currency.find_by_iso_numeric(208)).not_to eq      Money::Currency.new(:eur)
-      expect(Money::Currency.find_by_iso_numeric('840')).to eq        Money::Currency.new(:usd)
+    describe "UnknownCurrency" do
+      it "is a subclass of ArgumentError" do
+        expect(Currency::UnknownCurrency < ArgumentError).to be true
+      end
+    end
 
-      class Mock
-        def to_s
-          '208'
+    describe ".find" do
+      before { register_foo }
+      after  { unregister_foo }
+
+      it "returns currency matching given id" do
+        expected = Currency.new(:foo)
+        expect(Currency.find(:foo)).to eq  expected
+        expect(Currency.find(:FOO)).to eq  expected
+        expect(Currency.find("foo")).to eq expected
+        expect(Currency.find("FOO")).to eq expected
+      end
+
+      it "returns nil unless currency matching given id" do
+        expect(Currency.find("ZZZ")).to be_nil
+      end
+    end
+
+    describe ".find_by_iso_numeric" do
+      it "returns currency matching given numeric code" do
+        expect(Currency.find_by_iso_numeric(978)).to eq     Currency.new(:eur)
+        expect(Currency.find_by_iso_numeric(208)).not_to eq Currency.new(:eur)
+        expect(Currency.find_by_iso_numeric('840')).to eq   Currency.new(:usd)
+
+        class Mock
+          def to_s
+            '208'
+          end
+        end
+        expect(Currency.find_by_iso_numeric(Mock.new)).to eq     Currency.new(:dkk)
+        expect(Currency.find_by_iso_numeric(Mock.new)).not_to eq Currency.new(:usd)
+      end
+
+      it "returns nil if no currency has the given numeric code" do
+        expect(Currency.find_by_iso_numeric('non iso 4217 numeric code')).to be_nil
+        expect(Currency.find_by_iso_numeric(0)).to be_nil
+      end
+    end
+
+    describe ".wrap" do
+      it "returns nil if object is nil" do
+        expect(Currency.wrap(nil)).to be_nil
+        expect(Currency.wrap(Currency.new(:usd))).to eq Currency.new(:usd)
+        expect(Currency.wrap(:usd)).to eq Currency.new(:usd)
+      end
+    end
+
+    describe ".all" do
+      it "returns an array of currencies" do
+        expect(Currency.all).to include Currency.new(:usd)
+      end
+      it "includes registered currencies" do
+        register_foo
+        expect(Currency.all).to include Currency.new(:foo)
+        unregister_foo
+      end
+      it 'is sorted by priority' do
+        expect(Currency.all.first.priority).to eq 1
+      end
+      it "raises a MissingAttributeError if any currency has no priority" do
+        register_foo(:skip => :priority)
+        expect{Money::Currency.all}.to \
+          raise_error(Money::Currency::MissingAttributeError, /foo.*priority/)
+        unregister_foo
+      end
+    end
+
+
+    describe ".register" do
+      after { Currency.unregister(iso_code: "XXX") if Currency.find("XXX") }
+
+      it "registers a new currency" do
+        Currency.register(
+          iso_code: "XXX",
+          name: "Golden Doubloon",
+          symbol: "%",
+          subunit_to_unit: 100
+        )
+        new_currency = Currency.find("XXX")
+        expect(new_currency).not_to be_nil
+        expect(new_currency.name).to eq "Golden Doubloon"
+        expect(new_currency.symbol).to eq "%"
+      end
+
+      specify ":iso_code must be present" do
+        expect {
+          Currency.register(name: "New Currency")
+        }.to raise_error(KeyError)
+      end
+    end
+
+
+    describe ".unregister" do
+      it "unregisters a currency" do
+        Currency.register(iso_code: "XXX")
+        expect(Currency.find("XXX")).not_to be_nil # Sanity check
+        Currency.unregister(iso_code: "XXX")
+        expect(Currency.find("XXX")).to be_nil
+      end
+
+      it "returns true iff the currency existed" do
+        Currency.register(iso_code: "XXX")
+        expect(Currency.unregister(iso_code: "XXX")).to be_truthy
+        expect(Currency.unregister(iso_code: "XXX")).to be_falsey
+      end
+
+      it "can be passed an ISO code" do
+        Currency.register(iso_code: "XXX")
+        Currency.register(iso_code: "YYZ")
+        # Test with string:
+        Currency.unregister("XXX")
+        expect(Currency.find("XXX")).to be_nil
+        # Test with symbol:
+        Currency.unregister(:yyz)
+        expect(Currency.find(:yyz)).to be_nil
+      end
+    end
+
+
+    describe ".each" do
+      it "yields each currency to the block" do
+        expect(Currency).to respond_to(:each)
+        currencies = []
+        Currency.each do |currency|
+          currencies.push(currency)
+        end
+
+        # Don't bother testing every single currency
+        expect(currencies[0]).to eq Currency.all[0]
+        expect(currencies[1]).to eq Currency.all[1]
+        expect(currencies[-1]).to eq Currency.all[-1]
+      end
+    end
+
+
+    it "implements Enumerable" do
+      expect(Currency).to respond_to(:all?)
+      expect(Currency).to respond_to(:each_with_index)
+      expect(Currency).to respond_to(:map)
+      expect(Currency).to respond_to(:select)
+      expect(Currency).to respond_to(:reject)
+    end
+
+
+    describe "#initialize" do
+      it "lookups data from loaded config" do
+        currency = Currency.new("USD")
+        expect(currency.id).to                    eq :usd
+        expect(currency.priority).to              eq 1
+        expect(currency.iso_code).to              eq "USD"
+        expect(currency.iso_numeric).to           eq "840"
+        expect(currency.name).to                  eq "United States Dollar"
+        expect(currency.decimal_mark).to          eq "."
+        expect(currency.separator).to             eq "."
+        expect(currency.thousands_separator).to   eq ","
+        expect(currency.delimiter).to             eq ","
+        expect(currency.smallest_denomination).to eq 1
+      end
+
+      it "raises UnknownCurrency with unknown currency" do
+        expect { Currency.new("xxx") }.to raise_error(Currency::UnknownCurrency, /xxx/)
+      end
+    end
+
+    describe "#<=>" do
+      it "compares objects by priority" do
+        expect(Currency.new(:cad)).to be > Currency.new(:usd)
+        expect(Currency.new(:usd)).to be < Currency.new(:eur)
+      end
+
+      it "compares by id when priority is the same" do
+        Currency.register(iso_code: "ABD", priority: 15)
+        Currency.register(iso_code: "ABC", priority: 15)
+        Currency.register(iso_code: "ABE", priority: 15)
+        abd = Currency.find("ABD")
+        abc = Currency.find("ABC")
+        abe = Currency.find("ABE")
+        expect(abd).to be > abc
+        expect(abe).to be > abd
+        Currency.unregister("ABD")
+        Currency.unregister("ABC")
+        Currency.unregister("ABE")
+      end
+
+      context "when one of the currencies has no 'priority' set" do
+        it "compares by id" do
+          Currency.register(iso_code: "ABD") # No priority
+          abd = Currency.find(:abd)
+          usd = Currency.find(:usd)
+          expect(abd).to be < usd
+          Currency.unregister(iso_code: "ABD")
         end
       end
-      expect(Money::Currency.find_by_iso_numeric(Mock.new)).to eq     Money::Currency.new(:dkk)
-      expect(Money::Currency.find_by_iso_numeric(Mock.new)).not_to eq Money::Currency.new(:usd)
     end
 
-    it "returns nil if no currency has the given numeric code" do
-      expect(Money::Currency.find_by_iso_numeric('non iso 4217 numeric code')).to be_nil
-      expect(Money::Currency.find_by_iso_numeric(0)).to be_nil
-    end
-  end
-
-  describe ".wrap" do
-    it "returns nil if object is nil" do
-      expect(Money::Currency.wrap(nil)).to be_nil
-      expect(Money::Currency.wrap(Money::Currency.new(:usd))).to eq Money::Currency.new(:usd)
-      expect(Money::Currency.wrap(:usd)).to eq Money::Currency.new(:usd)
-    end
-  end
-
-  describe ".all" do
-    it "returns an array of currencies" do
-      expect(Money::Currency.all).to include Money::Currency.new(:usd)
-    end
-    it "includes registered currencies" do
-      register_foo
-      expect(Money::Currency.all).to include Money::Currency.new(:foo)
-      unregister_foo
-    end
-    it 'is sorted by priority' do
-      expect(Money::Currency.all.first.priority).to eq 1
-    end
-    it "raises a MissingAttributeError if any currency has no priority" do
-      register_foo(:skip => :priority)
-      expect{Money::Currency.all}.to \
-        raise_error(Money::Currency::MissingAttributeError, /foo.*priority/)
-      unregister_foo
-    end
-  end
-
-
-  describe ".register" do
-    after { Money::Currency.unregister(iso_code: "XXX") if Money::Currency.find("XXX") }
-
-    it "registers a new currency" do
-      Money::Currency.register(
-        iso_code: "XXX",
-        name: "Golden Doubloon",
-        symbol: "%",
-        subunit_to_unit: 100
-      )
-      new_currency = Money::Currency.find("XXX")
-      expect(new_currency).not_to be_nil
-      expect(new_currency.name).to eq "Golden Doubloon"
-      expect(new_currency.symbol).to eq "%"
-    end
-
-    specify ":iso_code must be present" do
-      expect {
-        Money::Currency.register(name: "New Currency")
-      }.to raise_error(KeyError)
-    end
-  end
-
-
-  describe ".unregister" do
-    it "unregisters a currency" do
-      Money::Currency.register(iso_code: "XXX")
-      expect(Money::Currency.find("XXX")).not_to be_nil # Sanity check
-      Money::Currency.unregister(iso_code: "XXX")
-      expect(Money::Currency.find("XXX")).to be_nil
-    end
-
-    it "returns true iff the currency existed" do
-      Money::Currency.register(iso_code: "XXX")
-      expect(Money::Currency.unregister(iso_code: "XXX")).to be_truthy
-      expect(Money::Currency.unregister(iso_code: "XXX")).to be_falsey
-    end
-
-    it "can be passed an ISO code" do
-      Money::Currency.register(iso_code: "XXX")
-      Money::Currency.register(iso_code: "YYZ")
-      # Test with string:
-      Money::Currency.unregister("XXX")
-      expect(Money::Currency.find("XXX")).to be_nil
-      # Test with symbol:
-      Money::Currency.unregister(:yyz)
-      expect(Money::Currency.find(:yyz)).to be_nil
-    end
-  end
-
-
-  describe ".each" do
-    it "yields each currency to the block" do
-      expect(Money::Currency).to respond_to(:each)
-      currencies = []
-      Money::Currency.each do |currency|
-        currencies.push(currency)
+    describe "#==" do
+      it "returns true if self === other" do
+        currency = Currency.new(:eur)
+        expect(currency).to eq currency
       end
 
-      # Don't bother testing every single currency
-      expect(currencies[0]).to eq Money::Currency.all[0]
-      expect(currencies[1]).to eq Money::Currency.all[1]
-      expect(currencies[-1]).to eq Money::Currency.all[-1]
-    end
-  end
+      it "returns true if the id is equal ignorning case" do
+        expect(Currency.new(:eur)).to     eq Currency.new(:eur)
+        expect(Currency.new(:eur)).to     eq Currency.new(:EUR)
+        expect(Currency.new(:eur)).not_to eq Currency.new(:usd)
+      end
 
+      it "allows direct comparison of currencies and symbols/strings" do
+        expect(Currency.new(:eur)).to     eq 'eur'
+        expect(Currency.new(:eur)).to     eq 'EUR'
+        expect(Currency.new(:eur)).to     eq :eur
+        expect(Currency.new(:eur)).to     eq :EUR
+        expect(Currency.new(:eur)).not_to eq 'usd'
+      end
 
-  it "implements Enumerable" do
-    expect(Money::Currency).to respond_to(:all?)
-    expect(Money::Currency).to respond_to(:each_with_index)
-    expect(Money::Currency).to respond_to(:map)
-    expect(Money::Currency).to respond_to(:select)
-    expect(Money::Currency).to respond_to(:reject)
-  end
-
-
-  describe "#initialize" do
-    it "lookups data from loaded config" do
-      currency = Money::Currency.new("USD")
-      expect(currency.id).to                    eq :usd
-      expect(currency.priority).to              eq 1
-      expect(currency.iso_code).to              eq "USD"
-      expect(currency.iso_numeric).to           eq "840"
-      expect(currency.name).to                  eq "United States Dollar"
-      expect(currency.decimal_mark).to          eq "."
-      expect(currency.separator).to             eq "."
-      expect(currency.thousands_separator).to   eq ","
-      expect(currency.delimiter).to             eq ","
-      expect(currency.smallest_denomination).to eq 1
-    end
-
-    it "raises UnknownMoney::Currency with unknown currency" do
-      expect { Money::Currency.new("xxx") }.to raise_error(Money::Currency::UnknownCurrency, /xxx/)
-    end
-  end
-
-  describe "#<=>" do
-    it "compares objects by priority" do
-      expect(Money::Currency.new(:cad)).to be > Money::Currency.new(:usd)
-      expect(Money::Currency.new(:usd)).to be < Money::Currency.new(:eur)
-    end
-
-    it "compares by id when priority is the same" do
-      Money::Currency.register(iso_code: "ABD", priority: 15)
-      Money::Currency.register(iso_code: "ABC", priority: 15)
-      Money::Currency.register(iso_code: "ABE", priority: 15)
-      abd = Money::Currency.find("ABD")
-      abc = Money::Currency.find("ABC")
-      abe = Money::Currency.find("ABE")
-      expect(abd).to be > abc
-      expect(abe).to be > abd
-      Money::Currency.unregister("ABD")
-      Money::Currency.unregister("ABC")
-      Money::Currency.unregister("ABE")
-    end
-
-    context "when one of the currencies has no 'priority' set" do
-      it "compares by id" do
-        Money::Currency.register(iso_code: "ABD") # No priority
-        abd = Money::Currency.find(:abd)
-        usd = Money::Currency.find(:usd)
-        expect(abd).to be < usd
-        Money::Currency.unregister(iso_code: "ABD")
+      it "allows comparison with nil and returns false" do
+        expect(Currency.new(:eur)).not_to be_nil
       end
     end
-  end
 
-  describe "#==" do
-    it "returns true if self === other" do
-      currency = Money::Currency.new(:eur)
-      expect(currency).to eq currency
+    describe "#eql?" do
+      it "returns true if #== returns true" do
+        expect(Currency.new(:eur).eql?(Currency.new(:eur))).to be true
+        expect(Currency.new(:eur).eql?(Currency.new(:usd))).to be false
+      end
     end
 
-    it "returns true if the id is equal ignorning case" do
-      expect(Money::Currency.new(:eur)).to     eq Money::Currency.new(:eur)
-      expect(Money::Currency.new(:eur)).to     eq Money::Currency.new(:EUR)
-      expect(Money::Currency.new(:eur)).not_to eq Money::Currency.new(:usd)
+    describe "#hash" do
+      it "returns the same value for equal objects" do
+        expect(Currency.new(:eur).hash).to eq Currency.new(:eur).hash
+        expect(Currency.new(:eur).hash).not_to eq Currency.new(:usd).hash
+      end
+
+      it "can be used to return the intersection of Currency object arrays" do
+        intersection = [Currency.new(:eur), Currency.new(:usd)] & [Currency.new(:eur)]
+        expect(intersection).to eq [Currency.new(:eur)]
+      end
     end
 
-    it "allows direct comparison of currencies and symbols/strings" do
-      expect(Money::Currency.new(:eur)).to     eq 'eur'
-      expect(Money::Currency.new(:eur)).to     eq 'EUR'
-      expect(Money::Currency.new(:eur)).to     eq :eur
-      expect(Money::Currency.new(:eur)).to     eq :EUR
-      expect(Money::Currency.new(:eur)).not_to eq 'usd'
+    describe "#inspect" do
+      it "works as documented" do
+        expect(Currency.new(:usd).inspect).to eq %Q{#<Money::Currency id: usd, priority: 1, symbol_first: true, thousands_separator: ,, html_entity: $, decimal_mark: ., name: United States Dollar, symbol: $, subunit_to_unit: 100, exponent: 2.0, iso_code: USD, iso_numeric: 840, subunit: Cent, smallest_denomination: 1>}
+      end
     end
 
-    it "allows comparison with nil and returns false" do
-      expect(Money::Currency.new(:eur)).not_to be_nil
-    end
-  end
-
-  describe "#eql?" do
-    it "returns true if #== returns true" do
-      expect(Money::Currency.new(:eur).eql?(Money::Currency.new(:eur))).to be true
-      expect(Money::Currency.new(:eur).eql?(Money::Currency.new(:usd))).to be false
-    end
-  end
-
-  describe "#hash" do
-    it "returns the same value for equal objects" do
-      expect(Money::Currency.new(:eur).hash).to eq Money::Currency.new(:eur).hash
-      expect(Money::Currency.new(:eur).hash).not_to eq Money::Currency.new(:usd).hash
+    describe "#to_s" do
+      it "works as documented" do
+        expect(Currency.new(:usd).to_s).to eq("USD")
+        expect(Currency.new(:eur).to_s).to eq("EUR")
+      end
     end
 
-    it "can be used to return the intersection of Currency object arrays" do
-      intersection = [Money::Currency.new(:eur), Money::Currency.new(:usd)] & [Money::Currency.new(:eur)]
-      expect(intersection).to eq [Money::Currency.new(:eur)]
-    end
-  end
-
-  describe "#inspect" do
-    it "works as documented" do
-      expect(Money::Currency.new(:usd).inspect).to eq %Q{#<Money::Currency id: usd, priority: 1, symbol_first: true, thousands_separator: ,, html_entity: $, decimal_mark: ., name: United States Dollar, symbol: $, subunit_to_unit: 100, exponent: 2.0, iso_code: USD, iso_numeric: 840, subunit: Cent, smallest_denomination: 1>}
-    end
-  end
-
-  describe "#to_s" do
-    it "works as documented" do
-      expect(Money::Currency.new(:usd).to_s).to eq("USD")
-      expect(Money::Currency.new(:eur).to_s).to eq("EUR")
-    end
-  end
-
-  describe "#to_str" do
-    it "works as documented" do
-      expect(Money::Currency.new(:usd).to_str).to eq("USD")
-      expect(Money::Currency.new(:eur).to_str).to eq("EUR")
-    end
-  end
-
-  describe "#to_sym" do
-    it "works as documented" do
-      expect(Money::Currency.new(:usd).to_sym).to eq(:USD)
-      expect(Money::Currency.new(:eur).to_sym).to eq(:EUR)
-    end
-  end
-
-  describe "#to_currency" do
-    it "works as documented" do
-      usd = Money::Currency.new(:usd)
-      expect(usd.to_currency).to eq usd
+    describe "#to_str" do
+      it "works as documented" do
+        expect(Currency.new(:usd).to_str).to eq("USD")
+        expect(Currency.new(:eur).to_str).to eq("EUR")
+      end
     end
 
-    it "doesn't create new symbols indefinitely" do
-      expect { Money::Currency.new("bogus") }.to raise_exception(Money::Currency::UnknownCurrency)
-      expect(Symbol.all_symbols.map{|s| s.to_s}).not_to include("bogus")
-    end
-  end
-
-  describe "#code" do
-    it "works as documented" do
-      expect(Money::Currency.new(:usd).code).to eq "$"
-      expect(Money::Currency.new(:azn).code).to eq "\u20BC"
-    end
-  end
-
-  describe "#exponent" do
-    it "conforms to iso 4217" do
-      Money::Currency.new(:jpy).exponent == 0
-      Money::Currency.new(:usd).exponent == 2
-      Money::Currency.new(:iqd).exponent == 3
-    end
-  end
-
-  describe "#decimal_places" do
-    it "proper places for known currency" do
-      Money::Currency.new(:mro).decimal_places == 1
-      Money::Currency.new(:usd).decimal_places == 2
+    describe "#to_sym" do
+      it "works as documented" do
+        expect(Currency.new(:usd).to_sym).to eq(:USD)
+        expect(Currency.new(:eur).to_sym).to eq(:EUR)
+      end
     end
 
-    it "proper places for custom currency" do
-      register_foo
-      Money::Currency.new(:foo).decimal_places == 3
-      unregister_foo
+    describe "#to_currency" do
+      it "works as documented" do
+        usd = Currency.new(:usd)
+        expect(usd.to_currency).to eq usd
+      end
+
+      it "doesn't create new symbols indefinitely" do
+        expect { Currency.new("bogus") }.to raise_exception(Currency::UnknownCurrency)
+        expect(Symbol.all_symbols.map{|s| s.to_s}).not_to include("bogus")
+      end
+    end
+
+    describe "#code" do
+      it "works as documented" do
+        expect(Currency.new(:usd).code).to eq "$"
+        expect(Currency.new(:azn).code).to eq "\u20BC"
+      end
+    end
+
+    describe "#exponent" do
+      it "conforms to iso 4217" do
+        Currency.new(:jpy).exponent == 0
+        Currency.new(:usd).exponent == 2
+        Currency.new(:iqd).exponent == 3
+      end
+    end
+
+    describe "#decimal_places" do
+      it "proper places for known currency" do
+        Currency.new(:mro).decimal_places == 1
+        Currency.new(:usd).decimal_places == 2
+      end
+
+      it "proper places for custom currency" do
+        register_foo
+        Currency.new(:foo).decimal_places == 3
+        unregister_foo
+      end
     end
   end
 end


### PR DESCRIPTION
This way we don't have to qualify every reference to 'Currency' etc by prefacing it with 'Money'