### PR TITLE
Comparing number to numeric now works

### DIFF
--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -58,6 +58,9 @@ class Money
     # @raise [TypeError] when other object is not Money
     #
     def <=>(other_money)
+      if other_money.is_a? Numeric
+        other_money = Money.new(other_money, currency)
+      end
       return nil unless other_money.is_a?(Money)
       if fractional != 0 && other_money.fractional != 0 && currency != other_money.currency
         other_money = other_money.exchange_to(currency)

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -58,9 +58,7 @@ class Money
     # @raise [TypeError] when other object is not Money
     #
     def <=>(other_money)
-      if other_money.is_a? Numeric
-        other_money = Money.new(other_money, currency)
-      end
+      return fractional <=> other_money if other_money.is_a?(Numeric)
       return nil unless other_money.is_a?(Money)
       if fractional != 0 && other_money.fractional != 0 && currency != other_money.currency
         other_money = other_money.exchange_to(currency)

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -74,6 +74,12 @@ describe Money do
   end
 
   describe "#<=>" do
+
+    it "compares to numeric" do
+      expect(Money.new(1)).to be > 0
+      expect(Money.new(1)).to be < 2
+    end
+
     it "compares the two object amounts (same currency)" do
       expect((Money.new(1_00, "USD") <=> Money.new(1_00, "USD"))).to eq 0
       expect((Money.new(1_00, "USD") <=> Money.new(99, "USD"))).to be > 0
@@ -109,8 +115,6 @@ describe Money do
     end
 
     it "raises TypeError when used to compare with an object that doesn't inherit from Money" do
-      expect(Money.new(1_00) <=> 100).to be_nil
-
       expect(Money.new(1_00) <=> Object.new).to be_nil
 
       expect(Money.new(1_00) <=> Class).to be_nil


### PR DESCRIPTION
This PR address the questions raised on the issue [604](https://github.com/RubyMoney/money/issues/604), it only allows Money objects to be compared to numeric values. It does not address the coercion issue (https://github.com/RubyMoney/money/pull/607/files)

```ruby
Money.new(1) > 0
=> true
```