### PR TITLE
Update the bundler on Travis to the latest available version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
     - rvm: jruby-head
     - rvm: rbx-2
   fast_finish: true
+before_install:
+  - gem update bundler
 script: bundle exec rspec spec
 notifications:
   email:


### PR DESCRIPTION
Seems like bundler shipped with rubies on TravisCI is very old (1.7.6). Which I think is causing this issue:

<img width="722" alt="screenshot 2017-09-05 09 35 37" src="https://user-images.githubusercontent.com/118353/30052543-b144e0cc-921d-11e7-9642-93c172980b0f.png">

This PR should fix it.