### PR TITLE
Decouple exchange rates storage from VariableExchange bank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
    `Money.default_currency`
  - `Money#==` changed to acknowledge that 0 in one currency is equal to 0 in any currency.
  - Changed KRW subunit_to_unit from 100 to 1
+ - Decouple exchange rates storage from bank objects and formalize storage public API. Default is `Money::RatesStore::Memory`.
 
 ## 6.5.1
  - Fix format for BYR currency

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ def add_rate(iso_from, iso_to, rate); end
 # @return [Numeric] rate.
 def get_rate(iso_from, iso_to); end
 
-# Iterate over rate tupes (iso_from, iso_to, rate)
+# Iterate over rate tuples (iso_from, iso_to, rate)
 #
 # @yieldparam iso_from [String] Currency ISO string.
 # @yieldparam iso_to [String] Currency ISO string.

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Money.new(1000, "EUR") + Money.new(1000, "USD") == Money.new(1500, "EUR")
 
 The default bank is initialized with an in-memory store for exchange rates.
 
-```
+```ruby
 Money.default_bank = Money::Bank::VariableExchange.new(Money::RatesStore::Memory.new)
 ```
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Money.add_rate("USD", "EUR", 0.5)
 Money.new(1000, "EUR") + Money.new(1000, "USD") == Money.new(1500, "EUR")
 ```
 
-### Bank stores
+### Exchange rate stores
 
 The default bank is initialized with an in-memory store for exchange rates.
 

--- a/lib/money/bank/variable_exchange.rb
+++ b/lib/money/bank/variable_exchange.rb
@@ -196,14 +196,14 @@ class Money
         raise Money::Bank::UnknownRateFormat unless
           RATE_FORMATS.include? format
 
-        store.transaction(opts) do |st|
+        store.transaction(opts) do
           s = case format
           when :json
-            JSON.dump(st.rates)
+            JSON.dump(store.rates)
           when :ruby
-            Marshal.dump(st.rates)
+            Marshal.dump(store.rates)
           when :yaml
-            YAML.dump(st.rates)
+            YAML.dump(store.rates)
           end
 
           unless file.nil?
@@ -237,7 +237,7 @@ class Money
         raise Money::Bank::UnknownRateFormat unless
           RATE_FORMATS.include? format
 
-        store.transaction(opts) do |st|
+        store.transaction(opts) do
           data = case format
            when :json
              JSON.load(s)
@@ -249,7 +249,7 @@ class Money
 
           opts = opts.dup
           opts[:without_mutex] = true
-          st.import_rates data, opts
+          store.import_rates data, opts
         end
 
         self

--- a/lib/money/rates_store/memory.rb
+++ b/lib/money/rates_store/memory.rb
@@ -74,7 +74,7 @@ class Money
         end
       end
 
-      # Iterate over rate tupes (iso_from, iso_to, rate)
+      # Iterate over rate tuples (iso_from, iso_to, rate)
       #
       # @yieldparam iso_from [String] Currency ISO string.
       # @yieldparam iso_to [String] Currency ISO string.

--- a/lib/money/rates_store/memory.rb
+++ b/lib/money/rates_store/memory.rb
@@ -1,0 +1,52 @@
+class Money
+  module RatesStore
+    class Memory
+      attr_reader :rates
+
+      def initialize(rt = {})
+        @rates = rt
+        @mutex = Mutex.new
+      end
+
+      def add_rate(currency_iso_from, currency_iso_to, rate, opts = {})
+        transaction(opts) {|st| rates[rate_key_for(currency_iso_from, currency_iso_to)] = rate }
+      end
+
+      def get_rate(currency_iso_from, currency_iso_to, opts = {})
+        transaction(opts) {|st| rates[rate_key_for(currency_iso_from, currency_iso_to)] }
+      end
+
+      def marshal_dump
+        [self.class, rates]
+      end
+
+      def import_rates(data, opts = {})
+        transaction(opts) {|st| @rates = data }
+        self
+      end
+
+      def transaction(opts = {}, &block)
+        if opts[:without_mutex]
+          block.call self
+        else
+          @mutex.synchronize { block.call(self) }
+        end
+      end
+
+      private
+
+      # Return the rate hashkey for the given currencies.
+      #
+      # @param [String] from The currency to exchange from.
+      # @param [String] to The currency to exchange to.
+      #
+      # @return [String]
+      #
+      # @example
+      #   rate_key_for("USD", "CAD") #=> "USD_TO_CAD"
+      def rate_key_for(currency_iso_from, currency_iso_to)
+        "#{currency_iso_from}_TO_#{currency_iso_to}".upcase
+      end
+    end
+  end
+end

