### PR TITLE
Fix issue with rounded_infinite_precision not using localised decimal mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
    return `nil` as `Comparable#==` will not rescue exceptions in the next release.
  - Fix `Currency` specs for `#exponent` and `#decimal_places` not making assertions.
  - Fix a couple of Ruby warnings found in specs.
+ - Use `Money#decimal_mark` when formatting with `rounded_infinite_precision` rule
+   set to `true`.
 
 ## 6.6.0
  - Fixed VariableExchange#exchange_with for big numbers.

--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -239,13 +239,13 @@ class Money
       formatted = self.abs.to_s
 
       if rules[:rounded_infinite_precision]
-        formatted.gsub!(/#{currency.decimal_mark}/, '.') unless '.' == currency.decimal_mark
+        formatted.gsub!(/#{decimal_mark}/, '.') unless '.' == decimal_mark
         formatted = ((BigDecimal(formatted) * currency.subunit_to_unit).round / BigDecimal(currency.subunit_to_unit.to_s)).to_s("F")
         formatted.gsub!(/\..*/) do |decimal_part|
           decimal_part << '0' while decimal_part.length < (currency.decimal_places + 1)
           decimal_part
         end
-        formatted.gsub!(/\./, currency.decimal_mark) unless '.' == currency.decimal_mark
+        formatted.gsub!(/\./, decimal_mark) unless '.' == decimal_mark
       end
 
       sign = self.negative? ? '-' : ''

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -569,6 +569,33 @@ describe Money, "formatting" do
           expect(Money.new(BigDecimal.new('100012.5'), "EUR").format(:rounded_infinite_precision => true)).to eq "€1.000,13"
         end
       end
+
+      describe "with i18n = true" do
+        before do
+          Money.use_i18n = true
+          reset_i18n
+          I18n.locale = :de
+          I18n.backend.store_translations(
+              :de,
+              :number => { :currency => { :format => { :delimiter => ".", :separator => "," } } }
+          )
+        end
+
+        after do
+          reset_i18n
+          I18n.locale = :en
+        end
+
+        it 'does round fractional when set to true' do
+          expect(Money.new(BigDecimal.new('12.1'), "USD").format(:rounded_infinite_precision => true)).to eq "$0,12"
+          expect(Money.new(BigDecimal.new('12.5'), "USD").format(:rounded_infinite_precision => true)).to eq "$0,13"
+          expect(Money.new(BigDecimal.new('123.1'), "BHD").format(:rounded_infinite_precision => true)).to eq "ب.د0,123"
+          expect(Money.new(BigDecimal.new('123.5'), "BHD").format(:rounded_infinite_precision => true)).to eq "ب.د0,124"
+          expect(Money.new(BigDecimal.new('100.1'), "USD").format(:rounded_infinite_precision => true)).to eq "$1,00"
+          expect(Money.new(BigDecimal.new('109.5'), "USD").format(:rounded_infinite_precision => true)).to eq "$1,10"
+          expect(Money.new(BigDecimal.new('1'), "MGA").format(:rounded_infinite_precision => true)).to eq "Ar0,2"
+        end
+      end
     end
 
     context "when the monetary value is 0" do


### PR DESCRIPTION
Formatting within this rule used `Currency#decimal_mark`. The problem is this represents the formatting for this currency and ignores any i18n delimiter and separator set by the application.

Fixes issue reported in #545 