### PR TITLE
[Issue #678] VND currency should have symbol_first: false

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -2323,7 +2323,7 @@
     "alternate_symbols": [],
     "subunit": "Hào",
     "subunit_to_unit": 1,
-    "symbol_first": true,
+    "symbol_first": false,
     "html_entity": "&#x20AB;",
     "decimal_mark": ",",
     "thousands_separator": ".",

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -324,6 +324,9 @@ describe Money, "formatting" do
         # Brazilian Real
         expect(one["BRL"]).to eq "R$1,00"
 
+        # Vietnamese Dong
+        expect(one["VND"]).to eq "100 ₫"
+
         # Other
         expect(one["SEK"]).to eq "1,00 kr"
         expect(one["GHC"]).to eq "₵1.00"


### PR DESCRIPTION
- Related to https://github.com/RubyMoney/money/issues/678
- Set VND currency to display dong symbol at the end