### PR TITLE
v6.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.8.3
+- Added support for the British Penny (GBX)
+- Fixed LKR currency html_entity symbol
+
 ## 6.8.2
 - Removed subunits for HUF
 - Fixed `#from_amount` accepting `nil` as currency_code

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -1253,7 +1253,7 @@
     "subunit": "Cent",
     "subunit_to_unit": 100,
     "symbol_first": false,
-    "html_entity": "&#x0BF9;",
+    "html_entity": "&#8360;",
     "decimal_mark": ".",
     "thousands_separator": ",",
     "iso_numeric": "144",

--- a/config/currency_non_iso.json
+++ b/config/currency_non_iso.json
@@ -77,5 +77,21 @@
     "thousands_separator": ",",
     "iso_numeric": "",
     "smallest_denomination": ""
+  },
+  "gbx": {
+    "priority": 100,
+    "iso_code": "GBX",
+    "name": "British Penny",
+    "symbol": "",
+    "disambiguate_symbol": "GBX",
+    "alternate_symbols": [],
+    "subunit": "",
+    "subunit_to_unit": 1,
+    "symbol_first": true,
+    "html_entity": "",
+    "decimal_mark": ".",
+    "thousands_separator": ",",
+    "iso_numeric": "",
+    "smallest_denomination": 1
   }
 }

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,3 +1,3 @@
 class Money
-  VERSION = "6.8.2"
+  VERSION = "6.8.3"
 end


### PR DESCRIPTION
This is pushed separately because there's a commit on `master` that breaks backwards compatibility and needs to be released as 6.9 (7.0 ideally, but probably too small of a change for major release).