### PR TITLE
Add Money.from_amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
    `.ca_dollar`, and `.euro`.
  - Add helper methods for British pounds: `Money.pound_sterling` and
    `Money.gbp`.
+ - Add `Money.from_amount` to create money from a value in units instead of
+   fractional units.
 
 ## 6.5.1
  - Fix format for BYR currency

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Money.new(1000, "USD") - Money.new(200, "USD") == Money.new(800, "USD")
 Money.new(1000, "USD") / 5                     == Money.new(200, "USD")
 Money.new(1000, "USD") * 5                     == Money.new(5000, "USD")
 
+# Unit to subunit conversions
+Money.from_amount(5, "USD") == Money.new(500, "USD")  # 5 USD
+Money.from_amount(5, "JPY") == Money.new(5, "JPY")    # 5 JPY
+Money.from_amount(5, "TND") == Money.new(5000, "TND") # 5 TND
+
 # Currency conversions
 some_code_to_setup_exchange_rates
 Money.new(1000, "USD").exchange_to("EUR") == Money.new(some_value, "EUR")

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -211,13 +211,35 @@ class Money
     self.default_bank = Bank::SingleCurrency.instance
   end
 
+  # Creates a new Money object of value given in the +unit+ of the given
+  # +currency+.
+  #
+  # @param [Numeric] amount The numerical value of the money.
+  # @param [Currency, String, Symbol] currency The currency format.
+  # @param [Money::Bank::*] bank The exchange bank to use.
+  #
+  # @example
+  #   Money.from_amount(23.45, "USD") # => #<Money fractional:2345 currency:USD>
+  #   Money.from_amount(23.45, "JPY") # => #<Money fractional:23 currency:JPY>
+  #
+  # @return [Money]
+  #
+  # @see #initialize
+  def self.from_amount(amount, currency = default_currency, bank = default_bank)
+    Numeric === amount or raise ArgumentError, "'amount' must be numeric"
+    currency = Currency.wrap(currency)
+    value = BigDecimal.new(amount.to_s) * currency.subunit_to_unit
+    value = value.round unless infinite_precision
+    new(value, currency, bank)
+  end
+
   # Creates a new Money object of value given in the
   # +fractional unit+ of the given +currency+.
   #
   # Alternatively you can use the convenience
   # methods like {Money.ca_dollar} and {Money.us_dollar}.
   #
-  # @param [Object] obj Either The fractional value of the money,
+  # @param [Object] obj Either the fractional value of the money,
   #   a Money object, or a currency. (If passed a currency as the first
   #   argument, a Money will be created in that currency with fractional value
   #   = 0.


### PR DESCRIPTION
Hi!

I'd like to propose the addition of a `Money.from_amount` constructor method, which creates a Money from a given amount in the currency's *units*. 

I think building money values from amounts in units is a pretty common use case, and i was a bit confused when i couldn't find a method to do so in the latest versions of this gem. I now know that methods like `Numeric#to_money` were moved to Monetize, and i agree with that decision, but i think that a method like `Money.from_amount` *does* have its place in Money. Mainly because Money already knows about amounts and fractional amounts, with `Money#amount` and `Money#fractional` respectively. And also because some applications don't need the complex parsing from strings that Monetize provides, and i'd rather avoid adding methods to builtins if possible :grin:

Another big reason i'd like to add this method is to make it very clear that this gem knows about currency subunits and can deal with currencies with different number of them†. The first snippet in the README only shows examples in dollars and euros, both of which can be similarly built by expressing an amount in cents. I think adding a couple of examples in currencies that have different subunit/unit ratios will help to make it clearer that, when using `Money.new`, we have to take care about subunits, and proposing the complementary `Money.from_amount` for the cases where we know that the values will be expressed in units instead.

Well, that was a mouthful. I hope you find this method fitting. And thanks for the great gem!

†: I actually used this gem for a while without knowing that :sweat_smile: 