### PR TITLE
fixed HUF smallest denomination

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -938,7 +938,7 @@
     "decimal_mark": ",",
     "thousands_separator": ".",
     "iso_numeric": "348",
-    "smallest_denomination": 500
+    "smallest_denomination": 5
   },
   "idr": {
     "priority": 100,


### PR DESCRIPTION
Currently the smallest HUF denomination is the 5 Ft coin:
https://en.wikipedia.org/wiki/Hungarian_forint