### PR TITLE
fix self_amount constructor accepting nil currency_code

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -229,7 +229,7 @@ class Money
   # @see #initialize
   def self.from_amount(amount, currency = default_currency, bank = default_bank)
     Numeric === amount or raise ArgumentError, "'amount' must be numeric"
-    currency = Currency.wrap(currency)
+    currency = Currency.wrap(currency) || Money.default_currency
     value = amount.to_d * currency.subunit_to_unit
     value = value.round(0, rounding_mode) unless infinite_precision
     new(value, currency, bank)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -169,6 +169,16 @@ describe Money do
         Money.from_amount(1.999).to_d
       end).to eq 1.99
     end
+
+    context 'given a currency is provided' do
+      context 'and the currency is nil' do
+        let(:currency) { nil }
+
+        it "should have the default currency" do
+          expect(Money.from_amount(1, currency).currency).to eq Money.default_currency
+        end
+      end
+    end
   end
 
   %w[cents pence].each do |units|


### PR DESCRIPTION
This scenario happened to me: 

```
currency_code = nil (returned by data store)
amount = 500

Money.from_amount(amount, currency_code).cents results in 
#<NoMethodError: undefined method `subunit_to_unit' for nil:NilClass>
```

Basically currency_code did not default to the default_currency value and was accepted as nil.