### PR TITLE
Display the BBD $ symbol before digits.

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -176,7 +176,7 @@
     "alternate_symbols": ["Bds$"],
     "subunit": "Cent",
     "subunit_to_unit": 100,
-    "symbol_first": false,
+    "symbol_first": true,
     "html_entity": "$",
     "decimal_mark": ".",
     "thousands_separator": ",",


### PR DESCRIPTION
The currency pattern for the BBD is defined as "¤#,##0.00" in the ICU library.

http://demo.icu-project.org/icu-bin/locexp?d_=en&_=en_BB