### PR TITLE
0 in one currency should equal 0 in any other currency

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,6 +75,7 @@ Michael Irwin
 Michael Reinsch
 Michael Rodrigues
 Mikael Wikman
+Mike Herrera
 Mike Połétyn
 Musannif Zahir
 Neil Middleton

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
  - Changed CLP subunit_to_unit from 1 to 100
  - Minor fixes to prevent warnings on unused variables and the redefinition of
    `Money.default_currency`
+ - `Money#==` changed to acknowledge that 0 in one currency is equal to 0 in any currency.
 
 ## 6.5.1
  - Fix format for BYR currency

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -12,20 +12,23 @@ class Money
     end
 
     # Checks whether two money objects have the same currency and the same
-    # amount. Checks against money objects with a different currency and checks
-    # against objects that do not respond to #to_money will always return false.
+    # amount. If money objects have a different currency it will only be true
+    # if the amounts are both zero. Checks against objects that do not respond
+    # to #to_money, in which case, it will always return false.
     #
     # @param [Money] other_money Value to compare with.
     #
     # @return [Boolean]
     #
     # @example
-    #   Money.new(100) == Money.new(101) #=> false
-    #   Money.new(100) == Money.new(100) #=> true
+    #   Money.new(100) == Money.new(101)           #=> false
+    #   Money.new(100) == Money.new(100)           #=> true
+    #   Money.new(0, "USD") == Money.new(0, "EUR") #=> true
     def ==(other_money)
       if other_money.respond_to?(:to_money)
         other_money = other_money.to_money
-        fractional == other_money.fractional && currency == other_money.currency
+        (fractional == other_money.fractional && currency == other_money.currency) ||
+          (fractional == 0 && other_money.fractional == 0)
       else
         false
       end

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -12,11 +12,18 @@ describe Money do
   end
 
   describe "#==" do
-    it "returns true if and only if their amount and currency are equal" do
+    it "returns true if both the amounts and currencies are equal" do
       expect(Money.new(1_00, "USD")).to     eq Money.new(1_00, "USD")
       expect(Money.new(1_00, "USD")).not_to eq Money.new(1_00, "EUR")
       expect(Money.new(1_00, "USD")).not_to eq Money.new(2_00, "USD")
       expect(Money.new(1_00, "USD")).not_to eq Money.new(99_00, "EUR")
+    end
+
+    it "returns true if both amounts are zero, even if currency differs" do
+      expect(Money.new(0, "USD")).to eq Money.new(0, "USD")
+      expect(Money.new(0, "USD")).to eq Money.new(0, "EUR")
+      expect(Money.new(0, "USD")).to eq Money.new(0, "AUD")
+      expect(Money.new(0, "USD")).to eq Money.new(0, "JPY")
     end
 
     it "returns false if used to compare with an object that doesn't respond to #to_money" do


### PR DESCRIPTION
A special circumstance for `#==` to recognize that:
The **value of 0 in currency A** is always equal to **the value of 0 in currency B**

This was initially inspired by an issue on [money-rails (#325)](https://github.com/RubyMoney/money-rails/issues/325)