### PR TITLE
fix formatting for edge case with i18n/yaml settings

### DIFF
--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -205,6 +205,7 @@ class Money
       rules = default_formatting_rules.merge(rules)
       rules = localize_formatting_rules(rules)
       rules = translate_formatting_rules(rules) if rules[:translate]
+      escaped_decimal_mark = Regexp.escape(decimal_mark)
 
       if fractional == 0
         if rules[:display_free].respond_to?(:to_str)
@@ -236,9 +237,9 @@ class Money
 
       # Inspiration: https://github.com/rails/rails/blob/16214d1108c31174c94503caced3855b0f6bad95/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb#L72-L79
       if rules[:drop_trailing_zeros]
-        escaped_decimal_mark = Regexp.escape(decimal_mark)
         formatted = formatted.sub(/(#{escaped_decimal_mark})(\d*[1-9])?0+\z/, '\1\2').sub(/#{escaped_decimal_mark}\z/, '')
       end
+      has_decimal_value = !!(formatted =~ /#{escaped_decimal_mark}/)
 
       thousands_separator_value = thousands_separator
       # Determine thousands_separator
@@ -275,7 +276,7 @@ class Money
         formatted="#{sign_before}#{sign}#{formatted}"
       end
 
-      apply_decimal_mark_from_rules(formatted, rules)
+      apply_decimal_mark_from_rules(formatted, rules) if has_decimal_value
 
       if rules[:with_currency]
         formatted << " "

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -110,6 +110,16 @@ describe Money, "formatting" do
         expect(money.format(:translate => true)).to eq("CAD$0.00")
       end
     end
+
+    context "with overridden i18n settings" do
+      it "should respect explicit overriding of thousands_separator/delimiter when decimal_mark/separator collide and there’s no decimal component for currencies that have no subunit" do
+        expect(Money.new(300_000, 'ISK').format(:thousands_separator => ".", decimal_mark: ',')).to eq "kr300.000"
+      end
+
+      it "should respect explicit overriding of thousands_separator/delimiter when decimal_mark/separator collide and there’s no decimal component for currencies with subunits that drop_trailing_zeros" do
+        expect(Money.new(300_000, 'USD').format(:thousands_separator => ".", decimal_mark: ',', drop_trailing_zeros: true)).to eq "$3.000"
+      end
+    end
   end
 
   describe "#format" do
@@ -417,6 +427,20 @@ describe Money, "formatting" do
 
       it "defaults to ',' if currency isn't recognized" do
         expect(Money.new(100000, "ZWD").format).to eq "$1,000.00"
+      end
+
+      context "without i18n" do
+        before { Money.use_i18n = false }
+
+        it "should respect explicit overriding of thousands_separator/delimiter when decimal_mark/separator collide and there’s no decimal component for currencies that have no subunit" do
+          expect(Money.new(300_000, 'ISK').format(:thousands_separator => ",", decimal_mark: '.')).to eq "kr300,000"
+        end
+
+        it "should respect explicit overriding of thousands_separator/delimiter when decimal_mark/separator collide and there’s no decimal component for currencies with subunits that drop_trailing_zeros" do
+          expect(Money.new(300_000, 'USD').format(:thousands_separator => ".", decimal_mark: ',', drop_trailing_zeros: true)).to eq "$3.000"
+        end
+
+        after { Money.use_i18n = true}
       end
     end
 


### PR DESCRIPTION
## The problem

When
- an explicit `thousands_separator` option is given that matches the [computed `decimal_mark`](https://github.com/RubyMoney/money/blob/741d11e7dbc6a4edcd6e17168f87d717fca64889/lib/money/money/formatting.rb#L294) (whether returned by locale with i18n or by Money's yaml config)
- an explicit `decimal_mark` option is given that does not match the [computed `decimal_mark`](https://github.com/RubyMoney/money/blob/741d11e7dbc6a4edcd6e17168f87d717fca64889/lib/money/money/formatting.rb#L294) (again, by i18n or yaml)
- a number is formatted that does not have a decimal component

Then
- the rightmost `thousands_separator` is clobbered by the [`apply_decimal_mark_from_rules ` formatting](https://github.com/RubyMoney/money/blob/741d11e7dbc6a4edcd6e17168f87d717fca64889/lib/money/money/formatting.rb#L339-L348)

Or, perhaps more clearly demonstrated in code:
```
[1] pry(main)> I18n.locale
=> :en
[2] pry(main)> Money.use_i18n = true
=> true
[3] pry(main)> Money.new(300_000_000, 'ISK').format(:thousands_separator => ".", decimal_mark: ',')
=> "kr300.000,000" # wrong with i18n on because of :en settings
[4] pry(main)> Money.use_i18n = false
=> false
[5] pry(main)> Money.new(300_000_000, 'ISK').format(:thousands_separator => ".", decimal_mark: ',')
=> "kr300.000.000" # works because options match Money's yaml config for ISK
[6] pry(main)> Money.new(300_000_000, 'ISK').format(:thousands_separator => ".", decimal_mark: 'D')
=> "kr300.000D000" # wrong because of difference with ISK yaml settings
```