### PR TITLE
eliminate subunits for forints

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -932,7 +932,7 @@
     "symbol": "Ft",
     "alternate_symbols": [],
     "subunit": "Fillér",
-    "subunit_to_unit": 100,
+    "subunit_to_unit": 1,
     "symbol_first": false,
     "html_entity": "",
     "decimal_mark": ",",


### PR DESCRIPTION
Solves https://github.com/RubyMoney/money/issues/677