### PR TITLE
Do not attempt to convert value being compared

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -90,6 +90,7 @@ Pavan Sudarshan
 pconnor
 Pedro Nascimento
 Pelle Braendgaard
+Peter Rhoades
 Phil Cohen
 pivotal-cloudplanner
 Prathan Thananart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## Next release
-
-TBD
+ - Remove implicit conversion of values being compared. Only accept `Money` and
+   subclasses of `Money` for comparisons.
 
 ## 6.6.0
  - Fixed VariableExchange#exchange_with for big numbers.

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -11,22 +11,23 @@ class Money
       self.class.new(-fractional, currency)
     end
 
-    # Checks whether two money objects have the same currency and the same
-    # amount. If money objects have a different currency it will only be true
-    # if the amounts are both zero. Checks against objects that do not respond
-    # to #to_money, in which case, it will always return false.
+    # Checks whether two Money objects have the same currency and the same
+    # amount. If Money objects have a different currency it will only be true
+    # if the amounts are both zero. Checks against objects that are not Money or
+    # a subclass will always return false.
     #
     # @param [Money] other_money Value to compare with.
     #
     # @return [Boolean]
     #
     # @example
-    #   Money.new(100).eql?(Money.new(101))           #=> false
-    #   Money.new(100).eql?(Money.new(100))           #=> true
-    #   Money.new(0, "USD").eql?(Money.new(0, "EUR")) #=> true
+    #   Money.new(100).eql?(Money.new(101))                #=> false
+    #   Money.new(100).eql?(Money.new(100))                #=> true
+    #   Money.new(100, "USD").eql?(Money.new(100, "GBP"))  #=> false
+    #   Money.new(0, "USD").eql?(Money.new(0, "EUR"))      #=> true
+    #   Money.new(100).eql?("1.00")                        #=> false
     def eql?(other_money)
-      if other_money.respond_to?(:to_money)
-        other_money = other_money.to_money
+      if other_money.is_a?(Money)
         (fractional == other_money.fractional && currency == other_money.currency) ||
           (fractional == 0 && other_money.fractional == 0)
       else
@@ -34,9 +35,9 @@ class Money
       end
     end
 
+    # Compares two Money objects
     def <=>(val)
-      if val.respond_to?(:to_money)
-        val = val.to_money unless val.respond_to?(:fractional)
+      if val.is_a?(Money)
         if fractional != 0 && val.fractional != 0 && currency != val.currency
           val = val.exchange_to(currency)
         end

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -31,7 +31,7 @@ describe Money do
       expect(Money.new(0, "USD")).to eq Money.new(0, "JPY")
     end
 
-    it "returns false if used to compare with an object that doesn't respond to #to_money" do
+    it "returns false if used to compare with an object that doesn't inherit from Money" do
       expect(Money.new(1_00, "USD")).not_to eq Object.new
       expect(Money.new(1_00, "USD")).not_to eq Class
       expect(Money.new(1_00, "USD")).not_to eq Kernel
@@ -39,21 +39,13 @@ describe Money do
       expect(Money.new(1_00, "USD")).not_to eq nil
     end
 
-    it "can be used to compare with an object that responds to #to_money" do
-      klass = Class.new do
-        def initialize(money)
-          @money = money
-        end
+    it "can be used to compare with an object that inherits from Money" do
+      klass = Class.new(Money)
 
-        def to_money
-          @money
-        end
-      end
-
-      expect(Money.new(1_00, "USD")).to     eq klass.new(Money.new(1_00, "USD"))
-      expect(Money.new(2_50, "USD")).to     eq klass.new(Money.new(2_50, "USD"))
-      expect(Money.new(2_50, "USD")).not_to eq klass.new(Money.new(3_00, "USD"))
-      expect(Money.new(1_00, "GBP")).not_to eq klass.new(Money.new(1_00, "USD"))
+      expect(Money.new(1_00, "USD")).to     eq klass.new(1_00, "USD")
+      expect(Money.new(2_50, "USD")).to     eq klass.new(2_50, "USD")
+      expect(Money.new(2_50, "USD")).not_to eq klass.new(3_00, "USD")
+      expect(Money.new(1_00, "GBP")).not_to eq klass.new(1_00, "USD")
     end
   end
 
