### PR TITLE
Typo Fixes and Consistency Changes

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -44,7 +44,7 @@ class Money
   # 1000.
   #
   # @return [Integer] when infinite_precision is false
-  # @return [BigDecimal] when infintie_precision is true
+  # @return [BigDecimal] when infinite_precision is true
   #
   # @see infinite_precision
   def fractional
@@ -78,7 +78,7 @@ class Money
 
   # @!attribute [r] currency
   #   @return [Currency] The money's currency.
-  # @!attribute [r] bank 
+  # @!attribute [r] bank
   #   @return [Money::Bank::Base] The +Money::Bank+-based object which currency
   #     exchanges are performed with.
 
@@ -95,7 +95,7 @@ class Money
     #     one to specify custom exchange rates.
     #
     # @!attribute default_formatting_rules
-    #   @return [Hash] Use this to define a default hash of rules for everytime
+    #   @return [Hash] Use this to define a default hash of rules for every time
     #     +Money#format+ is called.  Rules provided on method call will be
     #     merged with the default ones.  To overwrite a rule, just provide the
     #     intended value while calling +format+.
@@ -166,7 +166,7 @@ class Money
   setup_defaults
 
   # Use this to return the rounding mode.  You may also pass a
-  # rounding mode and a block to temporatly change it.  It will
+  # rounding mode and a block to temporarily change it.  It will
   # then return the results of the block instead.
   #
   # @param [BigDecimal::ROUND_MODE] mode
@@ -436,7 +436,7 @@ class Money
   end
 
   # Receive a money object with the same amount as the current Money object
-  # in american dollars.
+  # in American dollars.
   #
   # @return [Money]
   #
@@ -448,7 +448,7 @@ class Money
   end
 
   # Receive a money object with the same amount as the current Money object
-  # in canadian dollar.
+  # in Canadian dollar.
   #
   # @return [Money]
   #

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -34,13 +34,13 @@ class Money
   # The value of the monetary amount represented in the fractional or subunit
   # of the currency.
   #
-  # For example, in the US Dollar currency the fractional unit is cents, and
-  # there are 100 cents in one US Dollar. So given the Money representation of
+  # For example, in the US dollar currency the fractional unit is cents, and
+  # there are 100 cents in one US dollar. So given the Money representation of
   # one US dollar, the fractional interpretation is 100.
   #
-  # Another example is that of the Kuwaiti Dinar. In this case the fractional
-  # unit is the Fils and there 1000 Fils to one Kuwaiti Dinar. So given the
-  # Money representation of one Kuwaiti Dinar, the fractional interpretation is
+  # Another example is that of the Kuwaiti dinar. In this case the fractional
+  # unit is the fils and there 1000 fils to one Kuwaiti dinar. So given the
+  # Money representation of one Kuwaiti dinar, the fractional interpretation is
   # 1000.
   #
   # @return [Integer] when infinite_precision is false
@@ -56,7 +56,7 @@ class Money
   end
 
   # Round a given amount of money to the nearest possible amount in cash value. For
-  # example, in Swiss francs (CHF), the smallest possible amount of cash value is
+  # example, in Swiss franc (CHF), the smallest possible amount of cash value is
   # CHF 0.05. Therefore, this method rounds CHF 0.07 to CHF 0.05, and CHF 0.08 to
   # CHF 0.10.
   #
@@ -436,7 +436,7 @@ class Money
   end
 
   # Receive a money object with the same amount as the current Money object
-  # in American dollars.
+  # in United States dollar.
   #
   # @return [Money]
   #


### PR DESCRIPTION
I noticed a few typos and inconsistencies in the documentation for `money`. Hope this helps! :smile_cat: 