### PR TITLE
Relax i18n version constraint to allow patch version updates

### DIFF
--- a/money.gemspec
+++ b/money.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = "A Ruby Library for dealing with money and currency conversion."
   s.license     = "MIT"
 
-  s.add_dependency 'i18n', ['>= 0.6.4', '<= 0.8.0']
+  s.add_dependency 'i18n', ['>= 0.6.4', '< 0.9']
   s.add_dependency 'sixarm_ruby_unaccent', ['>= 1.1.1', '< 2']
 
   s.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Patch version bumps should not cause any breaking changes. I18n 0.8.1 has been released and contains a minor fix. Relaxing the version constraint to allow any version before 0.9 would enable updating the gem without a change in Money.