### PR TITLE
Fix Jordanian Dinar subunit (100 -> 1000).

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -1036,14 +1036,14 @@
     "name": "Jordanian Dinar",
     "symbol": "د.ا",
     "alternate_symbols": ["JD"],
-    "subunit": "Piastre",
-    "subunit_to_unit": 100,
+    "subunit": "Fils",
+    "subunit_to_unit": 1000,
     "symbol_first": true,
     "html_entity": "",
     "decimal_mark": ".",
     "thousands_separator": ",",
     "iso_numeric": "400",
-    "smallest_denomination": 0.5
+    "smallest_denomination": 5
   },
   "jpy": {
     "priority": 6,


### PR DESCRIPTION
According to http://en.wikipedia.org/wiki/ISO_4217 JOD exponent is 3.
Central Bank of Jordan is also states that 1/2 qirsh coin (i.e.
5 fulūs) is still in circulation (http://www.cbj.gov.jo/pages.php?local_type=26&category=14&subcategory=28)