### PR TITLE
Fix coercion issues

### DIFF
--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -52,14 +52,14 @@ class Money
     #
     # @raise [TypeError] when other object is not Money
     #
-    def <=>(other_money)
-      return nil unless other_money.is_a?(Money)
-      if fractional != 0 && other_money.fractional != 0 && currency != other_money.currency
-        other_money = other_money.exchange_to(currency)
+    def <=>(other)
+      if other.respond_to?(:zero?) && other.zero?
+        return other.is_a?(CoercedNumeric) ? 0 <=> fractional : fractional <=> 0
       end
-      fractional <=> other_money.fractional
+      return unless other.is_a?(Money)
+      other = other.exchange_to(currency) if nonzero? && currency != other.currency
+      fractional <=> other.fractional
     rescue Money::Bank::UnknownRate
-      nil
     end
 
     # Test if the amount is positive. Returns +true+ if the money amount is

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -108,16 +108,18 @@ describe Money do
       expect(Money.new(1_00) <=> klass.new(2_00)).to be < 0
     end
 
-    it "raises TypeError when used to compare with an object that doesn't inherit from Money" do
+    it "returns nill when comparing with an object that doesn't inherit from Money" do
       expect(Money.new(1_00) <=> 100).to be_nil
-
       expect(Money.new(1_00) <=> Object.new).to be_nil
-
       expect(Money.new(1_00) <=> Class).to be_nil
-
       expect(Money.new(1_00) <=> Kernel).to be_nil
-
       expect(Money.new(1_00) <=> /foo/).to be_nil
+    end
+
+    it 'compares with numeric 0' do
+      expect(Money.usd(1) < 0).to eq false
+      expect(Money.usd(1) > 0.0).to eq true
+      expect(Money.usd(0) >= 0.0).to eq true
     end
   end
 
@@ -622,6 +624,12 @@ describe Money do
       }.to raise_exception(ArgumentError)
 
       expect(2 <=> Money.new(2, 'USD')).to be_nil
+    end
+
+    it 'compares with numeric 0' do
+      expect(0 < Money.usd(1)).to eq true
+      expect(0.0 > Money.usd(1)).to eq false
+      expect(0.0 >= Money.usd(0)).to eq true
     end
 
     it "raises exceptions for all numeric types, not just Integer" do

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -205,15 +205,15 @@ describe Money do
     end
 
     it "does not multiply Money by Money (same currency)" do
-      expect { Money.new( 10, :USD) * Money.new( 4, :USD) }.to raise_error(ArgumentError)
+      expect { Money.new(10, :USD) * Money.new(4, :USD) }.to raise_error(TypeError)
     end
 
     it "does not multiply Money by Money (different currency)" do
-      expect { Money.new( 10, :USD) * Money.new( 4, :EUR) }.to raise_error(ArgumentError)
+      expect { Money.new(10, :USD) * Money.new(4, :EUR) }.to raise_error(TypeError)
     end
 
     it "does not multiply Money by an object which is NOT a number" do
-      expect { Money.new( 10, :USD) *  'abc' }.to raise_error(ArgumentError)
+      expect { Money.new(10, :USD) *  'abc' }.to raise_error(TypeError)
     end
 
     it "preserves the class in the result when using a subclass of Money" do
@@ -607,23 +607,21 @@ describe Money do
     it "correctly handles <=>" do
       expect {
         2 < Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_exception(ArgumentError)
 
       expect {
         2 > Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_exception(ArgumentError)
 
       expect {
         2 <= Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_exception(ArgumentError)
 
       expect {
         2 >= Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_exception(ArgumentError)
 
-      expect {
-        2 <=> Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      expect(2 <=> Money.new(2, 'USD')).to be_nil
     end
 
     it "raises exceptions for all numeric types, not just Integer" do


### PR DESCRIPTION
Avoid duplication of arithmethic methods for Money and coerced Numeric,
treat them as fully commutative operations.

See #606 