### PR TITLE
Adding reference to money-uphold-bank

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ implementations.
 - [money-open-exchange-rates](https://github.com/spk/money-open-exchange-rates)
 - [money-historical-bank](https://github.com/atwam/money-historical-bank)
 - [russian_central_bank](https://github.com/rmustafin/russian_central_bank)
+- [money-uphold-bank](https://github.com/subvisual/money-uphold-bank)
 
 ## Ruby on Rails
 


### PR DESCRIPTION
https://github.com/subvisual/money-uphold-bank

I build this bank integration to work with the API from https://uphold.com/

It's mainly because I'm building a couple of products for this API, but it has the interesting aspect of supporting Litecoin, Bitcoin, Ethereum and any other currency that might eventually get added to Uphold itself

(these crypto currencies are only visible by the Money gem if you register them manually)