### PR TITLE
Fix symbol for UZS

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -2289,7 +2289,7 @@
     "priority": 100,
     "iso_code": "UZS",
     "name": "Uzbekistan Som",
-    "symbol": null,
+    "symbol": "",
     "alternate_symbols": ["so‘m", "сўм", "сум", "s", "с"],
     "subunit": "Tiyin",
     "subunit_to_unit": 100,

--- a/config/currency_non_iso.json
+++ b/config/currency_non_iso.json
@@ -67,7 +67,7 @@
     "iso_code": "XFU",
     "name": "UIC Franc",
     "symbol": "",
-    "disambiguate_symbol": "",
+    "disambiguate_symbol": "XFU",
     "alternate_symbols": [],
     "subunit": "",
     "subunit_to_unit": 100,


### PR DESCRIPTION
This also adds a `disambiguate_symbol` for XFU, fixing a failing test

#682 