### PR TITLE
Money Collection

### DIFF
--- a/lib/money/collection.rb
+++ b/lib/money/collection.rb
@@ -21,11 +21,21 @@ class Money
       if @group_by_currency.size == 1
         sum = self.class.sum_single_currency(@collection)
       else
-        sum = self.class.sum_basic(
-          @group_by_currency.values.map{|moneys|
-            self.class.sum_single_currency(moneys)
-          }
-        )
+        sums_per_currency = @group_by_currency.values.map{|moneys|
+          self.class.sum_single_currency(moneys)
+        }
+
+        # If target_currency is specified, and is in collection,
+        # move it to the front so it has precedence over other currencies.
+        if target_currency
+          target_currency = self.class.convert_to_currency_object(target_currency)
+          if index = sums_per_currency.find_index{|money| money.currency == target_currency}
+            money = sums_per_currency.delete_at(index)
+            sums_per_currency.unshift money
+          end
+        end
+
+        sum = self.class.sum_basic(sums_per_currency)
       end
 
       if target_currency.nil?
@@ -84,6 +94,15 @@ class Money
     def self.sum_single_currency(moneys)
       total_fractional = moneys.reduce(0){|fractional, money| fractional += money.fractional }
       Money.new(total_fractional, moneys[0].currency)
+    end
+
+    def self.convert_to_currency_object(currency)
+      case currency
+      when String, Symbol
+        ::Money::Currency.new(currency)
+      when ::Money::Currency
+        currency
+      end
     end
   end
 end

--- a/lib/money/collection.rb
+++ b/lib/money/collection.rb
@@ -1,0 +1,4 @@
+class Money
+  class Collection
+  end
+end

--- a/lib/money/collection.rb
+++ b/lib/money/collection.rb
@@ -1,4 +1,60 @@
 class Money
   class Collection
+    include Enumerable
+
+    # @parma array [#to_a] collection of Money objects
+    def initialize(array = nil)
+      @collection = array.to_a
+    end
+
+    # Sums up Money objects in collection.
+    # @param target_currency [Currency, String, Symbol] - currency of the returning money object.
+    # @return [Money] sum of Money collection.
+    def sum(target_currency = nil)
+      if @collection.empty?
+        return Money.new(0, target_currency)
+      end
+
+      moneys_by_currency = @collection.group_by{|money|
+        money.currency
+      }.values
+
+      sum = self.class.sum_basic(moneys_by_currency.map{|moneys| self.class.sum_basic(moneys)})
+      if target_currency.nil?
+        sum
+      else
+        sum.exchange_to(target_currency)
+      end
+    end
+
+    #### delegations
+
+    def each
+      if block_given?
+        @collection.each{|x| yield(x)}
+        self
+      else
+        @collection.each
+      end
+    end
+
+    def <<(obj)
+      @collection << obj
+      self
+    end
+
+    def concat(other_ary)
+      @collection.concat(other_ary)
+      self
+    end
+
+    private
+
+    # Sums up Money objects using built-in :+ method.
+    # @param moneys [Enumerable<Money>] list of Moneys.
+    # @return [Money] sum of Money collection.
+    def self.sum_basic(moneys)
+      moneys.reduce{|total, money| total + money }
+    end
   end
 end

--- a/lib/money/collection.rb
+++ b/lib/money/collection.rb
@@ -24,16 +24,16 @@ class Money
           sum = sum.exchange_to(target_currency)
         end
       else
-        sums_per_currency = @group_by_currency.values.map{|moneys|
+        sums_per_currency = @group_by_currency.values.map do |moneys|
           self.class.sum_single_currency(moneys)
-        }
+        end
 
         # Convert to target_currency if specified
         if target_currency
           target_currency = Money::Currency.wrap(target_currency)
-          sums_per_currency.map!{|s|
+          sums_per_currency.map! do |s|
             s.exchange_to(target_currency)
-          }
+          end
         end
 
         sum = self.class.sum_basic(sums_per_currency)
@@ -43,15 +43,15 @@ class Money
     end
 
     def max
