### PR TITLE
Sort the AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,7 @@
 Abhay Kumar
 Adrian Longley
-Alex Speller
 Alexander Ross
+Alex Speller
 Andreas Loupasakis
 Andrei
 Andrew White
@@ -23,18 +23,19 @@ Choongmin Lee
 Chris Kampmeier
 Christian Billen
 Clarke Brunsdon
-Dave Kroondyk
 Daniel Sherson
+Dave Kroondyk
 Doug Droper
+Douglas Miller
 Ed Saunders
 Edwin Vlieg
 Eloy
 Evan Alter
 Exoth
 Filipe Goncalves
+Francisco Trindade
 François Beausoleil
 François Klingler
-Francisco Trindade
 Gabriel Gilder
 Gee-Hsien Chuang
 George Millo
@@ -48,16 +49,16 @@ James Hunt
 Jean-Louis Giordano
 Jean-Philippe Doyle
 Jell
-Jeremy McNevin
 Jérémy Lecour
+Jeremy McNevin
 Jesse Cooke
 Jim Kingdon
 John Duff
 John Gakos
 Jonathon M. Abbott
 Josh Delsman
-Joshua Clayton
 Josh Hepworth
+Joshua Clayton
 Julien Boyer
 Kaleem Ullah
 Kenichi Kamiya
@@ -69,11 +70,11 @@ Marco Otte-Witte
 Mateus Gomes
 Mateusz Wolsza
 Matias Korhonen
-Matt Jankowski
 Matthew McEachen
+Matt Jankowski
 Max Melentiev
-Michael J. Cohen
 Michael Irwin
+Michael J. Cohen
 Michael Reinsch
 Michael Rodrigues
 Mikael Wikman
@@ -86,8 +87,8 @@ Olek Janiszewski
 Orien Madgwick
 Paul McMahon
 Paulo Diniz
-Pavel Gabriel
 Pavan Sudarshan
+Pavel Gabriel
 pconnor
 Pedro Nascimento
 Pelle Braendgaard
@@ -99,15 +100,12 @@ Robert Starsi
 Romain Gérard
 Ryan Bigg
 sankaranarayanan
-Semyon Perepelitsa
 Scott Pierce
+Semyon Perepelitsa
 Shane Emmons
 Simone Carletti
 Spencer Rinehart
 Steve Morris
-Yok
-Yuri Sidorov
-Yuusuke Takizawa
 Thomas E Enebo
 Thomas Weymuth
 Ticean Bennett
@@ -121,6 +119,8 @@ Troels Knak-Nielsen
 Tsyren Ochirov
 Victor Shcherbakov
 Wei Zhu
+Yok
+Yuri Sidorov
+Yuusuke Takizawa
 Zubin Henner
 Бродяной Александр
-Douglas Miller


### PR DESCRIPTION
Some entries were simply in the wrong place, eg Douglas Miller as the
last entry of the file.

Also, all the authors beginning in 'Y' were previously between 'S' and 'T'.