### PR TITLE
Mention "MIT" in license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2005 Tobias Lutke
 Copyright (c) 2008 Phusion
 


### PR DESCRIPTION
Closes #639 

I have very little idea about software licenses, so i don't know if this is worth it, but proposing this change was simpler than adding a longer discussion comment it :stuck_out_tongue: 