### PR TITLE
Update Travis to use latest MRI Ruby stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.6
-  - 2.2.2
+  - 2.1.7
+  - 2.2.3
   - rbx-2
 script: bundle exec rspec spec
 notifications:


### PR DESCRIPTION
Figure Travis may as well be testing against the latest:

- 2.1.6 => 2.1.7
- 2.2.2 => 2.2.3