### PR TITLE
Update example for recent versions of ActiveRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,12 +316,12 @@ The following example implements an `ActiveRecord` store to save exchange rates 
 
 class ExchangeRate < ActiveRecord::Base
   def self.get_rate(from_iso_code, to_iso_code)
-    rate = find_by_from_and_to(from_iso_code, to_iso_code)
+    rate = find_by(:from => from_iso_code, :to => to_iso_code)
     rate.present? ? rate.rate : nil
   end
 
   def self.add_rate(from_iso_code, to_iso_code, rate)
-    exrate = find_or_initialize_by_from_and_to(from_iso_code, to_iso_code)
+    exrate = find_or_initialize_by(:from => from_iso_code, :to => to_iso_code)
     exrate.rate = rate
     exrate.save!
   end


### PR DESCRIPTION
In recents version of ActiveRecord `find_by_*` was replaced with `find_by(conditions_hash)` and `find_or_initialize_by_*` was replaced with `find_or_initialize_by(conditions_hash)`

This updates the example on the README to reflect the changes.