### PR TITLE
Fix a bug for `Money.zero`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Filipe Goncalves
 Francisco Trindade
 François Beausoleil
 François Klingler
+Fred Liang
 Gabriel Gilder
 Gee-Hsien Chuang
 George Millo

--- a/lib/money/money/constructors.rb
+++ b/lib/money/money/constructors.rb
@@ -11,6 +11,7 @@ class Money
     #   Money.empty #=> #<Money @fractional=0>
     def empty(currency = default_currency)
       @empty ||= {}
+      currency = Currency.new(currency)
       @empty[currency] ||= new(0, currency).freeze
     end
     alias_method :zero, :empty

--- a/spec/money/constructors_spec.rb
+++ b/spec/money/constructors_spec.rb
@@ -19,6 +19,14 @@ describe Money::Constructors do
       expect(Money.empty).to be_frozen
     end
 
+    it "always use Currency object to memoize Money objects" do
+      Money.instance_variable_set(:@empty, {})
+      expect {
+        Money.zero(:usd)
+        Money.zero
+      }.to_not raise_error
+    end
+
     it "instantiates a subclass when inheritance is used" do
       special_money_class = Class.new(Money)
       expect(special_money_class.empty).to be_a special_money_class


### PR DESCRIPTION
## What is the issue

Steps to reproduce the bug:

1. start a new ruby console by running `irb`
2. Run the following code
  ```rb
    require 'money'
    Money.zero(:usd)
    Money.zero
  ```
3. then you will see an error like
  ```
  NoMethodError: undefined method `priority' for :usd:Symbol
  ```

## Why it's happening

Here is another way to reproduce the issue

```rb
h = {usd: Money.new(1)}
h[Money.default_currency]
```
When we are trying to look up a value by Money::Currency, it invokes `currency <=> :usd`, since `:usd` doesn't have `priority` method, that's why we see the error.

Not sure if I should change CHANGELOG because this is a bugfix