### PR TITLE
Peruvian Sol

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -1675,7 +1675,7 @@
   "pen": {
     "priority": 100,
     "iso_code": "PEN",
-    "name": "Peruvian Nuevo Sol",
+    "name": "Peruvian Sol",
     "symbol": "S/.",
     "alternate_symbols": [],
     "subunit": "Céntimo",


### PR DESCRIPTION
At its introduction in 1991, the currency was officially called nuevo sol ("new sol"), but on November 13, 2015, the Peruvian Congress voted to rename the currency simply sol

https://en.wikipedia.org/wiki/Peruvian_sol