### PR TITLE
Remove `thread_safe` dependency

### DIFF
--- a/lib/money/bank/base.rb
+++ b/lib/money/bank/base.rb
@@ -1,5 +1,3 @@
-require 'thread'
-
 class Money
   # Provides classes that aid in the ability of exchange one currency with
   # another.

--- a/money.gemspec
+++ b/money.gemspec
@@ -26,7 +26,6 @@ Test responsibly :-)
 MSG
 
   s.add_dependency 'i18n', ['>= 0.6.4', '<= 0.7.0']
-  s.add_dependency 'thread_safe', '~> 0.3.5'
 
   s.add_development_dependency "bundler", "~> 1.3"
   s.add_development_dependency "rake"


### PR DESCRIPTION
Hi all,

It seems to me that using the whole `thread_safe` gem for a simple use case is quite an overkill. Here's a quick change that gets rid of the dependency, leveraging a built-in ruby mutex instead.

Also, notice the removal of `self.class.instances[id] = self` on line 263. Because `instances` Hash is initialized with a block, this line is not needed.