### PR TITLE
Change czk thousand separator to most used

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -581,7 +581,7 @@
     "symbol_first": false,
     "html_entity": "",
     "decimal_mark": ",",
-    "thousands_separator": ".",
+    "thousands_separator": " ",
     "iso_numeric": "203",
     "smallest_denomination": 100
   },


### PR DESCRIPTION
Changed thousands separator to another which is more used in Czech Republic.