### PR TITLE
Ensure formatting methods are defined as public with class_eval

### DIFF
--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -6,23 +6,25 @@ class Money
         [:thousands_separator, :delimiter, ","],
         [:decimal_mark, :separator, "."]
       ].each do |method, name, character|
-        define_i18n_method(method, name, character)
+        define_i18n_method(base, method, name, character)
       end
     end
 
-    def self.define_i18n_method(method, name, character)
-      define_method(method) do
-        if self.class.use_i18n
-          begin
-            I18n.t name, :scope => "number.currency.format", :raise => true
-          rescue I18n::MissingTranslationData
-            I18n.t name, :scope =>"number.format", :default => (currency.send(method) || character)
+    def self.define_i18n_method(base, method, name, character)
+      base.class_eval do
+        define_method(method) do
+          if self.class.use_i18n
+            begin
+              I18n.t name, :scope => "number.currency.format", :raise => true
+            rescue I18n::MissingTranslationData
+              I18n.t name, :scope =>"number.format", :default => (currency.send(method) || character)
+            end
+          else
+            currency.send(method) || character
           end
-        else
-          currency.send(method) || character
         end
+        alias_method name, method
       end
-      alias_method name, method
     end
 
     # Creates a formatted price string according to several rules.


### PR DESCRIPTION
I found an other way to fix this issue by working inside a `base.class_eval` block rather than calling private methods on the base, which I think is more standard/clean way to do this.

Fixes an issue on Ruby 2.3, when calling those dynamically defined methods we get a
NoMethodError (private method `separator' called for #<Money fractional:0 currency:USD>).