@@ -65,7 +57,7 @@ describe Money do
       expect(Money.new(1_00, "USD").eql?(Money.new(99_00, "EUR"))).to be false
     end
 
-    it "returns false if used to compare with an object that doesn't respond to #to_money" do
+    it "returns false if used to compare with an object that doesn't inherit from Money" do
       expect(Money.new(1_00, "USD").eql?(Object.new)).to  be false
       expect(Money.new(1_00, "USD").eql?(Class)).to       be false
       expect(Money.new(1_00, "USD").eql?(Kernel)).to      be false
@@ -73,21 +65,13 @@ describe Money do
       expect(Money.new(1_00, "USD").eql?(nil)).to         be false
     end
 
-    it "can be used to compare with an object that responds to #to_money" do
-      klass = Class.new do
-        def initialize(money)
-          @money = money
-        end
+    it "can be used to compare with an object that inherits from Money" do
+      klass = Class.new(Money)
 
-        def to_money
-          @money
-        end
-      end
-
-      expect(Money.new(1_00, "USD").eql?(klass.new(Money.new(1_00, "USD")))).to be true
-      expect(Money.new(2_50, "USD").eql?(klass.new(Money.new(2_50, "USD")))).to be true
-      expect(Money.new(2_50, "USD").eql?(klass.new(Money.new(3_00, "USD")))).to be false
-      expect(Money.new(1_00, "GBP").eql?(klass.new(Money.new(1_00, "USD")))).to be false
+      expect(Money.new(1_00, "USD").eql?(klass.new(1_00, "USD"))).to be true
+      expect(Money.new(2_50, "USD").eql?(klass.new(2_50, "USD"))).to be true
+      expect(Money.new(2_50, "USD").eql?(klass.new(3_00, "USD"))).to be false
+      expect(Money.new(1_00, "GBP").eql?(klass.new(1_00, "USD"))).to be false
     end
   end
 
@@ -112,23 +96,15 @@ describe Money do
       expect(Money.new(100_00, "USD") <=> target).to be > 0
     end
 
-    it "can be used to compare with an object that responds to #to_money" do
-      klass = Class.new do
-        def initialize(money)
-          @money = money
-        end
+    it "can be used to compare with an object that inherits from Money" do
+      klass = Class.new(Money)
 
-        def to_money
-          @money
-        end
-      end
-
-      expect(Money.new(1_00) <=> klass.new(Money.new(1_00))).to eq 0
-      expect(Money.new(1_00) <=> klass.new(Money.new(99))).to be > 0
-      expect(Money.new(1_00) <=> klass.new(Money.new(2_00))).to be < 0
+      expect(Money.new(1_00) <=> klass.new(1_00)).to eq 0
+      expect(Money.new(1_00) <=> klass.new(99)).to be > 0
+      expect(Money.new(1_00) <=> klass.new(2_00)).to be < 0
     end
 
-    it "returns nil when used to compare with an object that doesn't respond to #to_money" do
+    it "returns nil when used to compare with an object that doesn't inherit from Money" do
       expect(Money.new(1_00) <=> Object.new).to be_nil
       expect(Money.new(1_00) <=> Class).to be_nil
       expect(Money.new(1_00) <=> Kernel).to be_nil


### PR DESCRIPTION
When used with [Monetize](https://github.com/RubyMoney/monetize) gem Money can act confusingly when compared with non Money objects due to the conversion with `#to_money`.

```ruby
require 'monetize'

Money.new(100, 'USD') == Money.new(100, 'GBP').to_s
#==> true?

Money.new(100, 'GBP') == 1.0
#==> true?
```

I propose removing this implicit conversion in favour of being explicit with a `Money` in the comparison to avoid confusion and unexpected behaviour. If the object being compared is not a `Money` or a subclass then the comparison should fail.