### PR TITLE
eql? returns false for 0 value moneys of differing currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+- #eql? returns false when comparing Moneys with
+  fractional value of 0 and differing currencies.
+  This change aligns #eql? with #hash.
+
 ## 6.9.0
 - Extracted heuristics into money-heuristics gem
 

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -20,11 +20,10 @@ class Money
     end
 
     # Checks whether two Money objects have the same currency and the same
-    # amount. If Money objects have a different currency it will only be true
-    # if the amounts are both zero. Checks against objects that are not Money or
-    # a subclass will always return false.
+    # amount. Checks against objects that are not Money will always return
+    # false.
     #
-    # @param [Money] other_money Value to compare with.
+    # @param [Money] other Value to compare with.
     #
     # @return [Boolean]
     #
@@ -32,15 +31,12 @@ class Money
     #   Money.new(100).eql?(Money.new(101))                #=> false
     #   Money.new(100).eql?(Money.new(100))                #=> true
     #   Money.new(100, "USD").eql?(Money.new(100, "GBP"))  #=> false
-    #   Money.new(0, "USD").eql?(Money.new(0, "EUR"))      #=> true
+    #   Money.new(0, "USD").eql?(Money.new(0, "EUR"))      #=> false
     #   Money.new(100).eql?("1.00")                        #=> false
-    def eql?(other_money)
-      if other_money.is_a?(Money)
-        (fractional == other_money.fractional && currency == other_money.currency) ||
-          (fractional == 0 && other_money.fractional == 0)
-      else
-        false
-      end
+    def eql?(other)
+      other.is_a?(Money) &&
+        fractional == other.fractional &&
+        currency == other.currency
     end
 
     # Compares two Money objects. If money objects have a different currency it

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -66,12 +66,7 @@ describe Money do
       expect(Money.new(1_00, "USD").eql?(Money.new(1_00, "EUR"))).to  be false
       expect(Money.new(1_00, "USD").eql?(Money.new(2_00, "USD"))).to  be false
       expect(Money.new(1_00, "USD").eql?(Money.new(99_00, "EUR"))).to be false
-    end
-
-    it "returns true when their amounts are zero and currencies differ" do
-      expect(Money.new(0, "USD").eql?(Money.new(0, "EUR"))).to be true
-      expect(Money.new(0, "USD").eql?(Money.new(0, "USD"))).to be true
-      expect(Money.new(0, "AUD").eql?(Money.new(0, "EUR"))).to be true
+      expect(Money.new(0,    "USD").eql?(Money.new(0,     "EUR"))).to be false
     end
 
     it "returns false if used to compare with an object that doesn't inherit from Money" do


### PR DESCRIPTION
### Context

Re the discussion in PR https://github.com/RubyMoney/money/pull/705#issuecomment-306064365 it was decided that the `#eql?` method should align with our `#hash` implementation.

[docs](https://ruby-doc.org/core-2.4.1/Object.html#method-i-hash):
>This function must have the property that `a.eql?(b)` implies `a.hash == b.hash`. 

In the current implementation this property is not upheld in the case where both `a` and `b` have zero value:

```ruby
a = Money.new(0, 'USD')
b = Money.new(0, 'AUD')
a.eql?(b) #=> true
a.hash == b.hash #=> false
```

### Change

Remove the special handling of zero value money instances from the `#eql?` implementation. Instead we have a hard rule: both `fractional` and `currency` must be equal for `#eql?` to return `true`.

In the above example:

```ruby
a = Money.new(0, 'USD')
b = Money.new(0, 'AUD')
a.eql?(b) #=> false
a.hash == b.hash #=> false
```

As `a.eql?(b)` is false there is no requirement for `a.hash == b.hash` to be true. Thus, it satisfies the contract as specified in the Ruby documentation.

@antstorm As this is a breaking change, I've opened this PR against the `v7_new` branch. Is this appropriate?