### PR TITLE
Add transliteration to currency name search.

### DIFF
--- a/lib/money/currency/heuristics.rb
+++ b/lib/money/currency/heuristics.rb
@@ -53,7 +53,7 @@ class Money
       def currencies_by_name
         {}.tap do |r|
           table.each do |dummy,c|
-            name_parts = c[:name].downcase.split
+            name_parts = I18n.transliterate(c[:name]).downcase.split
             name_parts.each {|part| part.chomp!('.')}
 
             # construct one branch per word


### PR DESCRIPTION
If I try to find a currency like ```Nicaraguan Córdoba``` I can do it with method ```Money::Currency#analyze``` like this:

```ruby
Money::Currency.analyze('Nicaraguan Córdoba')
# => ["NIO"] 
```

But if I use ```Nicaraguan Cordoba``` instead of ```Nicaraguan Córdoba``` I get no results.

```ruby
Money::Currency.analyze('Nicaraguan Cordoba')
# => [] 
```

So, the search tree should first transliterate leaves with ```I18n.transliterate(leaf)``` or something similar.

See line [money/currency/heuristics.rb#L53](https://github.com/RubyMoney/money/blob/master/lib/money/currency/heuristics.rb#L53)

**This code solves the problem**

```ruby
class Money
  class Currency
    module Heuristics

      private

      def currencies_by_name
        {}.tap do |r|
          table.each do |dummy,c|
            name_parts = I18n.transliterate(c[:name]).downcase.split # Here we make a transliterate first
            name_parts.each {|part| part.chomp!('.')}

            # construct one branch per word
            root = r
            while name_part = name_parts.shift
              root = (root[name_part] ||= {})
            end

            # the leaf is a currency
            (root[:value] ||= []) << c
          end
        end
      end

    end
  end
end
```

This PR solves issue #553.