--- a/lib/money/rates_store/memory.rb
+++ b/lib/money/rates_store/memory.rb
@@ -74,6 +74,18 @@ class Money
         end
       end
 
+      # Iterate over rate tupes (iso_from, iso_to, rate)
+      #
+      # @yieldparam iso_from [String] Currency ISO string.
+      # @yieldparam iso_to [String] Currency ISO string.
+      # @yieldparam rate [Numeric] Exchange rate.
+      #
+      # @return [Enumerator]
+      #
+      # @example
+      #   store.each_rate do |iso_from, iso_to, rate|
+      #     puts [iso_from, iso_to, rate].join
+      #   end
       def each_rate(&block)
         enum = Enumerator.new do |yielder|
           index.each do |key, rate|

--- a/lib/money/rates_store/memory.rb
+++ b/lib/money/rates_store/memory.rb
@@ -9,11 +9,11 @@ class Money
       end
 
       def add_rate(currency_iso_from, currency_iso_to, rate, opts = {})
-        transaction(opts) {|st| rates[rate_key_for(currency_iso_from, currency_iso_to)] = rate }
+        transaction(opts) { rates[rate_key_for(currency_iso_from, currency_iso_to)] = rate }
       end
 
       def get_rate(currency_iso_from, currency_iso_to, opts = {})
-        transaction(opts) {|st| rates[rate_key_for(currency_iso_from, currency_iso_to)] }
+        transaction(opts) { rates[rate_key_for(currency_iso_from, currency_iso_to)] }
       end
 
       def marshal_dump
@@ -21,7 +21,7 @@ class Money
       end
 
       def import_rates(data, opts = {})
-        transaction(opts) {|st| @rates = data }
+        transaction(opts) { @rates = data }
         self
       end
 
@@ -29,7 +29,7 @@ class Money
         if opts[:without_mutex]
           block.call self
         else
-          @mutex.synchronize { block.call(self) }
+          @mutex.synchronize(&block)
         end
       end
 

--- a/lib/money/rates_store/memory.rb
+++ b/lib/money/rates_store/memory.rb
@@ -1,17 +1,60 @@
 class Money
   module RatesStore
+
+    # Class for thread-safe storage of exchange rate pairs.
+    # Used by instances of +Money::Bank::VariableExchange+.
+    #
+    # @example
+    #   store = Money::RatesStore::Memory.new
+    #   store.add_rate 'USD', 'CAD', 0.98
+    #   store.get_rate 'USD', 'CAD' # => 0.98
+    #   # import rates hash
+    #   store.import_rates({'USD_TO_EUR' => 0.90})
+    #   store.get_rate 'USD', 'EUR' => 0.90
     class Memory
       attr_reader :rates
 
+      # Initializes a new +Money::RatesStore::Memory+ object.
+      #
+      # @param [Hash] rt Optional initial exchange rate data.
       def initialize(rt = {})
         @rates = rt
         @mutex = Mutex.new
       end
 
+      # Registers a conversion rate and returns it. Uses +Mutex+ to synchronize data access.
+      #
+      # @param [String] currency_iso_from Currency to exchange from.
+      # @param [String] currency_iso_to Currency to exchange to.
+      # @param [Numeric] rate Rate to use when exchanging currencies.
+      # @param [Hash] opts Options hash to set special parameters
+      # @option opts [Boolean] :without_mutex disables the usage of a mutex
+      #
+      # @return [Numeric]
+      #
+      # @example
+      #   store = Money::RatesStore::Memory.new
+      #   store.add_rate("USD", "CAD", 1.24515)
+      #   store.add_rate("CAD", "USD", 0.803115)
       def add_rate(currency_iso_from, currency_iso_to, rate, opts = {})
         transaction(opts) { rates[rate_key_for(currency_iso_from, currency_iso_to)] = rate }
       end
 
