### PR TITLE
Fix KZT symbol

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -1202,7 +1202,7 @@
     "priority": 100,
     "iso_code": "KZT",
     "name": "Kazakhstani Tenge",
-    "symbol": "〒",
+    "symbol": "₸",
     "alternate_symbols": [],
     "subunit": "Tiyn",
     "subunit_to_unit": 100,


### PR DESCRIPTION
It was using postal mark: http://unicodelookup.com/#〒/1