### PR TITLE
Allow focus filter in specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ I18n.enforce_available_locales = false
 
 RSpec.configure do |c|
   c.order = :random
+  c.filter_run :focus
+  c.run_all_when_everything_filtered = true
 end
 
 def reset_i18n


### PR DESCRIPTION
Much easier to debug stuff with a focus flag available in rspecs. 

For examples see https://www.relishapp.com/rspec/rspec-core/v/3-4/docs/filtering/inclusion-filters