### PR TITLE
Lock json at 1.8.3 for ruby 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,13 @@
 source "https://rubygems.org"
 
 gem "coveralls", :require => false
-gem "json", :platform => :jruby
 gem "pry", :require => false
+
+# JSON gem no longer supports ruby < 2.0.0
+if defined?(JRUBY_VERSION)
+  gem "json"
+elsif RUBY_VERSION =~ /^1/
+  gem "json", "~> 1.8.3"
+end
 
 gemspec


### PR DESCRIPTION
JSON gem has dropped support for older rubies (https://github.com/flori/json/blob/master/CHANGES.md).

This will lock json at `1.8.3` for older rubies.