### PR TITLE
Rollback #666 + different caching solution

### DIFF
--- a/lib/money/money/constructors.rb
+++ b/lib/money/money/constructors.rb
@@ -10,7 +10,8 @@ class Money
     # @example
     #   Money.empty #=> #<Money @fractional=0>
     def empty(currency = default_currency)
-      new(0, currency)
+      @empty ||= {}
+      @empty[currency] ||= new(0, currency).freeze
     end
     alias_method :zero, :empty
 

--- a/lib/money/money/formatting.rb
+++ b/lib/money/money/formatting.rb
@@ -205,6 +205,10 @@ class Money
       rules = default_formatting_rules.merge(rules)
       rules = localize_formatting_rules(rules)
       rules = translate_formatting_rules(rules) if rules[:translate]
+
+      thousands_separator = self.thousands_separator
+      decimal_mark = self.decimal_mark
+
       escaped_decimal_mark = Regexp.escape(decimal_mark)
 
       if fractional == 0
@@ -288,11 +292,11 @@ class Money
     end
 
     def thousands_separator
-      @thousands_separator ||= i18n_format_for(:thousands_separator, :delimiter, ",")
+      i18n_format_for(:thousands_separator, :delimiter, ",")
     end
 
     def decimal_mark
-      @decimal_mark ||= i18n_format_for(:decimal_mark, :separator, ".")
+      i18n_format_for(:decimal_mark, :separator, ".")
     end
 
     alias_method :delimiter, :thousands_separator

--- a/spec/money/constructors_spec.rb
+++ b/spec/money/constructors_spec.rb
@@ -7,6 +7,18 @@ describe Money::Constructors do
       expect(Money.empty).to eq Money.new(0)
     end
 
+    it "memoizes the result" do
+      expect(Money.empty.object_id).to eq Money.empty.object_id
+    end
+
+    it "memoizes a result for each currency" do
+      expect(Money.empty(:cad).object_id).to eq Money.empty(:cad).object_id
+    end
+
+    it "doesn't allow money to be modified for a currency" do
+      expect(Money.empty).to be_frozen
+    end
+
     it "instantiates a subclass when inheritance is used" do
       special_money_class = Class.new(Money)
       expect(special_money_class.empty).to be_a special_money_class


### PR DESCRIPTION
Fixes a bug introduced by #666 not allowing to call `#format` on a frozen Money object.