### PR TITLE
Drop support for Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.7
   - 2.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next release
+ - Drop support for Ruby 1.9.3
  - Changed `Money#<=>` to return `nil` if the comparison is inappropriate. (#584)
  - Remove implicit conversion of values being compared. Only accept `Money` and
    subclasses of `Money` for comparisons and raise TypeError otherwise.


### PR DESCRIPTION
Ruby 1.9.3 has not been supported since 23 Feb 2015.
So, I think money gem finishes to support Ruby 1.9.3.

@semmons99 What do you think about it?