### PR TITLE
Fix specs not making any assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
    subclasses of `Money` for comparisons.
  - When comparing fails due to `Money::Bank::UnknownRate` `Money#<=>` will now
    return `nil` as `Comparable#==` will not rescue exceptions in the next release.
+ - Fix `Currency` specs for `#exponent` and `#decimal_places` not making assertions.
 
 ## 6.6.0
  - Fixed VariableExchange#exchange_with for big numbers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - When comparing fails due to `Money::Bank::UnknownRate` `Money#<=>` will now
    return `nil` as `Comparable#==` will not rescue exceptions in the next release.
  - Fix `Currency` specs for `#exponent` and `#decimal_places` not making assertions.
+ - Fix a couple of Ruby warnings found in specs.
 
 ## 6.6.0
  - Fixed VariableExchange#exchange_with for big numbers.

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 class Money
   describe Currency do
 
-    FOO = '{ "priority": 1, "iso_code": "FOO", "iso_numeric": "840", "name": "United States Dollar", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 450, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "smallest_denomination": 1 }'
+    FOO = '{ "priority": 1, "iso_code": "FOO", "iso_numeric": "840", "name": "United States Dollar", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 1000, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "smallest_denomination": 1 }'
 
     def register_foo(opts={})
       foo_attrs = JSON.parse(FOO, :symbolize_names => true)
@@ -339,21 +339,21 @@ class Money
 
     describe "#exponent" do
       it "conforms to iso 4217" do
-        Currency.new(:jpy).exponent == 0
-        Currency.new(:usd).exponent == 2
-        Currency.new(:iqd).exponent == 3
+        expect(Currency.new(:jpy).exponent).to eq 0
+        expect(Currency.new(:usd).exponent).to eq 2
+        expect(Currency.new(:iqd).exponent).to eq 3
       end
     end
 
     describe "#decimal_places" do
       it "proper places for known currency" do
-        Currency.new(:mro).decimal_places == 1
-        Currency.new(:usd).decimal_places == 2
+        expect(Currency.new(:mro).decimal_places).to eq 1
+        expect(Currency.new(:usd).decimal_places).to eq 2
       end
 
       it "proper places for custom currency" do
         register_foo
-        Currency.new(:foo).decimal_places == 3
+        expect(Currency.new(:foo).decimal_places).to eq 3
         unregister_foo
       end
     end

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -35,7 +35,7 @@ describe Money do
       expect(Money.new(1_00, "USD")).not_to eq Object.new
       expect(Money.new(1_00, "USD")).not_to eq Class
       expect(Money.new(1_00, "USD")).not_to eq Kernel
-      expect(Money.new(1_00, "USD")).not_to eq /foo/
+      expect(Money.new(1_00, "USD")).not_to eq(/foo/)
       expect(Money.new(1_00, "USD")).not_to eq nil
     end
 

--- a/spec/rates_store/memory_spec.rb
+++ b/spec/rates_store/memory_spec.rb
@@ -47,7 +47,7 @@ describe Money::RatesStore::Memory do
     context 'mutex' do
       it 'uses mutex' do
         expect(subject.instance_variable_get('@mutex')).to receive(:synchronize)
-        subject.transaction{ a = 1}
+        subject.transaction{ 1 + 1 }
       end
 
       it 'wraps block in mutex transaction only once' do
@@ -64,7 +64,7 @@ describe Money::RatesStore::Memory do
 
       it 'does not use mutex' do
         expect(subject.instance_variable_get('@mutex')).not_to receive(:synchronize)
-        subject.transaction{ a = 1}
+        subject.transaction{ 1 + 1 }
       end
     end
   end


### PR DESCRIPTION
While working on the gem I noticed a few Ruby warnings that could be easily fixed and also a couple of specs executing comparisons but not making any assertions.

These were found by running:

```
$ bundle exec rspec --warnings
```

**Side note:** Today I learned Ruby does not like `private` `attr_reader`, the alternative is to raise visibility to `protected` or just use the instance variables. https://bugs.ruby-lang.org/issues/10967