### PR TITLE
fix Money::Formatting#format docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 - Changed DKK symbol from 'kr' to 'kr.'
+- Improved Money::Formatting#format docs
 
 ## 6.7.0
  - Changed `Money#<=>` to return `nil` if the comparison is inappropriate. (#584)

--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -24,7 +24,7 @@ class Money
     #   Money.us_dollar(85).format(:with_currency => true)  #=> "$0.85 USD"
     #
     # @option rules [Boolean] :rounded_infinite_precision (false) Whether the
-    #  amount of money should be rounded when using infinite_precision
+    #  amount of money should be rounded when using {infinite_precision}
     #
     # @example
     #   Money.us_dollar(100.1).format #=> "$1.001"

--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -7,7 +7,7 @@ class Money
     #
     # @return [String]
     #
-    # @option *rules [Boolean, String] :display_free (false) Whether a zero
+    # @option rules [Boolean, String] :display_free (false) Whether a zero
     #  amount of money should be formatted of "free" or as the supplied string.
     #
     # @example
@@ -15,7 +15,7 @@ class Money
     #   Money.us_dollar(0).format(:display_free => "gratis") #=> "gratis"
     #   Money.us_dollar(0).format                            #=> "$0.00"
     #
-    # @option *rules [Boolean] :with_currency (false) Whether the currency name
+    # @option rules [Boolean] :with_currency (false) Whether the currency name
     #  should be appended to the result string.
     #
     # @example
@@ -23,7 +23,7 @@ class Money
     #   Money.ca_dollar(100).format(:with_currency => true) #=> "$1.00 CAD"
     #   Money.us_dollar(85).format(:with_currency => true)  #=> "$0.85 USD"
     #
-    # @option *rules [Boolean] :rounded_infinite_precision (false) Whether the
+    # @option rules [Boolean] :rounded_infinite_precision (false) Whether the
     #  amount of money should be rounded when using infinite_precision
     #
     # @example
@@ -31,20 +31,20 @@ class Money
     #   Money.us_dollar(100.1).format(:rounded_infinite_precision => true) #=> "$1"
     #   Money.us_dollar(100.9).format(:rounded_infinite_precision => true) #=> "$1.01"
     #
-    # @option *rules [Boolean] :no_cents (false) Whether cents should be omitted.
+    # @option rules [Boolean] :no_cents (false) Whether cents should be omitted.
     #
     # @example
     #   Money.ca_dollar(100).format(:no_cents => true) #=> "$1"
     #   Money.ca_dollar(599).format(:no_cents => true) #=> "$5"
     #
-    # @option *rules [Boolean] :no_cents_if_whole (false) Whether cents should be
+    # @option rules [Boolean] :no_cents_if_whole (false) Whether cents should be
     #  omitted if the cent value is zero
     #
     # @example
     #   Money.ca_dollar(10000).format(:no_cents_if_whole => true) #=> "$100"
     #   Money.ca_dollar(10034).format(:no_cents_if_whole => true) #=> "$100.34"
     #
-    # @option *rules [Boolean, String, nil] :symbol (true) Whether a money symbol
+    # @option rules [Boolean, String, nil] :symbol (true) Whether a money symbol
     #  should be prepended to the result string. The default is true. This method
     #  attempts to pick a symbol that's suitable for the given currency.
     #
@@ -75,10 +75,10 @@ class Money
     #   Money.new(10000000, "INR").format(:south_asian_number_formatting => true) #=> "1,00,000.00"
     #   Money.new(10000000).format(:south_asian_number_formatting => true) #=> "$1,00,000.00"
     #
-    # @option *rules [Boolean, nil] :symbol_before_without_space (true) Whether
-    # a space between the money symbol and the amount should be inserted when
-    # +:symbol_position+ is +:before+. The default is true (meaning no space). Ignored
-    # if +:symbol+ is false or +:symbol_position+ is not +:before+.
+    # @option rules [Boolean, nil] :symbol_before_without_space (true) Whether
+    #   a space between the money symbol and the amount should be inserted when
+    #   +:symbol_position+ is +:before+. The default is true (meaning no space). Ignored
+    #   if +:symbol+ is false or +:symbol_position+ is not +:before+.
     #
     # @example
     #   # Default is to not insert a space.
@@ -90,10 +90,10 @@ class Money
     #   # If set to false, will insert a space.
     #   Money.new(100, "USD").format(:symbol_before_without_space => false) #=> "$ 1.00"
     #
-    # @option *rules [Boolean, nil] :symbol_after_without_space (false) Whether
-    # a space between the the amount and the money symbol should be inserted when
-    # +:symbol_position+ is +:after+. The default is false (meaning space). Ignored
-    # if +:symbol+ is false or +:symbol_position+ is not +:after+.
+    # @option rules [Boolean, nil] :symbol_after_without_space (false) Whether
+    #   a space between the amount and the money symbol should be inserted when
+    #   +:symbol_position+ is +:after+. The default is false (meaning space). Ignored
+    #   if +:symbol+ is false or +:symbol_position+ is not +:after+.
     #
     # @example
     #   # Default is to insert a space.
@@ -102,7 +102,7 @@ class Money
     #   # If set to true, will not insert a space.
     #   Money.new(100, "USD").format(:symbol_position => :after, :symbol_after_without_space => true) #=> "1.00$"
     #
-    # @option *rules [Boolean, String, nil] :decimal_mark (true) Whether the
+    # @option rules [Boolean, String, nil] :decimal_mark (true) Whether the
     #  currency should be separated by the specified character or '.'
     #
     # @example
@@ -113,7 +113,7 @@ class Money
     #   # to "." as decimal_mark.
     #   Money.new(100, "FOO").format #=> "$1.00"
     #
-    # @option *rules [Boolean, String, nil] :thousands_separator (true) Whether
+    # @option rules [Boolean, String, nil] :thousands_separator (true) Whether
     #  the currency should be delimited by the specified character or ','
     #
     # @example
@@ -129,14 +129,14 @@ class Money
     #   # default to "," as thousands_separator.
     #   Money.new(100000, "FOO").format #=> "$1,000.00"
     #
-    # @option *rules [Boolean] :html (false) Whether the currency should be
+    # @option rules [Boolean] :html (false) Whether the currency should be
     #  HTML-formatted. Only useful in combination with +:with_currency+.
     #
     # @example
-    #   s = Money.ca_dollar(570).format(:html => true, :with_currency => true)
-    #   s #=>  "$5.70 <span class=\"currency\">CAD</span>"
+    #   Money.ca_dollar(570).format(:html => true, :with_currency => true)
+    #   #=> "$5.70 <span class=\"currency\">CAD</span>"
     #
-    # @option *rules [Boolean] :sign_before_symbol (false) Whether the sign should be
+    # @option rules [Boolean] :sign_before_symbol (false) Whether the sign should be
     #  before the currency symbol.
     #
     # @example
@@ -145,7 +145,7 @@ class Money
     #   Money.new(-100, "GBP").format(:sign_before_symbol => false) #=> "£-1.00"
     #   Money.new(-100, "GBP").format                               #=> "£-1.00"
     #
-    # @option *rules [Boolean] :sign_positive (false) Whether positive numbers should be
+    # @option rules [Boolean] :sign_positive (false) Whether positive numbers should be
     #  signed, too.
     #
     # @example
@@ -156,7 +156,7 @@ class Money
     #   Money.new(100, "GBP").format(:sign_positive => false, :sign_before_symbol => false) #=> "£1.00"
     #   Money.new(100, "GBP").format                               #=> "£+1.00"
     #
-    # @option *rules [Boolean] :disambiguate (false) Prevents the result from being ambiguous
+    # @option rules [Boolean] :disambiguate (false) Prevents the result from being ambiguous
     #  due to equal symbols for different currencies. Uses the `disambiguate_symbol`.
     #
     # @example
@@ -165,21 +165,21 @@ class Money
     #   Money.new(10000, "USD").format(:disambiguate => true)    #=> "$100.00"
     #   Money.new(10000, "CAD").format(:disambiguate => true)    #=> "C$100.00"
     #
-    # @option *rules [Boolean] :html_wrap_symbol (false) Wraps the currency symbol
+    # @option rules [Boolean] :html_wrap_symbol (false) Wraps the currency symbol
     #  in a html <span> tag.
     #
     # @example
     #   Money.new(10000, "USD").format(:disambiguate => false)
     #   #=> "<span class=\"currency_symbol\">$100.00</span>
     #
-    # @option *rules [Symbol] :symbol_position (:before) `:before` if the currency
+    # @option rules [Symbol] :symbol_position (:before) `:before` if the currency
     #   symbol goes before the amount, `:after` if it goes after.
     #
     # @example
     #   Money.new(10000, "USD").format(:symbol_position => :before) #=> "$100.00"
     #   Money.new(10000, "USD").format(:symbol_position => :after)  #=> "100.00 $"
     #
-    # @option *rules [Boolean] :translate (true) `true` Checks for custom
+    # @option rules [Boolean] :translate (true) `true` Checks for custom
     #   symbol definitions using I18n.
     #
     # @example
@@ -195,9 +195,9 @@ class Money
     #   Money.new(89000, :btc).format(:drop_trailing_zeros => true) #=> B⃦0.00089
     #   Money.new(110, :usd).format(:drop_trailing_zeros => true)   #=> $1.1
     #
-    # Note that the default rules can be defined through +Money.default_formatting_rules+ hash.
+    # Note that the default rules can be defined through {Money.default_formatting_rules} hash.
     #
-    # @see +Money.default_formatting_rules+ for more information.
+    # @see Money.default_formatting_rules Money.default_formatting_rules for more information.
     def format(*rules)
       # support for old format parameters
       rules = normalize_formatting_rules(rules)


### PR DESCRIPTION
## Before
<img width="1120" alt="screen shot 2016-02-17 at 4 57 45 pm" src="https://cloud.githubusercontent.com/assets/3403/13128022/801b53d4-d598-11e5-895e-37e9c5b82c88.png">
---
<img width="1117" alt="screen shot 2016-02-17 at 4 57 55 pm" src="https://cloud.githubusercontent.com/assets/3403/13128023/81d7c770-d598-11e5-832e-c4b28d73cb27.png">

## After
<img width="1382" alt="screen shot 2016-02-17 at 4 58 06 pm" src="https://cloud.githubusercontent.com/assets/3403/13128025/8603af44-d598-11e5-93f6-1575d70acae6.png">
---
<img width="1375" alt="screen shot 2016-02-17 at 5 00 58 pm" src="https://cloud.githubusercontent.com/assets/3403/13128027/882dc8a4-d598-11e5-9945-4163ce8981b1.png">
