### PR TITLE
Fix Money#== and Ruby 2.2 deprecation warning

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -15,7 +15,7 @@ require "money/money/formatting"
 #
 # @see http://en.wikipedia.org/wiki/Money
 class Money
-  include Money::Arithmetic, Money::Formatting, Comparable
+  include Comparable, Money::Arithmetic, Money::Formatting
   extend Constructors
 
   # Raised when smallest denomination of a currency is not defined

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -21,10 +21,10 @@ class Money
     # @return [Boolean]
     #
     # @example
-    #   Money.new(100) == Money.new(101)           #=> false
-    #   Money.new(100) == Money.new(100)           #=> true
-    #   Money.new(0, "USD") == Money.new(0, "EUR") #=> true
-    def ==(other_money)
+    #   Money.new(100).eql?(Money.new(101))           #=> false
+    #   Money.new(100).eql?(Money.new(100))           #=> true
+    #   Money.new(0, "USD").eql?(Money.new(0, "EUR")) #=> true
+    def eql?(other_money)
       if other_money.respond_to?(:to_money)
         other_money = other_money.to_money
         (fractional == other_money.fractional && currency == other_money.currency) ||
@@ -33,7 +33,6 @@ class Money
         false
       end
     end
-    alias_method :eql?, :==
 
     def <=>(val)
       if val.respond_to?(:to_money)

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -42,8 +42,6 @@ class Money
           val = val.exchange_to(currency)
         end
         fractional <=> val.fractional
-      else
-        raise ArgumentError, "Comparison of #{self.class} with #{val.inspect} failed"
       end
     end
 

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -123,12 +123,11 @@ describe Money do
       expect(Money.new(1_00) <=> klass.new(Money.new(2_00))).to be < 0
     end
 
-    it "raises ArgumentError when used to compare with an object that doesn't respond to #to_money" do
-      expected_message = /Comparison .+ failed/
-      expect{ Money.new(1_00) <=> Object.new  }.to raise_error(ArgumentError, expected_message)
-      expect{ Money.new(1_00) <=> Class       }.to raise_error(ArgumentError, expected_message)
-      expect{ Money.new(1_00) <=> Kernel      }.to raise_error(ArgumentError, expected_message)
-      expect{ Money.new(1_00) <=> /foo/       }.to raise_error(ArgumentError, expected_message)
+    it "returns nil when used to compare with an object that doesn't respond to #to_money" do
+      expect(Money.new(1_00) <=> Object.new).to be_nil
+      expect(Money.new(1_00) <=> Class).to be_nil
+      expect(Money.new(1_00) <=> Kernel).to be_nil
+      expect(Money.new(1_00) <=> /foo/).to be_nil
     end
   end
 


### PR DESCRIPTION
https://github.com/RubyMoney/money/pull/470 made a breaking change to the behavior of `Money#==`. This reverts the change in https://github.com/RubyMoney/money/pull/470 while still removing the deprecation warning.

Ruby 2.2 warns that `<=>` should return `nil` on invalid comparisons rather than raise an error.

Fixes https://github.com/RubyMoney/money/issues/469.