+      # Retrieve the rate for the given currencies. Uses +Mutex+ to synchronize data access.
+      # Delegates to +Money::RatesStore::Memory+
+      #
+      # @param [String] currency_iso_from Currency to exchange from.
+      # @param [String] currency_iso_to Currency to exchange to.
+      # @param [Hash] opts Options hash to set special parameters
+      # @option opts [Boolean] :without_mutex disables the usage of a mutex
+      #
+      # @return [Numeric]
+      #
+      # @example
+      #   store = Money::RatesStore::Memory.new
+      #   store.add_rate("USD", "CAD", 1.24515)
+      #
+      #   store.get_rate("USD", "CAD") #=> 1.24515
       def get_rate(currency_iso_from, currency_iso_to, opts = {})
         transaction(opts) { rates[rate_key_for(currency_iso_from, currency_iso_to)] }
       end
@@ -20,6 +63,23 @@ class Money
         [self.class, rates]
       end
 
+      # Loads rates data hash.
+      #
+      # @param [Hash] data The rates data
+      # @param [Hash] opts Options hash to set special parameters
+      # @option opts [Boolean] :without_mutex disables the usage of a mutex
+      #
+      # @return [self]
+      #
+      # @raise +Money::Bank::UnknownRateFormat+ if format is unknown.
+      #
+      # @example
+      #   data = {"USD_TO_CAD" => 1.24515, "CAD_TO_USD" => 0.803115}
+      #   store = Money::RatesStore::Memory
+      #   store.import_rates(:json, data)
+      #
+      #   store.get_rate("USD", "CAD") #=> 1.24515
+      #   store.get_rate("CAD", "USD") #=> 0.803115
       def import_rates(data, opts = {})
         transaction(opts) { @rates = data }
         self

--- a/spec/bank/variable_exchange_spec.rb
+++ b/spec/bank/variable_exchange_spec.rb
@@ -14,6 +14,22 @@ class Money
             end
           }
 
+          describe '#store' do
+            it 'defaults to Memory store' do
+              expect(bank.store).to be_a(Money::RatesStore::Memory)
+            end
+          end
+
+          describe 'custom store' do
+            let(:custom_store) { Object.new }
+
+            let(:bank) { VariableExchange.new(custom_store) }
+
+            it 'sets #store to be custom store' do
+              expect(bank.store).to eql(custom_store)
+            end
+          end
+
           describe "#exchange_with" do
             it "accepts str" do
               expect { bank.exchange_with(Money.new(100, 'USD'), 'EUR') }.to_not raise_exception
@@ -75,38 +91,38 @@ class Money
       end
 
       describe "#add_rate" do
-        it "adds rates correctly" do
-          subject.add_rate("USD", "EUR", 0.788332676)
-          subject.add_rate("EUR", "YEN", 122.631477)
+        it 'delegates to store#add_rate' do
+          expect(subject.store).to receive(:add_rate).with('USD', 'EUR', 1.25, {}).and_return 1.25
+          expect(subject.add_rate('USD', 'EUR', 1.25)).to eql 1.25
+        end
 
-          expect(subject.instance_variable_get(:@rates)['USD_TO_EUR']).to eq 0.788332676
-          expect(subject.instance_variable_get(:@rates)['EUR_TO_JPY']).to eq 122.631477
+        it "adds rates with correct ISO codes" do
+          expect(subject.store).to receive(:add_rate).with('USD', 'EUR', 0.788332676, {})
+          subject.add_rate("USD", "EUR", 0.788332676)
+
+          expect(subject.store).to receive(:add_rate).with('EUR', 'JPY', 122.631477, {})
+          subject.add_rate("EUR", "YEN", 122.631477)
         end
 
         it "treats currency names case-insensitively" do
           subject.add_rate("usd", "eur", 1)
-          expect(subject.instance_variable_get(:@rates)['USD_TO_EUR']).to eq 1
+          expect(subject.get_rate('USD', 'EUR')).to eq 1
         end
       end
 
       describe "#set_rate" do
