### PR TITLE
fix symbol for Danish Krone (DKK)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next release
+- Changed DKK symbol from 'kr' to 'kr.'
+
 ## 6.7.0
  - Changed `Money#<=>` to return `nil` if the comparison is inappropriate. (#584)
  - Remove implicit conversion of values being compared. Only accept `Money` and

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -604,7 +604,7 @@
     "priority": 100,
     "iso_code": "DKK",
     "name": "Danish Krone",
-    "symbol": "kr",
+    "symbol": "kr.",
     "disambiguate_symbol": "DKK",
     "alternate_symbols": [",-"],
     "subunit": "Øre",

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -435,7 +435,7 @@ describe Money, "formatting" do
 
       specify "should fallback to symbol if entity is not available" do
         string = Money.new(570, 'DKK').format(:html => true)
-        expect(string).to eq "5,70 kr"
+        expect(string).to eq "5,70 kr."
       end
     end
 
@@ -662,7 +662,7 @@ describe Money, "formatting" do
     it "returns ambiguous signs when disambiguate is not set" do
       expect(Money.new(1999_98, "USD").format).to eq("$1,999.98")
       expect(Money.new(1999_98, "CAD").format).to eq("$1,999.98")
-      expect(Money.new(1999_98, "DKK").format).to eq("1.999,98 kr")
+      expect(Money.new(1999_98, "DKK").format).to eq("1.999,98 kr.")
       expect(Money.new(1999_98, "NOK").format).to eq("1.999,98 kr")
       expect(Money.new(1999_98, "SEK").format).to eq("1 999,98 kr")
     end
@@ -670,7 +670,7 @@ describe Money, "formatting" do
     it "returns ambiguous signs when disambiguate is false" do
       expect(Money.new(1999_98, "USD").format(disambiguate: false)).to eq("$1,999.98")
       expect(Money.new(1999_98, "CAD").format(disambiguate: false)).to eq("$1,999.98")
-      expect(Money.new(1999_98, "DKK").format(disambiguate: false)).to eq("1.999,98 kr")
+      expect(Money.new(1999_98, "DKK").format(disambiguate: false)).to eq("1.999,98 kr.")
       expect(Money.new(1999_98, "NOK").format(disambiguate: false)).to eq("1.999,98 kr")
       expect(Money.new(1999_98, "SEK").format(disambiguate: false)).to eq("1 999,98 kr")
     end


### PR DESCRIPTION
We've had some customers write in and inform us that the currency symbol for Danish Krone is `kr.` and not `kr`. Wikipedia [agrees](https://en.wikipedia.org/wiki/Danish_krone). That's all! :heart: 