### PR TITLE
CLP subunit_to_unit change from 1 to 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
  - Changed CHF symbol from 'Fr' to 'CHF'
  - Changed CLF exponent from 0 to 4
  - Changed CLP subunit_to_unit from 1 to 100
+   https://github.com/RubyMoney/google_currency/issues/38
  - Minor fixes to prevent warnings on unused variables and the redefinition of
    `Money.default_currency`
  - `Money#==` changed to acknowledge that 0 in one currency is equal to 0 in any currency.

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -452,7 +452,7 @@
     "disambiguate_symbol": "CLP",
     "alternate_symbols": [],
     "subunit": "Peso",
-    "subunit_to_unit": 1,
+    "subunit_to_unit": 100,
     "symbol_first": true,
     "html_entity": "&#36;",
     "decimal_mark": ",",

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -371,7 +371,7 @@ YAML
       expect(Money.new(1_00,  "USD").amount).to eq 1
       expect(Money.new(1_000, "TND").amount).to eq 1
       expect(Money.new(1,     "VUV").amount).to eq 1
-      expect(Money.new(1,     "CLP").amount).to eq 1
+      expect(Money.new(1_00,     "CLP").amount).to eq 1
     end
 
     it "does not loose precision" do


### PR DESCRIPTION
I ran into a problem converting the CLP to USD using the Google Currency gem, you can read more here: https://github.com/RubyMoney/google_currency/issues/38

The Chilean Peso is improperly converting to other currencies because 1 CLP is not the smallest version of that currency.  There are supposed to be 100 centavos that make up 1 CLP. 

Google's finance site currently shows the conversion rate as 29555 CLP = 47.2880 USD

Inside Ruby, however, I see this:
2.1.3 :067 > Money.new(2955500, "CLP").exchange_to(:USD).to_f
 => 4728.8
2.1.3 :068 > Money.new(29555, "CLP").exchange_to(:USD).to_f
 => 47.28