### PR TITLE
Change HUF denomination

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,6 +99,7 @@ pivotal-cloudplanner
 Prathan Thananart
 Robert Starsi
 Romain Gérard
+Roman Shatsov
 Ryan Bigg
 sankaranarayanan
 Scott Pierce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.0.0
+- Set HUF subunit config according to ISO
+
 ## 6.10.1
 - Fix an issue with Money.empty memoization
 

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -932,13 +932,13 @@
     "symbol": "Ft",
     "alternate_symbols": [],
     "subunit": "",
-    "subunit_to_unit": 1,
+    "subunit_to_unit": 100,
     "symbol_first": false,
     "html_entity": "",
     "decimal_mark": ",",
     "thousands_separator": " ",
     "iso_numeric": "348",
-    "smallest_denomination": 5
+    "smallest_denomination": 500
   },
   "idr": {
     "priority": 100,


### PR DESCRIPTION
`subunit_to_unit` for HUF was changed from 100 to 1 in #679. According to [ISO](https://www.iso.org/iso-4217-currency-codes.html) (https://www.currency-iso.org/dam/downloads/lists/list_one.xml) and [Wikipedia](https://en.wikipedia.org/wiki/Hungarian_forint) `subunit_to_unit` for HUF is 100. It is important to have HUF configured according to ISO because usually cents is used in communication between services. Also, https://github.com/RubyMoney/money-rails gem recommends to store amount in cents.