### PR TITLE
Cache I18n calls for better performance

### DIFF
--- a/lib/money/money/constructors.rb
+++ b/lib/money/money/constructors.rb
@@ -11,7 +11,7 @@ class Money
     #   Money.empty #=> #<Money @fractional=0>
     def empty(currency = default_currency)
       @empty ||= {}
-      @empty[currency] ||= new(0, currency).freeze
+      @empty[currency] ||= new(0, currency)
     end
     alias_method :zero, :empty
 

--- a/lib/money/money/constructors.rb
+++ b/lib/money/money/constructors.rb
@@ -10,8 +10,7 @@ class Money
     # @example
     #   Money.empty #=> #<Money @fractional=0>
     def empty(currency = default_currency)
-      @empty ||= {}
-      @empty[currency] ||= new(0, currency)
+      new(0, currency)
     end
     alias_method :zero, :empty
 

--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -288,11 +288,11 @@ class Money
     end
 
     def thousands_separator
-      i18n_format_for(:thousands_separator, :delimiter, ",")
+      @thousands_separator ||= i18n_format_for(:thousands_separator, :delimiter, ",")
     end
 
     def decimal_mark
-      i18n_format_for(:decimal_mark, :separator, ".")
+      @decimal_mark ||= i18n_format_for(:decimal_mark, :separator, ".")
     end
 
     alias_method :delimiter, :thousands_separator

--- a/spec/money/constructors_spec.rb
+++ b/spec/money/constructors_spec.rb
@@ -15,10 +15,6 @@ describe Money::Constructors do
       expect(Money.empty(:cad).object_id).to eq Money.empty(:cad).object_id
     end
 
-    it "doesn't allow money to be modified for a currency" do
-      expect(Money.empty).to be_frozen
-    end
-
     it "instantiates a subclass when inheritance is used" do
       special_money_class = Class.new(Money)
       expect(special_money_class.empty).to be_a special_money_class

--- a/spec/money/constructors_spec.rb
+++ b/spec/money/constructors_spec.rb
@@ -7,14 +7,6 @@ describe Money::Constructors do
       expect(Money.empty).to eq Money.new(0)
     end
 
-    it "memoizes the result" do
-      expect(Money.empty.object_id).to eq Money.empty.object_id
-    end
-
-    it "memoizes a result for each currency" do
-      expect(Money.empty(:cad).object_id).to eq Money.empty(:cad).object_id
-    end
-
     it "instantiates a subclass when inheritance is used" do
       special_money_class = Class.new(Money)
       expect(special_money_class.empty).to be_a special_money_class

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -6,6 +6,11 @@ describe Money, "formatting" do
   INDIAN_BAR = '{ "priority": 1, "iso_code": "INDIAN_BAR", "iso_numeric": "840", "name": "Dollar with 4 decimal places", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 10000, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "south_asian_number_formatting": true, "smallest_denomination": 1}'
   EU4 = '{ "priority": 1, "iso_code": "EU4", "iso_numeric": "841", "name": "Euro with 4 decimal places", "symbol": "€", "subunit": "Cent", "subunit_to_unit": 10000, "symbol_first": true, "html_entity": "€", "decimal_mark": ",", "thousands_separator": ".", "smallest_denomination": 1 }'
 
+  after :each do
+    # Reset cached empty instances
+    Money.instance_variable_set '@empty', {}
+  end
+
   context "without i18n" do
     subject(:money) { Money.empty("USD") }
 

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -6,11 +6,6 @@ describe Money, "formatting" do
   INDIAN_BAR = '{ "priority": 1, "iso_code": "INDIAN_BAR", "iso_numeric": "840", "name": "Dollar with 4 decimal places", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 10000, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "south_asian_number_formatting": true, "smallest_denomination": 1}'
   EU4 = '{ "priority": 1, "iso_code": "EU4", "iso_numeric": "841", "name": "Euro with 4 decimal places", "symbol": "€", "subunit": "Cent", "subunit_to_unit": 10000, "symbol_first": true, "html_entity": "€", "decimal_mark": ",", "thousands_separator": ".", "smallest_denomination": 1 }'
 
-  after :each do
-    # Reset cached empty instances
-    Money.instance_variable_set '@empty', {}
-  end
-
   context "without i18n" do
     subject(:money) { Money.empty("USD") }
 


### PR DESCRIPTION
I18n calls are quite expensive, so caching this gives us an increase in performance of about 20%. Here's an example:

```ruby
res = Benchmark.measure do
  100_000.times do
    Money.euro(250).format
  end
end
puts res
```

Without caching:

```
=> 17.560000   0.060000  17.620000 ( 17.639144)
```

with caching:

```
=> 14.410000   0.040000  14.450000 ( 14.445001)
```

Although I had to remove the freeze on the empty Money object. The whole empty object pre-caching seems like a very premature optimization
