### PR TITLE
Minor spec tweaks

### DIFF
--- a/money.gemspec
+++ b/money.gemspec
@@ -29,7 +29,7 @@ MSG
 
   s.add_development_dependency "bundler", "~> 1.3"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec", "~> 3.0.0"
+  s.add_development_dependency "rspec", "~> 3.2.0"
   s.add_development_dependency "yard", "~> 0.8"
   s.add_development_dependency "kramdown", "~> 1.1"
 

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -11,7 +11,7 @@ class Money
       foo_attrs = JSON.parse(FOO, :symbolize_names => true)
       # Pass an array of attribute names to 'skip' to remove them from the 'FOO'
       # json before registering foo as a currency.
-      Array.wrap(opts[:skip]).each { |attr| foo_attrs.delete(attr) }
+      Array(opts[:skip]).each { |attr| foo_attrs.delete(attr) }
       Money::Currency.register(foo_attrs)
     end
 

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -287,15 +287,7 @@ describe Money do
       end
     end
 
-    context "infinite_precision = true" do
-      before do
-        Money.infinite_precision = true
-      end
-
-      after do
-        Money.infinite_precision = false
-      end
-
+    context "with infinite_precision", :infinite_precision do
       it "uses BigDecimal division" do
         ts = [
           {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 3.25, :USD)},
@@ -348,15 +340,7 @@ describe Money do
       end
     end
 
-    context "infinite_precision = true" do
-      before do
-        Money.infinite_precision = true
-      end
-
-      after do
-        Money.infinite_precision = false
-      end
-
+    context "with infinite_precision", :infinite_precision do
       it "uses BigDecimal division" do
         ts = [
           {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 3.25, :USD)},
@@ -409,15 +393,7 @@ describe Money do
       end
     end
 
