### PR TITLE
Add Chinese Yuan Offshore (CNH)

### DIFF
--- a/config/currency_non_iso.json
+++ b/config/currency_non_iso.json
@@ -99,6 +99,7 @@
     "iso_code": "CNH",
     "name": "Chinese Renminbi Yuan Offshore",
     "symbol": "¥",
+    "disambiguate_symbol": "CNH",
     "alternate_symbols": ["CN¥", "元", "CN元"],
     "subunit": "Fen",
     "subunit_to_unit": 100,

--- a/config/currency_non_iso.json
+++ b/config/currency_non_iso.json
@@ -93,5 +93,20 @@
     "thousands_separator": ",",
     "iso_numeric": "",
     "smallest_denomination": 1
+  },
+  "cnh": {
+    "priority": 100,
+    "iso_code": "CNH",
+    "name": "Chinese Renminbi Yuan Offshore",
+    "symbol": "¥",
+    "alternate_symbols": ["CN¥", "元", "CN元"],
+    "subunit": "Fen",
+    "subunit_to_unit": 100,
+    "symbol_first": true,
+    "html_entity": "￥",
+    "decimal_mark": ".",
+    "thousands_separator": ",",
+    "iso_numeric": "",
+    "smallest_denomination": 1
   }
 }


### PR DESCRIPTION
Add offshore Chinese Yuan (CNH). Most properties same like in CNY.
(reference: https://en.wikipedia.org/wiki/Renminbi)