### PR TITLE
Extract formatting into a separate module

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -17,7 +17,6 @@ require "money/money/formatter"
 class Money
   include Comparable
   include Money::Arithmetic
-  include Money::Formatter
   extend Constructors
 
   # Raised when smallest denomination of a currency is not defined
@@ -543,6 +542,32 @@ class Money
     else
       self
     end
+  end
+
+  # Creates a formatted price string according to several rules.
+  #
+  # @param [Hash] See Money::Formatter for the list of formatting options
+  #
+  # @return [String]
+  #
+  def format(*rules)
+    Money::Formatter.new(self, *rules).to_s
+  end
+
+  # Returns a thousands separator according to the locale
+  #
+  # @return [String]
+  #
+  def thousands_separator
+    Money::Formatter.new(self, {}).thousands_separator
+  end
+
+  # Returns a decimal mark according to the locale
+  #
+  # @return [String]
+  #
+  def decimal_mark
+    Money::Formatter.new(self, {}).decimal_mark
   end
 
   private

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -3,7 +3,7 @@ require "money/bank/variable_exchange"
 require "money/bank/single_currency"
 require "money/money/arithmetic"
 require "money/money/constructors"
-require "money/money/formatting"
+require "money/money/formatter"
 
 # "Money is any object or record that is generally accepted as payment for
 # goods and services and repayment of debts in a given socio-economic context
@@ -17,7 +17,7 @@ require "money/money/formatting"
 class Money
   include Comparable
   include Money::Arithmetic
-  include Money::Formatting
+  include Money::Formatter
   extend Constructors
 
   # Raised when smallest denomination of a currency is not defined

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -358,10 +358,10 @@ class Money
             if fraction == ""
               unit
             else
-              "#{unit}#{decimal_mark}#{fraction}"
+              "#{unit}#{currency.decimal_mark}#{fraction}"
             end
           else
-            "#{unit}#{decimal_mark}#{pad_subunit(subunit)}#{fraction}"
+            "#{unit}#{currency.decimal_mark}#{pad_subunit(subunit)}#{fraction}"
           end
 
     fractional < 0 ? "-#{str}" : str

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 class Money
-  module Formatting
+  module Formatter
     # Creates a formatted price string according to several rules.
     #
     # @param [Hash] rules The options used to format the string.

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -350,77 +350,77 @@ class Money
                        "\\1#{rules[:decimal_mark]}\\3")
       end
     end
-  end
 
-  def default_formatting_rules
-    self.class.default_formatting_rules || {}
-  end
+    def default_formatting_rules
+      self.class.default_formatting_rules || {}
+    end
 
