### PR TITLE
Make marshal dump work for memory store

### DIFF
--- a/lib/money/rates_store/memory.rb
+++ b/lib/money/rates_store/memory.rb
@@ -58,9 +58,8 @@ class Money
       end
 
       def marshal_dump
-        [self.class, index, options]
+        [self.class, options, index]
       end
-
 
       # Wraps block execution in a thread-safe transaction
       def transaction(&block)

--- a/spec/rates_store/memory_spec.rb
+++ b/spec/rates_store/memory_spec.rb
@@ -66,4 +66,15 @@ describe Money::RatesStore::Memory do
       end
     end
   end
+
+  describe '#marshal_dump' do
+    let(:subject) { Money::RatesStore::Memory.new(:optional => true) }
+
+    it 'can reload' do
+      bank = Money::Bank::VariableExchange.new(subject)
+      bank = Marshal.load(Marshal.dump(bank))
+      expect(bank.store.instance_variable_get(:@options)).to eq subject.instance_variable_get(:@options)
+      expect(bank.store.instance_variable_get(:@index)).to eq subject.instance_variable_get(:@index)
+    end
+  end
 end


### PR DESCRIPTION
Discovered a bug when I was testing conversion with a rails app. The test helper was setting a memory store with mock rates. When I ran just the single test there was no issues, but running the whole suite made the currency conversion fail.

I finally figured out it was due to the marshal dump, the arguments were in reverse order. This fixes the issue, and adding spec for the marshal dump.