### PR TITLE
Raise TypeError when comparing with non-Money objects

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -118,6 +118,7 @@ Tom Lianza
 tommeier
 Troels Knak-Nielsen
 Tsyren Ochirov
+Victor Shcherbakov
 Wei Zhu
 Zubin Henner
 Бродяной Александр

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
  - Remove implicit conversion of values being compared. Only accept `Money` and
-   subclasses of `Money` for comparisons.
+   subclasses of `Money` for comparisons and raise TypeError otherwise.
  - When comparing fails due to `Money::Bank::UnknownRate` `Money#<=>` will now
    return `nil` as `Comparable#==` will not rescue exceptions in the next release.
  - Fix `Currency` specs for `#exponent` and `#decimal_places` not making assertions.

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -54,17 +54,16 @@ class Money
     # @param [Money] other_money Value to compare with.
     #
     # @return [Fixnum]
-    # @return [nil] when object is not comparable
+    #
+    # @raise [TypeError] when other object is not Money
     #
     def <=>(other_money)
-      if other_money.is_a?(Money)
-        if fractional != 0 && other_money.fractional != 0 && currency != other_money.currency
-          other_money = other_money.exchange_to(currency)
-        end
-        fractional <=> other_money.fractional
+      raise TypeError unless other_money.is_a?(Money)
+      if fractional != 0 && other_money.fractional != 0 && currency != other_money.currency
+        other_money = other_money.exchange_to(currency)
       end
+      fractional <=> other_money.fractional
     rescue Money::Bank::UnknownRate
-      nil
     end
 
     # Test if the amount is positive. Returns +true+ if the money amount is

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -64,6 +64,7 @@ class Money
       end
       fractional <=> other_money.fractional
     rescue Money::Bank::UnknownRate
+      nil
     end
 
     # Test if the amount is positive. Returns +true+ if the money amount is

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -108,11 +108,26 @@ describe Money do
       expect(Money.new(1_00) <=> klass.new(2_00)).to be < 0
     end
 
-    it "returns nil when used to compare with an object that doesn't inherit from Money" do
-      expect(Money.new(1_00) <=> Object.new).to be_nil
-      expect(Money.new(1_00) <=> Class).to be_nil
-      expect(Money.new(1_00) <=> Kernel).to be_nil
-      expect(Money.new(1_00) <=> /foo/).to be_nil
+    it "raises TypeError when used to compare with an object that doesn't inherit from Money" do
+      expect {
+        Money.new(1_00) <=> 100
+      }.to raise_exception(TypeError)
+
+      expect {
+        Money.new(1_00) <=> Object.new
+      }.to raise_exception(TypeError)
+
+      expect {
+        Money.new(1_00) <=> Class
+      }.to raise_exception(TypeError)
+
+      expect {
+        Money.new(1_00) <=> Kernel
+      }.to raise_exception(TypeError)
+
+      expect {
+        Money.new(1_00) <=> /foo/
+      }.to raise_exception(TypeError)
     end
   end
 


### PR DESCRIPTION
This PR should fix the inconsistent behavior when Money.new(100) <=> 1 was giving you nil while 1 <=> Money.new(100) was raising a TypeError. Based on the discussion in #535 I think it was agreed that comparison should raise a TypeError in both cases.

This should fix #563 too.