### PR TITLE
Fix simulated output of major_currencies and all_currencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ def all_currencies(hash)
 end
 
 major_currencies(Money::Currency.table)
-# => [ :usd, :eur, :bgp, :cad ]
+# => [:usd, :eur, :gbp, :aud, :cad, :jpy]
 
 all_currencies(Money::Currency.table)
-# => [ :aed, :afn, all, ... ]
+# => [:aed, :afn, :all, ...]
 ```
 
 ### Default Currency


### PR DESCRIPTION
Corrected output to match the output of running the commands in `irb`.

major_currencies:
* corrected misspelling of :gbp.
* Added missing :aud and :jpy

all_currencies:
* output corrected to include ':' character before 'all' currency code