-      @group_by_currency.values.map{|moneys|
+      @group_by_currency.values.map do |moneys|
         moneys.max_by{|money| money.fractional}
-      }.max
+      end.max
     end
 
     def min
-      @group_by_currency.values.map{|moneys|
+      @group_by_currency.values.map do |moneys|
         moneys.min_by{|money| money.fractional}
-      }.min
+      end.min
     end
 
     #### delegations

--- a/lib/money/collection.rb
+++ b/lib/money/collection.rb
@@ -28,7 +28,7 @@ class Money
         # If target_currency is specified, and is in collection,
         # move it to the front so it has precedence over other currencies.
         if target_currency
-          target_currency = self.class.convert_to_currency_object(target_currency)
+          target_currency = Money::Currency.wrap(target_currency)
           if index = sums_per_currency.find_index{|money| money.currency == target_currency}
             money = sums_per_currency.delete_at(index)
             sums_per_currency.unshift money
@@ -110,15 +110,6 @@ class Money
     def self.sum_single_currency(moneys)
       total_fractional = moneys.reduce(0){|fractional, money| fractional += money.fractional }
       Money.new(total_fractional, moneys[0].currency)
-    end
-
-    def self.convert_to_currency_object(currency)
-      case currency
-      when String, Symbol
-        ::Money::Currency.new(currency)
-      when ::Money::Currency
-        currency
-      end
     end
   end
 end

--- a/lib/money/collection.rb
+++ b/lib/money/collection.rb
@@ -90,6 +90,10 @@ class Money
       self
     end
 
+    def size
+      @collection.size
+    end
+
     private
 
     # Sums up Money objects using built-in :+ method.

--- a/lib/money/collection.rb
+++ b/lib/money/collection.rb
@@ -80,11 +80,11 @@ class Money
 
     def concat(other_ary)
       @collection.concat(other_ary)
-      other_ary.each do |obj|
-        if @group_by_currency[obj.currency].nil?
-          @group_by_currency[obj.currency] = [obj]
+      other_ary.group_by(&:currency).each do |currency, ary|
+        if @group_by_currency[currency].nil?
+          @group_by_currency[currency] = ary
         else
-          @group_by_currency[obj.currency] << obj
+          @group_by_currency[currency].concat(ary)
         end
       end
       self

--- a/lib/money/collection.rb
+++ b/lib/money/collection.rb
@@ -45,6 +45,18 @@ class Money
       end
     end
 
+    def max
+      @group_by_currency.values.map{|moneys|
+        moneys.max_by{|money| money.fractional}
+      }.max
+    end
+
+    def min
+      @group_by_currency.values.map{|moneys|
+        moneys.min_by{|money| money.fractional}
+      }.min
+    end
+
     #### delegations
 
     def each

--- a/lib/money/collection.rb
+++ b/lib/money/collection.rb
@@ -4,7 +4,7 @@ class Money
 
     # @parma array [#to_a] collection of Money objects
     def initialize(array = nil)
-      @collection = array.to_a
+      @collection = array.to_a.dup
     end
 
     # Sums up Money objects in collection.

--- a/lib/money/collection.rb
+++ b/lib/money/collection.rb
@@ -1,3 +1,5 @@
+require 'money'
+
 class Money
   class Collection
     include Enumerable

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -91,6 +91,24 @@ RSpec.describe Money::Collection do
       expect(c.sum('foo')).to eq(Money.new(22,:foo))
       expect(c.sum('usd')).to eq(Money.new(11,:usd))
     end
+
+    it 'sums large number of Money' do
+      10.times do
+        # force first bunch to be FOO, the a bunch of USD,
+        # so there won't be currency conversion error even for native sum method
+        ary = 1000.times.map do
+          Money.new(Random.rand(100000), :foo)
+        end
+        ary.concat(
+          1000.times.map do
+            Money.new(Random.rand(100000), :usd)
+          end
+        )
+
+        c = Money::Collection.new(ary)
+        expect(c.sum('foo')).to eq(normal_sum(ary))
+      end
+    end
   end
 
   describe '#concat' do

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -95,4 +95,17 @@ RSpec.describe Money::Collection do
       expect(c.sum('foo')).to eq(Money.new(22,:foo))
     end
   end