+        it 'delegates to store#add_rate' do
+          expect(subject.store).to receive(:add_rate).with('USD', 'EUR', 1.25, {}).and_return 1.25
+          expect(subject.set_rate('USD', 'EUR', 1.25)).to eql 1.25
+        end
+
         it "sets a rate" do
           subject.set_rate('USD', 'EUR', 1.25)
-          expect(subject.instance_variable_get(:@rates)['USD_TO_EUR']).to eq 1.25
+          expect(subject.store.get_rate('USD', 'EUR')).to eq 1.25
         end
 
         it "raises an UnknownCurrency exception when an unknown currency is passed" do
           expect { subject.set_rate('AAA', 'BBB', 1.25) }.to raise_exception(Currency::UnknownCurrency)
-        end
-
-        it "uses a mutex by default" do
-          expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
-          subject.set_rate('USD', 'EUR', 1.25)
-        end
-
-        it "doesn't use mutex if requested not to" do
-          expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
-          subject.set_rate('USD', 'EUR', 1.25, :without_mutex => true)
         end
       end
 
@@ -120,13 +136,8 @@ class Money
           expect { subject.get_rate('AAA', 'BBB') }.to raise_exception(Currency::UnknownCurrency)
         end
 
-        it "uses a mutex by default" do
-          expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
-          subject.get_rate('USD', 'EUR')
-        end
-
-        it "doesn't use mutex if requested not to" do
-          expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
+        it "delegates options to store" do
+          expect(subject.store).to receive(:get_rate).with('USD', 'EUR', {:without_mutex => true})
           subject.get_rate('USD', 'EUR', :without_mutex => true)
         end
       end
@@ -176,7 +187,7 @@ class Money
         end
 
         it "uses a mutex by default" do
-          expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
+          expect(subject.store.instance_variable_get(:@mutex)).to receive(:synchronize)
           subject.export_rates(:yaml)
         end
 
@@ -221,44 +232,15 @@ class Money
         end
 
         it "uses a mutex by default" do
-          expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
+          expect(subject.store.instance_variable_get(:@mutex)).to receive(:synchronize)
           s = "--- \nUSD_TO_EUR: 1.25\nUSD_TO_JPY: 2.55\n"
           subject.import_rates(:yaml, s)
         end
 
         it "doesn't use mutex if requested not to" do
-          expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
+          expect(subject.store.instance_variable_get(:@mutex)).not_to receive(:synchronize)
           s = "--- \nUSD_TO_EUR: 1.25\nUSD_TO_JPY: 2.55\n"
           subject.import_rates(:yaml, s, :without_mutex => true)
-        end
-      end
-
-      describe "#rate_key_for" do
-        it "accepts str/str" do
-          expect { subject.send(:rate_key_for, 'USD', 'EUR')}.to_not raise_exception
-        end
-
-        it "accepts currency/str" do
-          expect { subject.send(:rate_key_for, Currency.wrap('USD'), 'EUR')}.to_not raise_exception
-        end
-
-        it "accepts str/currency" do
-          expect { subject.send(:rate_key_for, 'USD', Currency.wrap('EUR'))}.to_not raise_exception
-        end
-
-        it "accepts currency/currency" do
-          expect { subject.send(:rate_key_for, Currency.wrap('USD'), Currency.wrap('EUR'))}.to_not raise_exception
-        end
-
-        it "returns a hashkey based on the passed arguments" do
-          expect(subject.send(:rate_key_for, 'USD', 'EUR')).to eq 'USD_TO_EUR'
-          expect(subject.send(:rate_key_for, Currency.wrap('USD'), 'EUR')).to eq 'USD_TO_EUR'
-          expect(subject.send(:rate_key_for, 'USD', Currency.wrap('EUR'))).to eq 'USD_TO_EUR'
-          expect(subject.send(:rate_key_for, Currency.wrap('USD'), Currency.wrap('EUR'))).to eq 'USD_TO_EUR'
-        end
-
-        it "raises a Money::Currency::UnknownCurrency exception when an unknown currency is passed" do
-          expect { subject.send(:rate_key_for, 'AAA', 'BBB')}.to raise_exception(Currency::UnknownCurrency)
         end
       end
 

