### PR TITLE
Use Money.new instead of Numeric#to_money in VariableExchange docs

### DIFF
--- a/lib/money/bank/variable_exchange.rb
+++ b/lib/money/bank/variable_exchange.rb
@@ -24,10 +24,10 @@ class Money
     #   c2 = Money.new(100_00, "CAD")
     #
     #   # Exchange 100 USD to CAD:
-    #   bank.exchange_with(c1, "CAD") #=> #<Money @fractional=1245150>
+    #   bank.exchange_with(c1, "CAD") #=> #<Money fractional:12451 currency:CAD>
     #
     #   # Exchange 100 CAD to USD:
-    #   bank.exchange_with(c2, "USD") #=> #<Money @fractional=803115>
+    #   bank.exchange_with(c2, "USD") #=> #<Money fractional:8031 currency:USD>
     class VariableExchange < Base
 
       attr_reader :rates, :mutex
@@ -80,10 +80,10 @@ class Money
       #   c2 = Money.new(100_00, "CAD")
       #
       #   # Exchange 100 USD to CAD:
-      #   bank.exchange_with(c1, "CAD") #=> #<Money @fractional=1245150>
+      #   bank.exchange_with(c1, "CAD") #=> #<Money fractional:12451 currency:CAD>
       #
       #   # Exchange 100 CAD to USD:
-      #   bank.exchange_with(c2, "USD") #=> #<Money @fractional=803115>
+      #   bank.exchange_with(c2, "USD") #=> #<Money fractional:8031 currency:USD>
       def exchange_with(from, to_currency, &block)
         to_currency = Currency.wrap(to_currency)
         if from.currency == to_currency

--- a/lib/money/bank/variable_exchange.rb
+++ b/lib/money/bank/variable_exchange.rb
@@ -20,8 +20,8 @@ class Money
     #   bank.add_rate("USD", "CAD", 1.24515)
     #   bank.add_rate("CAD", "USD", 0.803115)
     #
-    #   c1 = 100_00.to_money("USD")
-    #   c2 = 100_00.to_money("CAD")
+    #   c1 = Money.new(100_00, "USD")
+    #   c2 = Money.new(100_00, "CAD")
     #
     #   # Exchange 100 USD to CAD:
     #   bank.exchange_with(c1, "CAD") #=> #<Money @fractional=1245150>
@@ -76,8 +76,8 @@ class Money
       #   bank.add_rate("USD", "CAD", 1.24515)
       #   bank.add_rate("CAD", "USD", 0.803115)
       #
-      #   c1 = 100_00.to_money("USD")
-      #   c2 = 100_00.to_money("CAD")
+      #   c1 = Money.new(100_00, "USD")
+      #   c2 = Money.new(100_00, "CAD")
       #
       #   # Exchange 100 USD to CAD:
       #   bank.exchange_with(c1, "CAD") #=> #<Money @fractional=1245150>


### PR DESCRIPTION
A very minor improvement. `Numeric#to_money` is no longer part of this gem, so i think it's preferable to use `Money.new` in the docs instead.

Cheers! :beers: 