-    context "infinite_precision = true" do
-      before do
-        Money.infinite_precision = true
-      end
-
-      after do
-        Money.infinite_precision = false
-      end
-
+    context "with infinite_precision", :infinite_precision do
       it "uses BigDecimal division" do
         ts = [
             {:a => Money.new( 13, :USD), :b =>  4, :c => [Money.new( 3, :USD), Money.new( 1, :USD)]},

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -512,15 +512,7 @@ describe Money, "formatting" do
       end
     end
 
-    describe ":rounded_infinite_precision option" do
-      before do
-        Money.infinite_precision = true
-      end
-
-      after do
-        Money.infinite_precision = false
-      end
-
+    describe ":rounded_infinite_precision option", :infinite_precision do
       it "does round fractional when set to true" do
         expect(Money.new(BigDecimal.new('12.1'), "USD").format(:rounded_infinite_precision => true)).to eq "$0.12"
         expect(Money.new(BigDecimal.new('12.5'), "USD").format(:rounded_infinite_precision => true)).to eq "$0.13"
@@ -541,15 +533,13 @@ describe Money, "formatting" do
         expect(Money.new(BigDecimal.new('1'), "MGA").format(:rounded_infinite_precision => false)).to eq "Ar0.1"
       end
 
-      describe ":rounded_infinite_precision option with i18n = false" do
+      describe "with i18n = false" do
         before do
           Money.use_i18n = false
-          Money.infinite_precision = true
         end
 
         after do
           Money.use_i18n = true
-          Money.infinite_precision = false
         end
 
         it 'does round fractional when set to true' do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -78,8 +78,7 @@ describe Money do
       end
     end
 
-    context "infinite_precision = true" do
-      before { expect(Money).to receive(:infinite_precision).and_return(true) }
+    context "with infinite_precision", :infinite_precision do
       context 'given the initializing value is 1.50' do
         let(:initializing_value) { 1.50 }
 
@@ -146,6 +145,13 @@ describe Money do
       expect(Money.from_amount(555.5, "JPY").amount).to eq "556".to_d
     end
 
+    it "does not round the given amount when infinite_precision is set", :infinite_precision do
+      expect(Money.from_amount(4.444, "USD").amount).to eq "4.444".to_d
+      expect(Money.from_amount(5.555, "USD").amount).to eq "5.555".to_d
+      expect(Money.from_amount(444.4, "JPY").amount).to eq "444.4".to_d
+      expect(Money.from_amount(555.5, "JPY").amount).to eq "555.5".to_d
+    end
+
     it "accepts an optional currency" do
       expect(Money.from_amount(1).currency).to eq Money.default_currency
       jpy = Money::Currency.wrap("JPY")
@@ -157,23 +163,6 @@ describe Money do
       expect(Money.from_amount(1).bank).to eq Money.default_bank
       bank = double "bank"
       expect(Money.from_amount(1, "USD", bank).bank).to eq bank
-    end
-
-    context "infinite_precision = true" do
-      before do
-        Money.infinite_precision = true
-      end
-
-      after do
-        Money.infinite_precision = false
-      end
-
-      it "does not round the given amount to subunits" do
-        expect(Money.from_amount(4.444, "USD").amount).to eq "4.444".to_d
-        expect(Money.from_amount(5.555, "USD").amount).to eq "5.555".to_d
-        expect(Money.from_amount(444.4, "JPY").amount).to eq "444.4".to_d
-        expect(Money.from_amount(555.5, "JPY").amount).to eq "555.5".to_d
-      end
     end
   end
 
@@ -232,19 +221,9 @@ YAML
         expect(m.fractional).to be_a(Integer)
       end
 
-      context "with infinite_precision" do
-        before do
-          Money.infinite_precision = true
-        end
-
-        after do
-          Money.infinite_precision = false
-        end
-
-        it "is a BigDecimal" do
-          money = YAML::load serialized
-          expect(money.fractional).to be_a BigDecimal
-        end
+      it "is a BigDecimal when using infinite_precision", :infinite_precision do
+        money = YAML::load serialized
+        expect(money.fractional).to be_a BigDecimal
       end
     end
 
@@ -290,15 +269,7 @@ YAML
       end
     end
 
-    context "infinite_precision = true" do
-      before do
-        Money.infinite_precision = true
-      end
-
-      after do
-        Money.infinite_precision = false
-      end
-
+    context "with infinite_precision", :infinite_precision do
       it "returns the amount in fractional unit" do
         expect(Money.new(1_00).fractional).to eq BigDecimal("100")
       end
@@ -378,19 +349,9 @@ YAML
       expect(money.round_to_nearest_cash_value).to be_a Fixnum
     end
   
-    context "with infinite_precision" do
-      before do
-        Money.infinite_precision = true
-      end
-
-      after do
-        Money.infinite_precision = false
-      end
-
-      it "returns a BigDecimal" do
-        money = Money.new(100, "EUR")
-        expect(money.round_to_nearest_cash_value).to be_a BigDecimal
-      end
+    it "returns a BigDecimal when infinite_precision is set", :infinite_precision do
+      money = Money.new(100, "EUR")
+      expect(money.round_to_nearest_cash_value).to be_a BigDecimal
     end
   end
 
@@ -501,15 +462,7 @@ YAML
       expect(Money.new(10_00, "BRL").to_s).to eq "10,00"
     end
 
-    context "infinite_precision = true" do
-      before do
-        Money.infinite_precision = true
-      end
-
-      after do
-        Money.infinite_precision = false
-      end
-
+    context "with infinite_precision", :infinite_precision do
       it "shows fractional cents" do
         expect(Money.new(1.05, "USD").to_s).to eq "0.0105"
       end
@@ -629,15 +582,7 @@ YAML
       expect { Money.us_dollar(0.05).allocate([0.5, 0.6]) }.to raise_error(ArgumentError)
     end
 
-    context "infinite_precision = true" do
-      before do
-        Money.infinite_precision = true
-      end
-
-      after do
-        Money.infinite_precision = false
-      end
-
+    context "with infinite_precision", :infinite_precision do
       it "allows for fractional cents allocation" do
         one_third = BigDecimal("1") / BigDecimal("3")
 
@@ -674,15 +619,7 @@ YAML
       expect(moneys[2].cents).to eq 33
     end
 
-    context "infinite_precision = true" do
-      before do
-        Money.infinite_precision = true
-      end
-
-      after do
-        Money.infinite_precision = false
-      end
-
+    context "with infinite_precision", :infinite_precision do
       it "allows for splitting by fractional cents" do
         thirty_three_and_one_third = BigDecimal("100") / BigDecimal("3")
 
@@ -700,10 +637,6 @@ YAML
     subject(:rounded) { money.round }
 
     context "without infinite_precision" do
-      before do
-        Money.infinite_precision = false
-      end
-
       it "returns self (as it is already rounded)" do
         rounded = money.round
         expect(rounded).to be money
@@ -711,15 +644,7 @@ YAML
       end
     end
 
-    context "with infinite_precision" do
-      before do
-        Money.infinite_precision = true
-      end
-
-      after do
-        Money.infinite_precision = false
-      end
-
+    context "with infinite_precision", :infinite_precision do
       it "returns a different money" do
         expect(rounded).not_to be money
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,3 +21,13 @@ end
 def reset_i18n
   I18n.backend = I18n::Backend::Simple.new
 end
+
+RSpec.shared_context "with infinite precision", :infinite_precision do
+  before do
+    Money.infinite_precision = true
+  end
+
+  after do
+    Money.infinite_precision = false
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,18 +21,3 @@ end
 def reset_i18n
   I18n.backend = I18n::Backend::Simple.new
 end
-
-class Array
-
-  # No ActiveSupport :(
-  def self.wrap(object)
-    if object.nil?
-      []
-    elsif object.respond_to?(:to_ary)
-      object.to_ary || [object]
-    else
-      [object]
-    end
-  end
-
-end


### PR DESCRIPTION
Just a couple of minor tweaks to the specs.

Remove an unnecessary `Array.wrap` definition from spec_helper.rb and use the `Kernel#Array` method instead.

Remove repetition of setting and un-setting `Money.infinite_precision` on specs and use an RSpec "shared context" tagged as `:infinite_precision` instead.