### PR TITLE
Feature/ruby 2.3.0

### DIFF
--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -104,7 +104,7 @@ class Money
     # @example
     #   Money.new(100) + Money.new(100) #=> #<Money @fractional=200>
     def +(other_money)
-      return self if other_money == 0
+      return self if other_money.zero?
       raise TypeError unless other_money.is_a?(Money)
       other_money = other_money.exchange_to(currency)
       self.class.new(fractional + other_money.fractional, currency)
@@ -122,7 +122,7 @@ class Money
     # @example
     #   Money.new(100) - Money.new(99) #=> #<Money @fractional=1>
     def -(other_money)
-      return self if other_money == 0
+      return self if other_money.zero?
       raise TypeError unless other_money.is_a?(Money)
       other_money = other_money.exchange_to(currency)
       self.class.new(fractional - other_money.fractional, currency)

--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -6,12 +6,12 @@ class Money
         [:thousands_separator, :delimiter, ","],
         [:decimal_mark, :separator, "."]
       ].each do |method, name, character|
-        define_i18n_method(method, name, character)
+        define_i18n_method(base, method, name, character)
       end
     end
 
-    def self.define_i18n_method(method, name, character)
-      define_method(method) do
+    def self.define_i18n_method(base, method, name, character)
+      base.send(:define_method, method, ->{
         if self.class.use_i18n
           begin
             I18n.t name, :scope => "number.currency.format", :raise => true
@@ -21,8 +21,9 @@ class Money
         else
           currency.send(method) || character
         end
-      end
-      alias_method name, method
+      })
+
+      base.send(:alias_method, name, method)
     end
 
     # Creates a formatted price string according to several rules.


### PR DESCRIPTION
This is some changes for compatibility with upcoming Ruby 2.3.0. Don't expect to merge yet, I just want to bring up the discussion and I think some changes could be spit into different patches.

- An other solution for the +/- operators would be doing `other_money == Money.new(0)`, but I think it is more beautiful with simply `.zero?`. I think this change could be merged as it would ?

- The define_method issue is still quite cryptic to me, any other suggestion is welcomed. The news/changelog of Ruby does not indicate something specific about methods now being privates but it seems like it does. Maybe it is an issue on the Ruby side. I can split this change apart if 

There is still an unexpected `TypeError` issue with exchange feature I am looking into.