### PR TITLE
Fix commutative property issue

### DIFF
--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -2,13 +2,23 @@ class Money
   CoercedNumber = Struct.new(:value) do
     include Comparable
 
-    def +(other) raise TypeError; end
-    def -(other) raise TypeError; end
+    def +(other)
+      return other if value.zero?
+      raise TypeError
+    end
+
+    def -(other)
+      return -other if value.zero?
+      raise TypeError
+    end
+
     def /(other) raise TypeError; end
-    def <=>(other) raise TypeError; end
 
     def *(other)
       other * value
+    end
+
+    def <=>(other)
     end
   end
 

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -607,23 +607,21 @@ describe Money do
     it "correctly handles <=>" do
       expect {
         2 < Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_exception(ArgumentError)
 
       expect {
         2 > Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_exception(ArgumentError)
 
       expect {
         2 <= Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_exception(ArgumentError)
 
       expect {
         2 >= Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_exception(ArgumentError)
 
-      expect {
-        2 <=> Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      expect(2 <=> Money.new(2, 'USD')).to be_nil
     end
 
     it "raises exceptions for all numeric types, not just Integer" do


### PR DESCRIPTION
## Was

```ruby
Money.new(1, 'USD') - 0   # <Money fractional:1 currency:USD>
0 - Money.new(1, 'USD')   # TypeError: TypeError

Money.new(1, 'USD') + 0   # <Money fractional:1 currency:USD>
0 + Money.new(1, 'USD')   # TypeError: TypeError

Money.new(1, 'USD') <=> 0   # nil
0 <=> Money.new(1, 'USD')   # TypeError: TypeError
```
## Now

```ruby
Money.new(1, 'USD') - 0   # <Money fractional:1 currency:USD>
0 - Money.new(1, 'USD')   # <Money fractional:-1 currency:USD>

Money.new(1, 'USD') + 0   # <Money fractional:1 currency:USD>
0 + Money.new(1, 'USD')   # <Money fractional:1 currency:USD>

Money.new(1, 'USD') <=> 0   # nil
0 <=> Money.new(1, 'USD')   # nil
```