### PR TITLE
Fixnum is deprecated in ruby 2.4.

### DIFF
--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -314,10 +314,10 @@ class Money
     end
     private :compare_ids
 
-    # Returns a Fixnum hash value based on the +id+ attribute in order to use
+    # Returns a Integer hash value based on the +id+ attribute in order to use
     # functions like & (intersection), group_by, etc.
     #
-    # @return [Fixnum]
+    # @return [Integer]
     #
     # @example
     #   Money::Currency.new(:usd).hash #=> 428936
@@ -397,7 +397,7 @@ class Money
     # Note that MGA and MRO are exceptions and are rounded to 1
     # @see https://en.wikipedia.org/wiki/ISO_4217#Active_codes
     #
-    # @return [Fixnum]
+    # @return [Integer]
     def exponent
       Math.log10(@subunit_to_unit).round
     end

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -117,7 +117,7 @@ class Money
     #   @return [Boolean] Use this to enable infinite precision cents
     #
     # @!attribute [rw] conversion_precision
-    #   @return [Fixnum] Use this to specify precision for converting Rational
+    #   @return [Integer] Use this to specify precision for converting Rational
     #     to BigDecimal
     attr_accessor :default_bank, :default_formatting_rules,
       :use_i18n, :infinite_precision, :conversion_precision
@@ -317,10 +317,10 @@ class Money
     @currency = Currency.wrap(val)
   end
 
-  # Returns a Fixnum hash value based on the +fractional+ and +currency+ attributes
+  # Returns a Integer hash value based on the +fractional+ and +currency+ attributes
   # in order to use functions like & (intersection), group_by, etc.
   #
-  # @return [Fixnum]
+  # @return [Integer]
   #
   # @example
   #   Money.new(100).hash #=> 908351
@@ -551,7 +551,7 @@ class Money
     if num.respond_to?(:to_d)
       num.is_a?(Rational) ? num.to_d(self.class.conversion_precision) : num.to_d
     else
-      BigDecimal.new(num.to_s)
+      BigDecimal.new(num.to_s.empty? ? 0 : num.to_s)
     end
   end
 

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -48,7 +48,7 @@ class Money
     #
     # @param [Money] other_money Value to compare with.
     #
-    # @return [Fixnum]
+    # @return [Integer]
     #
     # @raise [TypeError] when other object is not Money
     #
@@ -195,9 +195,9 @@ class Money
     # Divide money by money or fixnum and return array containing quotient and
     # modulus.
     #
-    # @param [Money, Fixnum] val Number to divmod by.
+    # @param [Money, Integer] val Number to divmod by.
     #
-    # @return [Array<Money,Money>,Array<Fixnum,Money>]
+    # @return [Array<Money,Money>,Array<Integer,Money>]
     #
     # @example
     #   Money.new(100).divmod(9)            #=> [#<Money @fractional=11>, #<Money @fractional=1>]
@@ -225,7 +225,7 @@ class Money
 
     # Equivalent to +self.divmod(val)[1]+
     #
-    # @param [Money, Fixnum] val Number take modulo with.
+    # @param [Money, Integer] val Number take modulo with.
     #
     # @return [Money]
     #
@@ -238,7 +238,7 @@ class Money
 
     # Synonym for +#modulo+.
     #
-    # @param [Money, Fixnum] val Number take modulo with.
+    # @param [Money, Integer] val Number take modulo with.
     #
     # @return [Money]
     #
@@ -249,7 +249,7 @@ class Money
 
     # If different signs +self.modulo(val) - val+ otherwise +self.modulo(val)+
     #
-    # @param [Money, Fixnum] val Number to rake remainder with.
+    # @param [Money, Integer] val Number to rake remainder with.
     #
     # @return [Money]
     #

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -176,7 +176,7 @@ describe Money do
       expect(Money.new(10_00, "USD") + other).to eq Money.new(19_00, "USD")
     end
 
-    it "adds Fixnum 0 to money and returns the same ammount" do
+    it "adds Integer 0 to money and returns the same ammount" do
       expect(Money.new(10_00) + 0).to eq Money.new(10_00)
     end
 
@@ -197,7 +197,7 @@ describe Money do
       expect(Money.new(10_00, "USD") - other).to eq Money.new(1_00, "USD")
     end
 
-    it "subtract Fixnum 0 to money and returns the same ammount" do
+    it "subtract Integer 0 to money and returns the same ammount" do
       expect(Money.new(10_00) - 0).to eq Money.new(10_00)
     end
 
@@ -208,7 +208,7 @@ describe Money do
   end
 
   describe "#*" do
-    it "multiplies Money by Fixnum and returns Money" do
+    it "multiplies Money by Integer and returns Money" do
       ts = [
         {:a => Money.new( 10, :USD), :b =>  4, :c => Money.new( 40, :USD)},
         {:a => Money.new( 10, :USD), :b => -4, :c => Money.new(-40, :USD)},
@@ -239,7 +239,7 @@ describe Money do
   end
 
   describe "#/" do
-    it "divides Money by Fixnum and returns Money" do
+    it "divides Money by Integer and returns Money" do
       ts = [
         {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 3, :USD)},
         {:a => Money.new( 13, :USD), :b => -4, :c => Money.new(-3, :USD)},
@@ -335,7 +335,7 @@ describe Money do
   end
 
   describe "#div" do
-    it "divides Money by Fixnum and returns Money" do
+    it "divides Money by Integer and returns Money" do
       ts = [
           {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 3, :USD)},
           {:a => Money.new( 13, :USD), :b => -4, :c => Money.new(-3, :USD)},
@@ -388,7 +388,7 @@ describe Money do
   end
 
   describe "#divmod" do
-    it "calculates division and modulo with Fixnum" do
+    it "calculates division and modulo with Integer" do
       ts = [
           {:a => Money.new( 13, :USD), :b =>  4, :c => [Money.new( 3, :USD), Money.new( 1, :USD)]},
           {:a => Money.new( 13, :USD), :b => -4, :c => [Money.new(-4, :USD), Money.new(-3, :USD)]},
@@ -451,7 +451,7 @@ describe Money do
   end
 
   describe "#modulo" do
-    it "calculates modulo with Fixnum" do
+    it "calculates modulo with Integer" do
       ts = [
           {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 1, :USD)},
           {:a => Money.new( 13, :USD), :b => -4, :c => Money.new(-3, :USD)},
@@ -490,7 +490,7 @@ describe Money do
   end
 
   describe "#%" do
-    it "calculates modulo with Fixnum" do
+    it "calculates modulo with Integer" do
       ts = [
           {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 1, :USD)},
           {:a => Money.new( 13, :USD), :b => -4, :c => Money.new(-3, :USD)},
@@ -529,7 +529,7 @@ describe Money do
   end
 
   describe "#remainder" do
-    it "calculates remainder with Fixnum" do
+    it "calculates remainder with Integer" do
       ts = [
           {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 1, :USD)},
           {:a => Money.new( 13, :USD), :b => -4, :c => Money.new( 1, :USD)},

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -349,7 +349,7 @@ YAML
       expect {money.round_to_nearest_cash_value}.to raise_error(Money::UndefinedSmallestDenomination)
     end
 
-    it "returns a Fixnum when infinite_precision is not set" do
+    it "returns a Integer when infinite_precision is not set" do
       money = Money.new(100, "USD")
       expect(money.round_to_nearest_cash_value).to be_a Integer
     end


### PR DESCRIPTION
Hi,

This solves some deprecation warning for ruby 2.4.

See https://bugs.ruby-lang.org/issues/12005