### PR TITLE
Remove localize formatting rules

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -120,6 +120,7 @@ Tsyren Ochirov
 Victor Shcherbakov
 Wei Zhu
 Yok
+Yuki Hariguchi
 Yuri Sidorov
 Yuusuke Takizawa
 Zubin Henner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.7.2
+- Remove `localize_formatting_rules`
+
 ## 6.7.1
 - Changed DKK symbol from 'kr' to 'kr.'
 - Improved Money::Formatting#format docs

--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -203,7 +203,6 @@ class Money
       rules = normalize_formatting_rules(rules)
 
       rules = default_formatting_rules.merge(rules)
-      rules = localize_formatting_rules(rules)
       rules = translate_formatting_rules(rules) if rules[:translate]
       escaped_decimal_mark = Regexp.escape(decimal_mark)
 
@@ -371,15 +370,6 @@ class Money
       rules[:symbol] = I18n.t currency.iso_code, :scope => "number.currency.symbol", :raise => true
     rescue I18n::MissingTranslationData
       # Do nothing
-    end
-    rules
-  end
-
-  def localize_formatting_rules(rules)
-    if currency.iso_code == "JPY" && I18n.locale == :ja
-      rules[:symbol] = "円" unless rules[:symbol] == false
-      rules[:symbol_position] = :after
-      rules[:symbol_after_without_space] = true
     end
     rules
   end

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -123,17 +123,6 @@ describe Money, "formatting" do
   end
 
   describe "#format" do
-    context "Locale :ja" do
-      before { @_locale = I18n.locale; I18n.locale = :ja }
-
-      it "formats Japanese currency in Japanese properly" do
-        money = Money.new(1000, "JPY")
-        expect(money.format).to eq "1,000円"
-        expect(money.format(:symbol => false)).to eq "1,000"
-      end
-
-      after  { I18n.locale = @_locale }
-    end
 
     it "returns the monetary value as a string" do
       expect(Money.ca_dollar(100).format).to eq "$1.00"


### PR DESCRIPTION
Since `Formatting#localize_formatting_rules` prevent from overwriting rules, this patch is going to propose to remove `Formatting#localize_formatting_rules`.

First of all, this method was introduced at https://github.com/RubyMoney/money/pull/101. But it doesn't make sense to me and unexpected behavior. Not only '円' but also '圓'(it's more formal) or even 'yen' can be used.
