### PR TITLE
Return nil when currency cannot be converted for comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Next release
  - Remove implicit conversion of values being compared. Only accept `Money` and
    subclasses of `Money` for comparisons.
+ - When comparing fails due to `Money::Bank::UnknownRate` `Money#<=>` will now
+   return `nil` as `Comparable#==` will not rescue exceptions in the next release.
 
 ## 6.6.0
  - Fixed VariableExchange#exchange_with for big numbers.

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -35,14 +35,23 @@ class Money
       end
     end
 
-    # Compares two Money objects
-    def <=>(val)
-      if val.is_a?(Money)
-        if fractional != 0 && val.fractional != 0 && currency != val.currency
-          val = val.exchange_to(currency)
+    # Compares two Money objects. If money objects have a different currency it
+    # will attempt to convert the currency.
+    #
+    # @param [Money] other_money Value to compare with.
+    #
+    # @return [Fixnum]
+    # @return [nil] when object is not comparable
+    #
+    def <=>(other_money)
+      if other_money.is_a?(Money)
+        if fractional != 0 && other_money.fractional != 0 && currency != other_money.currency
+          other_money = other_money.exchange_to(currency)
         end
-        fractional <=> val.fractional
+        fractional <=> other_money.fractional
       end
+    rescue Money::Bank::UnknownRate
+      nil
     end
 
     # Test if the amount is positive. Returns +true+ if the money amount is

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -96,6 +96,12 @@ describe Money do
       expect(Money.new(100_00, "USD") <=> target).to be > 0
     end
 
+    it "returns nil if currency conversion fails, and therefore cannot be compared" do
+      target = Money.new(200_00, "EUR")
+      expect(target).to receive(:exchange_to).with(Money::Currency.new("USD")).and_raise(Money::Bank::UnknownRate)
+      expect(Money.new(100_00, "USD") <=> target).to be_nil
+    end
+
     it "can be used to compare with an object that inherits from Money" do
       klass = Class.new(Money)
 


### PR DESCRIPTION
In the future Ruby releases `#==` will no longer rescue exceptions and expects `#<=>` to return `nil` if the comparison is inappropriate (because in Money `#==` is provided by [Comparable](http://ruby-doc.org/core-2.2.3/Comparable.html))

I know this has come up in a couple of times before but Ruby is complaining louder in spec output now (because some specs should be breaking and raising `Money::Bank::UnknownRate`).

I guess this follows on from work done in #528