### PR TITLE
fix smallest_denomination for BYR

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -381,7 +381,7 @@
     "decimal_mark": ",",
     "thousands_separator": " ",
     "iso_numeric": "974",
-    "smallest_denomination": 50
+    "smallest_denomination": 100
   },
   "bzd": {
     "priority": 100,


### PR DESCRIPTION
there is a new smallest denomination in Belarus since July 1, 2015, when 50 BYR coupon was annulled