### PR TITLE
Put symbol in proper place for fr-CA locale

### DIFF
--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -380,6 +380,9 @@ class Money
       rules[:symbol] = "円" unless rules[:symbol] == false
       rules[:symbol_position] = :after
       rules[:symbol_after_without_space] = true
+    elsif currency.iso_code == "CAD" && I18n.locale == :"fr-CA"
+      rules[:symbol_position] = :after
+      rules[:symbol_after_without_space] = true
     end
     rules
   end

--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -380,9 +380,11 @@ class Money
       rules[:symbol] = "円" unless rules[:symbol] == false
       rules[:symbol_position] = :after
       rules[:symbol_after_without_space] = true
-    elsif currency.iso_code == "CAD" && I18n.locale == :"fr-CA"
+    elsif I18n.locale == :"fr-CA"
       rules[:symbol_position] = :after
-      rules[:symbol_after_without_space] = true
+      rules[:decimal_mark] = ","
+      rules[:thousands_separator] = " "
+      rules[:symbol_after_without_space] = false
     end
     rules
   end

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -124,26 +124,22 @@ describe Money, "formatting" do
 
   describe "#format" do
     context "Locale :ja" do
-      before { @_locale = I18n.locale; I18n.locale = :ja }
+      around { |ex| I18n.with_locale(:ja) { ex.run } }
 
       it "formats Japanese currency in Japanese properly" do
         money = Money.new(1000, "JPY")
         expect(money.format).to eq "1,000円"
         expect(money.format(:symbol => false)).to eq "1,000"
       end
-
-      after  { I18n.locale = @_locale }
     end
 
     context "Locale fr-CA" do
-      before { @_locale = I18n.locale; I18n.locale = :"fr-CA" }
+      around { |ex| I18n.with_locale(:"fr-CA") { ex.run } }
 
       it "formats French Canadian currency properly" do
         money = Money.new(1000, "CAD")
         expect(money.format).to eq "10.00$"
       end
-
-      after  { I18n.locale = @_locale }
     end
 
     it "returns the monetary value as a string" do

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -136,9 +136,12 @@ describe Money, "formatting" do
     context "Locale fr-CA" do
       around { |ex| I18n.with_locale(:"fr-CA") { ex.run } }
 
-      it "formats French Canadian currency properly" do
+      it "formats the currencies properly" do
         money = Money.new(1000, "CAD")
-        expect(money.format).to eq "10.00$"
+        expect(money.format).to eq "10,00 $"
+
+        money = Money.new(1_000_000_00, "EUR")
+        expect(money.format).to eq "1 000 000,00 €"
       end
     end
 

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -135,6 +135,17 @@ describe Money, "formatting" do
       after  { I18n.locale = @_locale }
     end
 
+    context "Locale fr-CA" do
+      before { @_locale = I18n.locale; I18n.locale = :"fr-CA" }
+
+      it "formats French Canadian currency properly" do
+        money = Money.new(1000, "CAD")
+        expect(money.format).to eq "10.00$"
+      end
+
+      after  { I18n.locale = @_locale }
+    end
+
     it "returns the monetary value as a string" do
       expect(Money.ca_dollar(100).format).to eq "$1.00"
       expect(Money.new(40008).format).to eq "$400.08"


### PR DESCRIPTION
The proper place for the symbol for French-speaking Canada is at the end.
