### PR TITLE
Update <=> to return nil if the comparison is inappropriate

### DIFF
--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -58,7 +58,7 @@ class Money
     # @raise [TypeError] when other object is not Money
     #
     def <=>(other_money)
-      raise TypeError unless other_money.is_a?(Money)
+      return nil unless other_money.is_a?(Money)
       if fractional != 0 && other_money.fractional != 0 && currency != other_money.currency
         other_money = other_money.exchange_to(currency)
       end

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -109,25 +109,15 @@ describe Money do
     end
 
     it "raises TypeError when used to compare with an object that doesn't inherit from Money" do
-      expect {
-        Money.new(1_00) <=> 100
-      }.to raise_exception(TypeError)
+      expect(Money.new(1_00) <=> 100).to be_nil
 
-      expect {
-        Money.new(1_00) <=> Object.new
-      }.to raise_exception(TypeError)
+      expect(Money.new(1_00) <=> Object.new).to be_nil
 
-      expect {
-        Money.new(1_00) <=> Class
-      }.to raise_exception(TypeError)
+      expect(Money.new(1_00) <=> Class).to be_nil
 
-      expect {
-        Money.new(1_00) <=> Kernel
-      }.to raise_exception(TypeError)
+      expect(Money.new(1_00) <=> Kernel).to be_nil
 
-      expect {
-        Money.new(1_00) <=> /foo/
-      }.to raise_exception(TypeError)
+      expect(Money.new(1_00) <=> /foo/).to be_nil
     end
   end
 


### PR DESCRIPTION
Comparable#== no more rescue exceptions of #<=> in ruby >= 2.3

@see https://bugs.ruby-lang.org/issues/7688 and #576 

This change is backward compatible and fix the last known issue with 2.3.0-preview2.