### PR TITLE
only one unit in South Korean Won

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
  - Changed CLP subunit_to_unit from 1 to 100
  - Minor fixes to prevent warnings on unused variables and the redefinition of
    `Money.default_currency`
+ - Changed KRW subunit_to_unit from 100 to 1
 
 ## 6.5.1
  - Fix format for BYR currency

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -1142,7 +1142,7 @@
     "name": "South Korean Won",
     "symbol": "₩",
     "subunit": null,
-    "subunit_to_unit": 100,
+    "subunit_to_unit": 1,
     "alternate_symbols": [],
     "symbol_first": true,
     "html_entity": "&#x20A9;",


### PR DESCRIPTION
Minor unit was the jeon but no longer used. See http://en.wikipedia.org/wiki/South_Korean_won.