--- a/spec/bank/variable_exchange_spec.rb
+++ b/spec/bank/variable_exchange_spec.rb
@@ -92,15 +92,15 @@ class Money
 
       describe "#add_rate" do
         it 'delegates to store#add_rate' do
-          expect(subject.store).to receive(:add_rate).with('USD', 'EUR', 1.25, {}).and_return 1.25
+          expect(subject.store).to receive(:add_rate).with('USD', 'EUR', 1.25).and_return 1.25
           expect(subject.add_rate('USD', 'EUR', 1.25)).to eql 1.25
         end
 
         it "adds rates with correct ISO codes" do
-          expect(subject.store).to receive(:add_rate).with('USD', 'EUR', 0.788332676, {})
+          expect(subject.store).to receive(:add_rate).with('USD', 'EUR', 0.788332676)
           subject.add_rate("USD", "EUR", 0.788332676)
 
-          expect(subject.store).to receive(:add_rate).with('EUR', 'JPY', 122.631477, {})
+          expect(subject.store).to receive(:add_rate).with('EUR', 'JPY', 122.631477)
           subject.add_rate("EUR", "YEN", 122.631477)
         end
 
@@ -112,7 +112,7 @@ class Money
 
       describe "#set_rate" do
         it 'delegates to store#add_rate' do
-          expect(subject.store).to receive(:add_rate).with('USD', 'EUR', 1.25, {}).and_return 1.25
+          expect(subject.store).to receive(:add_rate).with('USD', 'EUR', 1.25).and_return 1.25
           expect(subject.set_rate('USD', 'EUR', 1.25)).to eql 1.25
         end
 
@@ -136,8 +136,8 @@ class Money
           expect { subject.get_rate('AAA', 'BBB') }.to raise_exception(Currency::UnknownCurrency)
         end
 
-        it "delegates options to store" do
-          expect(subject.store).to receive(:get_rate).with('USD', 'EUR', {:without_mutex => true})
+        it "delegates options to store, options are a no-op" do
+          expect(subject.store).to receive(:get_rate).with('USD', 'EUR')
           subject.get_rate('USD', 'EUR', :without_mutex => true)
         end
       end
@@ -186,8 +186,8 @@ class Money
           end
         end
 
-        it "delegates options to store" do
-          expect(subject.store).to receive(:transaction).with({:foo => 1})
+        it "delegates execution to store, options are a no-op" do
+          expect(subject.store).to receive(:transaction)
           subject.export_rates(:yaml, nil, :foo => 1)
         end
 
@@ -227,8 +227,8 @@ class Money
           end
         end
 
-        it "delegates options to store#transaction" do
-          expect(subject.store).to receive(:transaction).with({:foo => 1})
+        it "delegates execution to store#transaction" do
+          expect(subject.store).to receive(:transaction)
           s = "--- \nUSD_TO_EUR: 1.25\nUSD_TO_JPY: 2.55\n"
           subject.import_rates(:yaml, s, :foo => 1)
         end

--- a/spec/bank/variable_exchange_spec.rb
+++ b/spec/bank/variable_exchange_spec.rb
@@ -186,15 +186,11 @@ class Money
           end
         end
 
-        it "uses a mutex by default" do
-          expect(subject.store.instance_variable_get(:@mutex)).to receive(:synchronize)
-          subject.export_rates(:yaml)
+        it "delegates options to store" do
+          expect(subject.store).to receive(:transaction).with({:foo => 1})
+          subject.export_rates(:yaml, nil, :foo => 1)
         end
 
-        it "doesn't use mutex if requested not to" do
-          expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
-          subject.export_rates(:yaml, nil, :without_mutex => true)
-        end
       end
 
       describe "#import_rates" do
@@ -231,17 +227,12 @@ class Money
           end
         end
 
-        it "uses a mutex by default" do
-          expect(subject.store.instance_variable_get(:@mutex)).to receive(:synchronize)
+        it "delegates options to store#transaction" do
+          expect(subject.store).to receive(:transaction).with({:foo => 1})
           s = "--- \nUSD_TO_EUR: 1.25\nUSD_TO_JPY: 2.55\n"
