### PR TITLE
Any state change should be protected by mutex.

### DIFF
--- a/lib/money/rates_store/memory.rb
+++ b/lib/money/rates_store/memory.rb
@@ -67,10 +67,12 @@ class Money
         if @in_transaction || options[:without_mutex]
           block.call self
         else
-          @in_transaction = true
-          result = @mutex.synchronize(&block)
-          @in_transaction = false
-          result
+          @mutex.synchronize do
+            @in_transaction = true
+            result = block.call
+            @in_transaction = false
+            result
+          end
         end
       end
 


### PR DESCRIPTION
## What

I might have introduced a potential threading bug with #516

This change makes sure that ANY change to the state of `RatesStore::Memory` is protected by the mutex.

Banks and stores are essentially globals, so this should prevent race conditions when setting the temporary `@in_transaction` flag.