+
+  describe 'no side effect' do
+    it 'does not change original array that is passed in the initialize method' do
+      m1 = Money.new(10,:usd)
+      ary = [m1]
+
+      c = Money::Collection.new(ary)
+      c << Money.new(1,:usd)
+
+      expect(ary.size).to eq(1)
+      expect(ary[0]).to eq(m1)
+    end
+  end
 end

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -111,6 +111,52 @@ RSpec.describe Money::Collection do
     end
   end
 
+  describe '#min' do
+    it 'returns accurate smallest Money object' do
+      ary = [
+        Money.new(30,:foo),
+        Money.new(1,:usd),
+        Money.new(3,:foo),
+      ]
+
+      c = Money::Collection.new(ary)
+      expect(c.min).to eq(Money.new(1,:usd))
+    end
+
+    it 'returns smallest Money objects (from many items)' do
+      ary = 1000.times.map do
+        Money.new(Random.rand(100000) + 10, :foo)
+      end
+      c = Money::Collection.new(ary)
+      min = Money.new(1, :usd)
+      c << min
+      expect(c.min).to eq(min)
+    end
+  end
+
+  describe '#max' do
+    it 'returns accurate biggest Money object' do
+      ary = [
+        Money.new(30,:foo),
+        Money.new(1,:usd),
+        Money.new(3,:foo),
+      ]
+
+      c = Money::Collection.new(ary)
+      expect(c.max).to eq(Money.new(30,:foo))
+    end
+
+    it 'returns biggest Money objects (from many items)' do
+      ary = 1000.times.map do
+        Money.new(Random.rand(100000), :foo)
+      end
+      c = Money::Collection.new(ary)
+      max = Money.new(100001, :usd)
+      c << max
+      expect(c.max).to eq(max)
+    end
+  end
+
   describe '#concat' do
     it 'concats Money objects to collection' do
       ary = [

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe Money::Collection do
       expect(c.sum).to eq(Money.new(11,:usd))
     end
 
+    it 'sums correctly, avoiding rounding twice if possible' do
+      ary = [
+        Money.new(10,:usd),
+        Money.new(1,:foo),
+      ]
+
+      c = Money::Collection.new(ary)
+
+      expect(c.sum(:foo)).to eq(Money.new(21,:foo))
+    end
+
     it 'returns sum in the specified currency' do
       ary = [
         Money.new(10,:usd),

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -16,10 +16,21 @@ RSpec.describe Money::Collection do
 
     Money.add_rate("FOO", "USD", 0.5)
     Money.add_rate("USD", "FOO", 2)
+
+
+    bar = {
+      :iso_code        => "BAR",
+      :subunit_to_unit => 100,
+    }
+    Money::Currency.register(bar)
+
+    Money.add_rate("BAR", "FOO", 1)
+    Money.add_rate("FOO", "BAR", nil) # Disallow conversion
   end
 
   after :all do
     Money::Currency.unregister("FOO")
+    Money::Currency.unregister("BAR")
   end
 
   describe '#sum' do
@@ -90,6 +101,17 @@ RSpec.describe Money::Collection do
 
       expect(c.sum('foo')).to eq(Money.new(22,:foo))
       expect(c.sum('usd')).to eq(Money.new(11,:usd))
+    end
+
+    it 'returns sum in the specified currency and without unnecessary intermediate conversion' do
+      ary = [
+        Money.new(10,:usd),
+        Money.new(1,:bar),
+      ]
+
+      c = Money::Collection.new(ary)
+
+      expect(c.sum('foo')).to eq(Money.new(21,:foo))
     end
 
     it 'sums large number of Money' do

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+require 'money/collection'
+
+RSpec.describe Money::Collection do
+  # Adds up array of Money one by one and returns the sum.
+  def normal_sum(array)
+    array.reduce{|total, money| total + money }
+  end
+
+  before :all do
+    foo = {
+      :iso_code        => "FOO",
+      :subunit_to_unit => 100,
+    }
+    Money::Currency.register(foo)
+
+    Money.add_rate("FOO", "USD", 0.5)
+    Money.add_rate("USD", "FOO", 2)
+  end
+
+  after :all do
+    Money::Currency.unregister("FOO")
+  end
+
+  describe '#sum' do
+    it 'sums with no element' do
+      c = Money::Collection.new
+      expect(c.sum).to eq(Money.zero)
+    end
+
+    it 'sums with single element' do
+      c = Money::Collection.new
+      c << Money.new(10,:usd)
+      expect(c.sum).to eq(Money.new(10,:usd))
+    end
+
+    it 'sums same currency' do
+      ary = [
+        Money.new(10,:usd),
+        Money.new(20,:usd),
+        Money.new(30,:usd),
+      ]
+
+      c = Money::Collection.new(ary)
+
+      expect(c.sum).to eq(Money.new(60,:usd))
+    end
+
+    it 'sums different currencies' do
+      ary = [
+        Money.new(100,:usd),
+        Money.new(10,:foo),
+      ]
+
+      c = Money::Collection.new(ary)
+
+      expect(c.sum).to eq(normal_sum(ary))
+    end
+
+    it 'sums correctly, avoiding rounding down error' do
+      ary = [
+        Money.new(10,:usd),
+        Money.new(1,:foo),
+        Money.new(1,:foo),
+      ]
+
+      c = Money::Collection.new(ary)
+
+      expect(c.sum).to eq(Money.new(11,:usd))
+    end
+
+    it 'returns sum in the specified currency' do
+      ary = [
+        Money.new(10,:usd),
+        Money.new(2,:foo),
+      ]
+
+      c = Money::Collection.new(ary)
+
+      expect(c.sum('foo')).to eq(Money.new(22,:foo))
+      expect(c.sum('usd')).to eq(Money.new(11,:usd))
+    end
+  end
+
+  describe '#concat' do
+    it 'concats Money objects to collection' do
+      ary = [
+        Money.new(10,:usd),
+        Money.new(2,:foo),
+      ]
+
+      c = Money::Collection.new
+      c.concat ary
+
+      expect(c.sum('foo')).to eq(Money.new(22,:foo))
+    end
+  end
+end

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -94,6 +94,30 @@ RSpec.describe Money::Collection do
 
       expect(c.sum('foo')).to eq(Money.new(22,:foo))
     end
+
+    it 'concats Money objects to collection multiple times' do
+      ary = [
+        Money.new(10,:usd),
+        Money.new(2,:foo),
+      ]
+
+      c = Money::Collection.new
+      c.concat ary
+      c.concat ary
+
+      expect(c.sum('foo')).to eq(Money.new(44,:foo))
+    end
+  end
+
+  describe '#<<' do
+    it 'concats Money object to collection multiple times' do
+      c = Money::Collection.new
+      c << Money.new(10,:usd)
+      c << Money.new(10,:foo)
+      c << Money.new(10,:usd)
+
+      expect(c.sum).to eq(Money.new(25,:usd))
+    end
   end
 
   describe 'no side effect' do

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -167,6 +167,7 @@ RSpec.describe Money::Collection do
       c = Money::Collection.new
       c.concat ary
 
+      expect(c.size).to eq(2)
       expect(c.sum('foo')).to eq(Money.new(22,:foo))
     end
 
@@ -180,6 +181,7 @@ RSpec.describe Money::Collection do
       c.concat ary
       c.concat ary
 
+      expect(c.size).to eq(4)
       expect(c.sum('foo')).to eq(Money.new(44,:foo))
     end
   end


### PR DESCRIPTION
Fix #734 

I think once people are okay with the interface and implementation, then I'll add documentations to readme and changelog so it is mergeable

----

Calculating sum/min/max on a bunch of Money objects, with accuracy and efficiency.

This is achieved by minimizing number of currency conversions and object creations.

For large collections, sum/min/max can perform up to 4 times as fast. For small collections (n<10), it can perform at least 2 times as fast.