### PR TITLE
Change CLF exponent from 0 to 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
  - Add `Money.from_amount` to create money from a value in units instead of
    fractional units.
  - Changed CHF symbol from 'Fr' to 'CHF'
+ - Changed CLF exponent from 0 to 4
 
 ## 6.5.1
  - Fix format for BYR currency

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -437,7 +437,7 @@
     "symbol": "UF",
     "alternate_symbols": [],
     "subunit": "Peso",
-    "subunit_to_unit": 1,
+    "subunit_to_unit": 10000,
     "symbol_first": true,
     "html_entity": "&#x20B1;",
     "decimal_mark": ",",


### PR DESCRIPTION
The [ISO standard](http://www.currency-iso.org/en/home/tables/table-a1.html) indicates that there are 4 decimal places to the "Minor unit" for the CLF currency.