### PR TITLE
html_entity for COP should be $

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -501,7 +501,7 @@
     "subunit": "Centavo",
     "subunit_to_unit": 100,
     "symbol_first": true,
-    "html_entity": "&#x20B1;",
+    "html_entity": "&#36;",
     "decimal_mark": ",",
     "thousands_separator": ".",
     "iso_numeric": "170",


### PR DESCRIPTION
currency symbol for COP is "$" and its defined correctly. But html_entity is still pointing to &#x20B1;  (₱).
Changing html_entity to $.

ISO standard also says currency symbol for COP is $.
http://www.xe.com/currency/cop-colombian-peso

Please let me know if I missed anything.
