### PR TITLE
Fix for XTS ISO code

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -2561,7 +2561,7 @@
   },
   "xts": {
     "priority": 100,
-    "iso_code": "xts",
+    "iso_code": "XTS",
     "name": "Codes specifically reserved for testing purposes",
     "symbol": "",
     "alternate_symbols": [],


### PR DESCRIPTION
Micro update here. I noticed that the `iso_code` for XTS was all lowercase in the data, but according to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) it should be all uppercase just like any other code.