### PR TITLE
Allow subclassing money

### DIFF
--- a/lib/money/bank/variable_exchange.rb
+++ b/lib/money/bank/variable_exchange.rb
@@ -108,7 +108,7 @@ class Money
         else
           if rate = get_rate(from.currency, to_currency)
             fractional = calculate_fractional(from, to_currency)
-            Money.new(
+            from.class.new(
               exchange(fractional, rate, &block), to_currency
             )
           else

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -497,7 +497,7 @@ class Money
       left_over.to_i.times { |i| amounts[i % amounts.length] += 1 }
     end
 
-    amounts.collect { |fractional| Money.new(fractional, currency) }
+    amounts.collect { |fractional| self.class.new(fractional, currency) }
   end
 
   # Split money amongst parties evenly without losing pennies.
@@ -535,7 +535,7 @@ class Money
   #
   def round(rounding_mode = self.class.rounding_mode)
     if self.class.infinite_precision
-      Money.new(fractional.round(0, rounding_mode), self.currency)
+      self.class.new(fractional.round(0, rounding_mode), self.currency)
     else
       self
     end
@@ -605,8 +605,8 @@ class Money
   end
 
   def split_flat(num)
-    low = Money.new(fractional / num, currency)
-    high = Money.new(low.fractional + 1, currency)
+    low = self.class.new(fractional / num, currency)
+    high = self.class.new(low.fractional + 1, currency)
 
     remainder = fractional % num
 

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -340,7 +340,7 @@ class Money
   #
   # @return [String]
   def inspect
-    "#<Money fractional:#{fractional} currency:#{currency}>"
+    "#<#{self.class.name} fractional:#{fractional} currency:#{currency}>"
   end
 
   # Returns the amount of money as a string.

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -8,7 +8,7 @@ class Money
     # @example
     #    - Money.new(100) #=> #<Money @fractional=-100>
     def -@
-      Money.new(-fractional, currency)
+      self.class.new(-fractional, currency)
     end
 
     # Checks whether two money objects have the same currency and the same
@@ -83,7 +83,7 @@ class Money
     def +(other_money)
       return self if other_money == 0
       other_money = other_money.exchange_to(currency)
-      Money.new(fractional + other_money.fractional, currency)
+      self.class.new(fractional + other_money.fractional, currency)
     end
 
     # Returns a new Money object containing the difference between the two
@@ -100,7 +100,7 @@ class Money
     def -(other_money)
       return self if other_money == 0
       other_money = other_money.exchange_to(currency)
-      Money.new(fractional - other_money.fractional, currency)
+      self.class.new(fractional - other_money.fractional, currency)
     end
 
     # Multiplies the monetary value with the given number and returns a new
@@ -119,9 +119,9 @@ class Money
     #
     def *(value)
       if value.is_a? Numeric
-        Money.new(fractional * value, currency)
+        self.class.new(fractional * value, currency)
       else
-        raise ArgumentError, "Can't multiply a Money by a #{value.class.name}'s value"
+        raise ArgumentError, "Can't multiply a #{self.class.name} by a #{value.class.name}'s value"
       end
     end
 
@@ -141,10 +141,10 @@ class Money
     #   Money.new(100) / Money.new(10) #=> 10.0
     #
     def /(value)
-      if value.is_a?(Money)
+      if value.is_a?(self.class)
         fractional / as_d(value.exchange_to(currency).fractional).to_f
       else
-        Money.new(fractional / as_d(value), currency)
+        self.class.new(fractional / as_d(value), currency)
       end
     end
 
@@ -182,16 +182,16 @@ class Money
     def divmod_money(val)
       cents = val.exchange_to(currency).cents
       quotient, remainder = fractional.divmod(cents)
-      [quotient, Money.new(remainder, currency)]
+      [quotient, self.class.new(remainder, currency)]
     end
     private :divmod_money
 
     def divmod_other(val)
       if self.class.infinite_precision
         quotient, remainder = fractional.divmod(as_d(val))
-        [Money.new(quotient, currency), Money.new(remainder, currency)]
+        [self.class.new(quotient, currency), self.class.new(remainder, currency)]
       else
-        [div(val), Money.new(fractional.modulo(val), currency)]
+        [div(val), self.class.new(fractional.modulo(val), currency)]
       end
     end
     private :divmod_other
@@ -236,7 +236,7 @@ class Money
       if (fractional < 0 && val < 0) || (fractional > 0 && val > 0)
         self.modulo(val)
       else
-        self.modulo(val) - (val.is_a?(Money) ? val : Money.new(val, currency))
+        self.modulo(val) - (val.is_a?(Money) ? val : self.class.new(val, currency))
       end
     end
 
@@ -247,7 +247,7 @@ class Money
     # @example
     #   Money.new(-100).abs #=> #<Money @fractional=100>
     def abs
-      Money.new(fractional.abs, currency)
+      self.class.new(fractional.abs, currency)
     end
 
     # Test if the money amount is zero.

--- a/lib/money/money/constructors.rb
+++ b/lib/money/money/constructors.rb
@@ -11,7 +11,7 @@ class Money
     #   Money.empty #=> #<Money @fractional=0>
     def empty(currency = default_currency)
       @empty ||= {}
-      @empty[currency] ||= Money.new(0, currency).freeze
+      @empty[currency] ||= new(0, currency).freeze
     end
     alias_method :zero, :empty
 
@@ -28,7 +28,7 @@ class Money
     #   n.cents    #=> 100
     #   n.currency #=> #<Money::Currency id: cad>
     def ca_dollar(cents)
-      Money.new(cents, "CAD")
+      new(cents, "CAD")
     end
     alias_method :cad, :ca_dollar
 
@@ -45,7 +45,7 @@ class Money
     #   n.cents    #=> 100
     #   n.currency #=> #<Money::Currency id: usd>
     def us_dollar(cents)
-      Money.new(cents, "USD")
+      new(cents, "USD")
     end
     alias_method :usd, :us_dollar
 
@@ -61,7 +61,7 @@ class Money
     #   n.cents    #=> 100
     #   n.currency #=> #<Money::Currency id: eur>
     def euro(cents)
-      Money.new(cents, "EUR")
+      new(cents, "EUR")
     end
     alias_method :eur, :euro
 
@@ -77,7 +77,7 @@ class Money
     #   n.fractional    #=> 100
     #   n.currency #=> #<Money::Currency id: gbp>
     def pound_sterling(pence)
-      Money.new(pence, "GBP")
+      new(pence, "GBP")
     end
     alias_method :gbp, :pound_sterling
 

--- a/spec/bank/variable_exchange_spec.rb
+++ b/spec/bank/variable_exchange_spec.rb
@@ -71,6 +71,11 @@ class Money
               amount = 10**20
               expect(bank.exchange_with(Money.usd(amount), :EUR)).to eq Money.eur(1.33 * amount)
             end
+
+            it "preserves the class in the result when given a subclass of Money" do
+              special_money_class = Class.new(Money)
+              expect(bank.exchange_with(special_money_class.new(100, 'USD'), 'EUR')).to be_a special_money_class
+            end
           end
         end
 

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -9,6 +9,11 @@ describe Money do
       expect((- Money.new(1))).to  eq Money.new(-1)
       expect((- Money.new(-1))).to eq Money.new(1)
     end
+
+    it "preserves the class in the result when using a subclass of Money" do
+      special_money_class = Class.new(Money)
+      expect(- special_money_class.new(10_00)).to be_a special_money_class
+    end
   end
 
   describe "#==" do
@@ -173,6 +178,11 @@ describe Money do
     it "adds Fixnum 0 to money and returns the same ammount" do
       expect(Money.new(10_00) + 0).to eq Money.new(10_00)
     end
+
+    it "preserves the class in the result when using a subclass of Money" do
+      special_money_class = Class.new(Money)
+      expect(special_money_class.new(10_00, "USD") + Money.new(90, "USD")).to be_a special_money_class
+    end
   end
 
   describe "#-" do
@@ -188,6 +198,11 @@ describe Money do
 
     it "subtract Fixnum 0 to money and returns the same ammount" do
       expect(Money.new(10_00) - 0).to eq Money.new(10_00)
+    end
+
+    it "preserves the class in the result when using a subclass of Money" do
+      special_money_class = Class.new(Money)
+      expect(special_money_class.new(10_00, "USD") - Money.new(90, "USD")).to be_a special_money_class
     end
   end
 
@@ -215,6 +230,11 @@ describe Money do
     it "does not multiply Money by an object which is NOT a number" do
       expect { Money.new( 10, :USD) *  'abc' }.to raise_error(ArgumentError)
     end
+
+    it "preserves the class in the result when using a subclass of Money" do
+      special_money_class = Class.new(Money)
+      expect(special_money_class.new(10_00, "USD") * 2).to be_a special_money_class
+    end
   end
 
   describe "#/" do
@@ -228,6 +248,11 @@ describe Money do
       ts.each do |t|
         expect(t[:a] / t[:b]).to eq t[:c]
       end
+    end
+
+    it "preserves the class in the result when using a subclass of Money" do
+      special_money_class = Class.new(Money)
+      expect(special_money_class.new(10_00, "USD") / 2).to be_a special_money_class
     end
 
     context 'rounding preference' do
@@ -412,6 +437,16 @@ describe Money do
         end
       end
     end
+
+    it "preserves the class in the result when dividing a subclass of Money by a fixnum" do
+      special_money_class = Class.new(Money)
+      expect(special_money_class.new(10_00, "USD").divmod(4).last).to be_a special_money_class
+    end
+
+    it "preserves the class in the result when using a subclass of Money by a subclass of Money" do
+      special_money_class = Class.new(Money)
+      expect(special_money_class.new(10_00, "USD").divmod(special_money_class.new(4_00)).last).to be_a special_money_class
+    end
   end
 
   describe "#modulo" do
@@ -511,6 +546,11 @@ describe Money do
       n = Money.new(-1, :USD)
       expect(n.abs).to eq Money.new( 1, :USD)
       expect(n).to     eq Money.new(-1, :USD)
+    end
+
+    it "preserves the class in the result when using a subclass of Money" do
+      special_money_class = Class.new(Money)
+      expect(special_money_class.new(-1).abs).to be_a special_money_class
     end
   end
 

--- a/spec/money/constructors_spec.rb
+++ b/spec/money/constructors_spec.rb
@@ -20,12 +20,22 @@ describe Money::Constructors do
     it "doesn't allow money to be modified for a currency" do
       expect(Money.empty).to be_frozen
     end
+
+    it "instantiates a subclass when inheritance is used" do
+      special_money_class = Class.new(Money)
+      expect(special_money_class.empty).to be_a special_money_class
+    end
   end
 
 
   describe "::zero" do
     subject { Money.zero }
     it { is_expected.to eq Money.empty }
+
+    it "instantiates a subclass when inheritance is used" do
+      special_money_class = Class.new(Money)
+      expect(special_money_class.zero).to be_a special_money_class
+    end
   end
 
 
@@ -36,6 +46,11 @@ describe Money::Constructors do
 
     it "is aliased to ::cad" do
       expect(Money.cad(50)).to eq Money.ca_dollar(50)
+    end
+
+    it "instantiates a subclass when inheritance is used" do
+      special_money_class = Class.new(Money)
+      expect(special_money_class.ca_dollar(0)).to be_a special_money_class
     end
   end
 
@@ -48,6 +63,11 @@ describe Money::Constructors do
     it "is aliased to ::usd" do
       expect(Money.usd(50)).to eq Money.us_dollar(50)
     end
+
+    it "instantiates a subclass when inheritance is used" do
+      special_money_class = Class.new(Money)
+      expect(special_money_class.us_dollar(0)).to be_a special_money_class
+    end
   end
 
 
@@ -59,6 +79,11 @@ describe Money::Constructors do
     it "is aliased to ::eur" do
       expect(Money.eur(50)).to eq Money.euro(50)
     end
+
+    it "instantiates a subclass when inheritance is used" do
+      special_money_class = Class.new(Money)
+      expect(special_money_class.euro(0)).to be_a special_money_class
+    end
   end
 
 
@@ -69,6 +94,11 @@ describe Money::Constructors do
 
     it "is aliased to ::gbp" do
       expect(Money.gbp(50)).to eq Money.pound_sterling(50)
+    end
+
+    it "instantiates a subclass when inheritance is used" do
+      special_money_class = Class.new(Money)
+      expect(special_money_class.pound_sterling(0)).to be_a special_money_class
     end
   end
 


### PR DESCRIPTION
I can see from the spec previously included that it was desired that subclassing would work, but the implementation was incomplete.

Scenario:

    class SpecialMoney < Money
      # ...
    end

    SpecialMoney.new(val1) + SpecialMoney.new(val2)
    # => returns Money instead of SpecialMoney, thus losing the
    # SpecialMoney extensions.

All specs remain green, and it works as expected. New specs have been added to attempt to prevent regression.