### PR TITLE
Added Money#installments method

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -97,6 +97,7 @@ Phil Cohen
 pivotal-cloudplanner
 Prathan Thananart
 Robert Starsi
+Rodolfo Spalenza
 Romain Gérard
 Ryan Bigg
 sankaranarayanan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 6.7.1
+- Added `Money#installments` utils method
 - Changed DKK symbol from 'kr' to 'kr.'
 - Improved Money::Formatting#format docs
 - Updated VEF symbol from 'Bs F' to 'Bs'

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -4,6 +4,7 @@ require "money/bank/single_currency"
 require "money/money/arithmetic"
 require "money/money/constructors"
 require "money/money/formatting"
+require "money/money/utils"
 
 # "Money is any object or record that is generally accepted as payment for
 # goods and services and repayment of debts in a given socio-economic context
@@ -18,6 +19,7 @@ class Money
   include Comparable
   include Money::Arithmetic
   include Money::Formatting
+  include Money::Utils
   extend Constructors
 
   # Raised when smallest denomination of a currency is not defined

--- a/lib/money/money/utils.rb
+++ b/lib/money/money/utils.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+class Money
+  module Utils
+    # Returns installments of a money with residue dissolved in firt installments.
+    #
+    # @param [Integer] number of installments
+    #
+    # @return [Array<Money,Money>]
+    #
+    # @example
+    #   Money.new(101).installments(3) #=> [#<Money @fractional:34>, #<Money @fractional:34>, #<Money @fractional:33>]
+    def installments(number)
+      installment, residual = self.divmod(number)
+
+      installments = number.times.map { installment }
+      residues     = residual.fractional.times.map { self.class.new(1, currency) }
+
+      installments.zip(residues).map do |installment, residue|
+        installment + (residue || self.class.new(0, currency))
+      end
+    end
+  end
+end

--- a/spec/money/utils_spec.rb
+++ b/spec/money/utils_spec.rb
@@ -1,0 +1,49 @@
+# encoding: utf-8
+describe Money do
+  let(:amount)       { 100 }
+  let(:installments) { 5 }
+
+  subject { Money.new(amount) }
+
+  describe '#installments' do
+    it "returns size's array equal number of installments" do
+      expect(subject.installments(installments).size).to eq(installments)
+    end
+
+    it 'ensures total of installments is the same of amount' do
+      installments_sum = subject.installments(installments).inject(:+)
+      expect(installments_sum).to eq(subject)
+    end
+
+    context 'when number of installments is less than amount value' do
+      let(:amount) { 3 }
+
+      it 'returns installments with amount equal zero' do
+        latest_installment = subject.installments(installments).last(2)
+
+        latest_installment.each do |instalment|
+          expect(instalment).to be_zero
+        end
+      end
+    end
+
+    context 'when modulus is zero' do
+      it 'returns same value for all instalments' do
+        expect(subject.installments(installments).uniq.size).to eq(1)
+      end
+    end
+
+    context 'when modulus is not zero' do
+      let(:amount)       { 101 }
+      let(:installments) { 3 }
+
+      it 'dissolves residue in first installments' do
+        first_installments = subject.installments(installments).first(2)
+
+        first_installments.each do |instalment|
+          expect(instalment.fractional).to eq(34)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In many countries divide credit card in installments is normal. The problem is when this divide has a residue like 100 / 3 => 99 + 1. We need add this residue in some installments.
This method returns array with the residue dissolved in first installments. I created `Utils` module because I think this is not a arithmetic operation.

Thanks.