-          subject.import_rates(:yaml, s)
+          subject.import_rates(:yaml, s, :foo => 1)
         end
 
-        it "doesn't use mutex if requested not to" do
-          expect(subject.store.instance_variable_get(:@mutex)).not_to receive(:synchronize)
-          s = "--- \nUSD_TO_EUR: 1.25\nUSD_TO_JPY: 2.55\n"
-          subject.import_rates(:yaml, s, :without_mutex => true)
-        end
       end
 
       describe "#marshal_dump" do

--- a/spec/rates_store/memory_spec.rb
+++ b/spec/rates_store/memory_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Money::RatesStore::Memory do
+  let(:subject) { described_class.new }
+
+  describe '#add_rate and #get_rate' do
+    it 'stores rate in memory' do
+      expect(subject.add_rate('USD', 'CAD', 0.9)).to eql 0.9
+      expect(subject.get_rate('USD', 'CAD')).to eql 0.9
+    end
+  end
+
+  describe 'add_rate' do
+    it "uses a mutex by default" do
+      expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
+      subject.add_rate('USD', 'EUR', 1.25)
+    end
+
+    it "doesn't use mutex if requested not to" do
+      expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
+      subject.add_rate('USD', 'EUR', 1.25, :without_mutex => true)
+    end
+  end
+
+  describe '#rates' do
+    before do
+      subject.add_rate("USD", "EUR", 0.788332676)
+      subject.add_rate("EUR", "JPY", 122.631477)
+    end
+
+    it 'indexes added rates' do
+      expect(subject.rates['USD_TO_EUR']).to eq 0.788332676
+      expect(subject.rates['EUR_TO_JPY']).to eq 122.631477
+    end
+  end
+end


### PR DESCRIPTION
## What

Decouple exchange rate storage from `Money::Bank::VariableExchange` by introducing new `Money::RatesStore::Memory` class.

`VariableExchange` uses new class by default but can be instantiated with custom stores as well.

This change should be backwards compatible.

## Why

It should be able to reuse the `VariableExchange` bank with custom storage mechanisms. Ie. in one of my apps I use `ActiveRecord`, but it could also be Redis, the filesystem or others. It shouldn't be necessary to subclass, monkey-patch or otherwise extend `VariableExchange` in order to swap the storage mechanism.

Using composition instead of inheritance allows us to design custom strategies for storing and retrieving exchange rates. Some examples:

```ruby
# Default. Nothing changes
bank = Money::Bank::VariableExchange.new
# Same as...
bank = Money::Bank::VariableExchange.new(Money::RatesStore::Memory.new)

# With active-record class.
# This will work as long as class implements .add_rate and .get_rate
bank = Money::Bank::VariableExchange.new(ExchangeRate)

# Custom Redis store
bank = Money::Bank::VariableExchange.new(MyCustomRedisStore.new(host: 'localhost:6379'))
```

### Custom stores

A custom store only needs to implement `#add_rate` and `#get_rate`.

```ruby
class MyCustomRedisStore
  def initialize(opts)
    @client = Redis.new(opts)
  end

  def add_rate(iso_from, iso_to, rate)
    @redis.set key(iso_from, iso_to), rate
  end

  def get_rate(iso_from, iso_to)
    @redis.get key(iso_from, iso_to)
  end

  private
  def key(a, b)
    [a, b].join('_TO_')
  end
end
```

### Composite stores

In this way we can also implement caching strategies, for example when fetching rates data from 3rd party services:

```ruby
api_store = CustomAPiStore.new('https://openexchangerates.org', 'API_KEY')
cache_store = MemcacheStore.new(api_store, ttl: 3600)

bank = Money::Bank::VariableExchange.new(cache_store)
```

This could simplify and standardise implementing custom backends, as well as make it easier to re-use generic stores (caching, filesystem or database storage, others).

## Notes

The default `RatesStore::Memory` includes functionality to keep data importing and exporting working.
In the future it would be nice extract import/export to a more generic API that works with different kinds of stores.