-  def regexp_format(formatted, rules, decimal_mark, symbol_value)
-    regexp_decimal = Regexp.escape(decimal_mark)
-    if rules[:south_asian_number_formatting]
-      /(\d+?)(?=(\d\d)+(\d)(?:\.))/
-    else
-      # Symbols may contain decimal marks (E.g "դր.")
-      if formatted.sub(symbol_value.to_s, "") =~ /#{regexp_decimal}/
-        /(\d)(?=(?:\d{3})+(?:#{regexp_decimal}))/
+    def regexp_format(formatted, rules, decimal_mark, symbol_value)
+      regexp_decimal = Regexp.escape(decimal_mark)
+      if rules[:south_asian_number_formatting]
+        /(\d+?)(?=(\d\d)+(\d)(?:\.))/
       else
-        /(\d)(?=(?:\d{3})+(?:[^\d]{1}|$))/
-      end
-    end
-  end
-
-  def translate_formatting_rules(rules)
-    begin
-      rules[:symbol] = I18n.t currency.iso_code, :scope => "number.currency.symbol", :raise => true
-    rescue I18n::MissingTranslationData
-      # Do nothing
-    end
-    rules
-  end
-
-  def localize_formatting_rules(rules)
-    if currency.iso_code == "JPY" && I18n.locale == :ja
-      rules[:symbol] = "円" unless rules[:symbol] == false
-      rules[:symbol_position] = :after
-      rules[:symbol_after_without_space] = true
-    end
-    rules
-  end
-
-  def symbol_value_from(rules)
-    if rules.has_key?(:symbol)
-      if rules[:symbol] === true
-        if rules[:disambiguate] && currency.disambiguate_symbol
-          currency.disambiguate_symbol
+        # Symbols may contain decimal marks (E.g "դր.")
+        if formatted.sub(symbol_value.to_s, "") =~ /#{regexp_decimal}/
+          /(\d)(?=(?:\d{3})+(?:#{regexp_decimal}))/
         else
-          symbol
+          /(\d)(?=(?:\d{3})+(?:[^\d]{1}|$))/
         end
-      elsif rules[:symbol]
-        rules[:symbol]
-      else
-        ""
       end
-    elsif rules[:html]
-      currency.html_entity == '' ? currency.symbol : currency.html_entity
-    elsif rules[:disambiguate] && currency.disambiguate_symbol
-      currency.disambiguate_symbol
-    else
-      symbol
     end
-  end
 
-  def symbol_position_from(rules)
-    if rules.has_key?(:symbol_position)
-      if [:before, :after].include?(rules[:symbol_position])
-        return rules[:symbol_position]
-      else
-        raise ArgumentError, ":symbol_position must be ':before' or ':after'"
+    def translate_formatting_rules(rules)
+      begin
+        rules[:symbol] = I18n.t currency.iso_code, :scope => "number.currency.symbol", :raise => true
+      rescue I18n::MissingTranslationData
+        # Do nothing
       end
-    elsif currency.symbol_first?
-      :before
-    else
-      :after
+      rules
+    end
+
+    def localize_formatting_rules(rules)
+      if currency.iso_code == "JPY" && I18n.locale == :ja
+        rules[:symbol] = "円" unless rules[:symbol] == false
+        rules[:symbol_position] = :after
+        rules[:symbol_after_without_space] = true
+      end
+      rules
+    end
+
+    def symbol_value_from(rules)
+      if rules.has_key?(:symbol)
+        if rules[:symbol] === true
+          if rules[:disambiguate] && currency.disambiguate_symbol
+            currency.disambiguate_symbol
+          else
+            symbol
+          end
+        elsif rules[:symbol]
+          rules[:symbol]
+        else
+          ""
+        end
+      elsif rules[:html]
+        currency.html_entity == '' ? currency.symbol : currency.html_entity
+      elsif rules[:disambiguate] && currency.disambiguate_symbol
+        currency.disambiguate_symbol
+      else
+        symbol
+      end
+    end
+
+    def symbol_position_from(rules)
+      if rules.has_key?(:symbol_position)
+        if [:before, :after].include?(rules[:symbol_position])
+          return rules[:symbol_position]
+        else
+          raise ArgumentError, ":symbol_position must be ':before' or ':after'"
+        end
+      elsif currency.symbol_first?
+        :before
+      else
+        :after
+      end
     end
   end
 end

--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -1,0 +1,71 @@
+# encoding: UTF-8
+
+class Money
+  class FormattingRules
+    def initialize(currency, *raw_rules)
+      @currency = currency
+
+      # support for old format parameters
+      @rules = normalize_formatting_rules(raw_rules)
+
+      @rules = default_formatting_rules.merge(@rules)
+      @rules = localize_formatting_rules(@rules)
+      @rules = translate_formatting_rules(@rules) if @rules[:translate]
+    end
+
+    def [](key)
+      @rules[key]
+    end
+
+    def has_key?(key)
+      @rules.has_key? key
+    end
+
+    private
+
+    attr_reader :currency
+
+    # Cleans up formatting rules.
+    #
+    # @param [Hash] rules
+    #
+    # @return [Hash]
+    def normalize_formatting_rules(rules)
+      if rules.size == 0
+        rules = {}
+      elsif rules.size == 1
+        rules = rules.pop
+        rules = { rules => true } if rules.is_a?(Symbol)
+      end
+      if !rules.include?(:decimal_mark) && rules.include?(:separator)
+        rules[:decimal_mark] = rules[:separator]
+      end
+      if !rules.include?(:thousands_separator) && rules.include?(:delimiter)
+        rules[:thousands_separator] = rules[:delimiter]
+      end
+      rules
+    end
+
+    def default_formatting_rules
+      Money.default_formatting_rules || {}
+    end
+
+    def translate_formatting_rules(rules)
+      begin
+        rules[:symbol] = I18n.t currency.iso_code, :scope => "number.currency.symbol", :raise => true
+      rescue I18n::MissingTranslationData
+        # Do nothing
+      end
+      rules
+    end
+
+    def localize_formatting_rules(rules)
+      if currency.iso_code == "JPY" && I18n.locale == :ja
+        rules[:symbol] = "円" unless rules[:symbol] == false
+        rules[:symbol_position] = :after
+        rules[:symbol_after_without_space] = true
+      end
+      rules
+    end
+  end
+end


### PR DESCRIPTION
Formatting is a separate concern and there's no good reason for including it into the `Money` class. This PR extracts it into a class which `Money` uses to format the output.