### PR TITLE
Update money.gemspec

### DIFF
--- a/money.gemspec
+++ b/money.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = "A Ruby Library for dealing with money and currency conversion."
   s.license     = "MIT"
 
-  s.add_dependency 'i18n', ['>= 0.6.4', '< 0.9']
+  s.add_dependency 'i18n', ">= 0.6.4"
 
   s.add_development_dependency "bundler", "~> 1.3"
   s.add_development_dependency "rake"


### PR DESCRIPTION
i18n version 0.9 has been released. Money's constraint on the version is "<0.9" so it's blocking update.

This PR relaxes constraint in the i18n version so that upgrading is unblocked.

Tests are passing.