### PR TITLE
Fix case of coerced zero numeric subtraction.

### DIFF
--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -125,7 +125,9 @@ class Money
     [:+, :-].each do |op|
       define_method(op) do |other|
         unless other.is_a?(Money)
-          return self if other.zero?
+          if other.zero?
+            return other.is_a?(CoercedNumeric) ? Money.empty.public_send(op, self) : self
+          end
           raise TypeError
         end
         other = other.exchange_to(currency)

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -654,6 +654,11 @@ describe Money do
       }.to raise_exception(TypeError)
     end
 
+    it "allows subtraction from numeric zero" do
+      result = 0 - Money.new(4, 'USD')
+      expect(result).to eq Money.new(-4, 'USD')
+    end
+
     it "treats multiplication as commutative" do
       expect {
         2 * Money.new(2, 'USD')

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -659,6 +659,11 @@ describe Money do
       expect(result).to eq Money.new(-4, 'USD')
     end
 
+    it "allows addition from numeric zero" do
+      result = 0 + Money.new(4, 'USD')
+      expect(result).to eq Money.new(4, 'USD')
+    end
+
     it "treats multiplication as commutative" do
       expect {
         2 * Money.new(2, 'USD')


### PR DESCRIPTION
## Before:

This works as expected:

```ruby
Money.new(0) - Money.new(100)
=> #<Money fractional:-100 currency:USD>
```

But this does not:
```ruby
0 - Money.new(100)
=> #<Money fractional:100 currency:USD>
```

A common case for the above would be when summing a list and subtracing a value from the sum. For instance, this works:

```ruby
my_list = [Money.new(-10), Money.new(10)]
my_list.sum - Money.new(100)
=> #<Money fractional:-100 currency:USD>
```

But if you happen to end up with an empty list and forget to handle it:

```ruby
my_list = []
my_list.sum - Money.new(100)
=> #<Money fractional:100 currency:USD>
```

Uh oh! That's a bug!

Rather than requiring the developer to know to provide a default `Money.empty` value to `.sum` (which would fix the latter issue, but not the former one), this PR addresses the underlying issue of commutativeness being assumed during coercion even on subtraction. In reality, subtraction is not commutative, even if all we care about is the zero numeric case.

## After:

Once we apply the correct order on subtraction with a zero CoercedNumeric, we get a negative monetary amount:

```ruby
0 - Money.new(100)
=> #<Money fractional:-100 currency:USD>
```

```ruby
my_list = []
my_list.sum - Money.new(100)
=> #<Money fractional:-100 currency:USD>
```