### PR TITLE
Do not ignore disambiguate option when symbol: true in `format` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `Money#==` will now raise error for non-zero numeric values
 - Fixed divmod
 - Added disambiguation symbol to USD Dollar
+- Use disambiguation symbol when both disambiguate and symbol are true in `format` method
 
 ## 6.7.0
  - Changed `Money#<=>` to return `nil` if the comparison is inappropriate. (#584)

--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -387,7 +387,11 @@ class Money
   def symbol_value_from(rules)
     if rules.has_key?(:symbol)
       if rules[:symbol] === true
-        symbol
+        if rules[:disambiguate] && currency.disambiguate_symbol
+          currency.disambiguate_symbol
+        else
+          symbol
+        end
       elsif rules[:symbol]
         rules[:symbol]
       else
@@ -395,7 +399,7 @@ class Money
       end
     elsif rules[:html]
       currency.html_entity == '' ? currency.symbol : currency.html_entity
-    elsif rules[:disambiguate] and currency.disambiguate_symbol
+    elsif rules[:disambiguate] && currency.disambiguate_symbol
       currency.disambiguate_symbol
     else
       symbol

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -707,6 +707,22 @@ describe Money, "formatting" do
       expect(Money.new(1999_98, "SEK").format(disambiguate: true)).to eq("1 999,98 SEK")
     end
 
+    it "returns disambiguate signs when disambiguate: true and symbol: true" do
+      expect(Money.new(1999_98, "USD").format(disambiguate: true, symbol: true)).to eq("US$1,999.98")
+      expect(Money.new(1999_98, "CAD").format(disambiguate: true, symbol: true)).to eq("C$1,999.98")
+      expect(Money.new(1999_98, "DKK").format(disambiguate: true, symbol: true)).to eq("1.999,98 DKK")
+      expect(Money.new(1999_98, "NOK").format(disambiguate: true, symbol: true)).to eq("1.999,98 NOK")
+      expect(Money.new(1999_98, "SEK").format(disambiguate: true, symbol: true)).to eq("1 999,98 SEK")
+    end
+
+    it "returns no signs when disambiguate: true and symbol: false" do
+      expect(Money.new(1999_98, "USD").format(disambiguate: true, symbol: false)).to eq("1,999.98")
+      expect(Money.new(1999_98, "CAD").format(disambiguate: true, symbol: false)).to eq("1,999.98")
+      expect(Money.new(1999_98, "DKK").format(disambiguate: true, symbol: false)).to eq("1.999,98")
+      expect(Money.new(1999_98, "NOK").format(disambiguate: true, symbol: false)).to eq("1.999,98")
+      expect(Money.new(1999_98, "SEK").format(disambiguate: true, symbol: false)).to eq("1 999,98")
+    end
+
     it "should never return an ambiguous format with disambiguate: true" do
       formatted_results = {}
 


### PR DESCRIPTION
I am not sure if this was a design decision, but currently calling `format` with both `disambiguate` and `symbol` options set to `true` will just return the ambiguous symbol:
```
Money.new(1999_98, "USD").format(disambiguate: true, symbol: true)
=> "$1,999.98"
```

It felt more natural to me if the behavior was to instead use the disambiguate symbol in this case:
```
Money.new(1999_98, "USD").format(disambiguate: true, symbol: true)
=> "US$1,999.98"
```