### PR TITLE
Ensure coerce only applies to multiplication

### DIFF
--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -1,4 +1,17 @@
 class Money
+  CoercedNumber = Struct.new(:value) do
+    include Comparable
+
+    def +(other) raise TypeError; end
+    def -(other) raise TypeError; end
+    def /(other) raise TypeError; end
+    def <=>(other) raise TypeError; end
+
+    def *(other)
+      other * value
+    end
+  end
+
   module Arithmetic
 
     # Returns a money object with changed polarity.
@@ -82,6 +95,7 @@ class Money
     #   Money.new(100) + Money.new(100) #=> #<Money @fractional=200>
     def +(other_money)
       return self if other_money == 0
+      raise TypeError unless other_money.is_a?(Money)
       other_money = other_money.exchange_to(currency)
       Money.new(fractional + other_money.fractional, currency)
     end
@@ -99,6 +113,7 @@ class Money
     #   Money.new(100) - Money.new(99) #=> #<Money @fractional=1>
     def -(other_money)
       return self if other_money == 0
+      raise TypeError unless other_money.is_a?(Money)
       other_money = other_money.exchange_to(currency)
       Money.new(fractional - other_money.fractional, currency)
     end
@@ -279,7 +294,7 @@ class Money
     # @example
     #   2 * Money.new(10) #=> #<Money @fractional=20>
     def coerce(other)
-      [self, other]
+      [CoercedNumber.new(other), self]
     end
   end
 end

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -546,5 +546,73 @@ describe Money do
       result = 2 * Money.new(4, 'USD')
       expect(result).to eq Money.new(8, 'USD')
     end
+
+    it "raises TypeError dividing by a Money (unless other is a Money)" do
+      expect {
+        2 / Money.new(2, 'USD')
+      }.to raise_exception(TypeError)
+    end
+
+    it "raises TypeError subtracting by a Money (unless other is a Money)" do
+      expect {
+        2 - Money.new(2, 'USD')
+      }.to raise_exception(TypeError)
+    end
+
+    it "raises TypeError adding by a Money (unless other is a Money)" do
+      expect {
+        2 + Money.new(2, 'USD')
+      }.to raise_exception(TypeError)
+    end
+
+    it "treats multiplication as commutative" do
+      expect {
+        2 * Money.new(2, 'USD')
+      }.to_not raise_exception
+      result = 2 * Money.new(2, 'USD')
+      expect(result).to eq(Money.new(4, 'USD'))
+    end
+
+    it "doesn't work with non-numerics" do
+      expect {
+        "2" * Money.new(2, 'USD')
+      }.to raise_exception(TypeError)
+    end
+
+    it "correctly handles <=>" do
+      expect {
+        2 < Money.new(2, 'USD')
+      }.to raise_exception(TypeError)
+
+      expect {
+        2 > Money.new(2, 'USD')
+      }.to raise_exception(TypeError)
+
+      expect {
+        2 <= Money.new(2, 'USD')
+      }.to raise_exception(TypeError)
+
+      expect {
+        2 >= Money.new(2, 'USD')
+      }.to raise_exception(TypeError)
+
+      expect {
+        2 <=> Money.new(2, 'USD')
+      }.to raise_exception(TypeError)
+    end
+
+    it "raises exceptions for all numeric types, not just Integer" do
+      expect {
+        2.0 / Money.new(2, 'USD')
+      }.to raise_exception(TypeError)
+
+      expect {
+        Rational(2,3) / Money.new(2, 'USD')
+      }.to raise_exception(TypeError)
+
+      expect {
+        BigDecimal(2) / Money.new(2, 'USD')
+      }.to raise_exception(TypeError)
+    end
   end
 end


### PR DESCRIPTION
Resurrected @semmons99's commit from last year, that properly handles coercion for non-`Money` objects. Raises a `TypeError` in cases like `0 - Money.new(1)`, where it otherwise produces a wrong result.

Here's some discussion around this — https://github.com/RubyMoney/money-rails/issues/343