### PR TITLE
Fix for south asian number formatting

### DIFF
--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -252,9 +252,16 @@ class Money
         thousands_separator_value = rules[:thousands_separator] || ''
       end
 
+      # FIXME: This is a temporary solution for south asian number formatting and INDIAN_BAR
+      #        currency, because the regexp we use cannot handle > 3 digits after decimal mark
+      whole_part, decimal_part = formatted.split(decimal_mark, 2)
+
       # Apply thousands_separator
-      formatted.gsub!(regexp_format(formatted, rules, decimal_mark, symbol_value),
-                      "\\1#{thousands_separator_value}")
+      regexp = regexp_format(whole_part, rules, decimal_mark, symbol_value)
+      whole_part.gsub!(regexp, "\\1#{thousands_separator_value}")
+
+      # FIXME: Re-assemble the result after applying the regexp
+      formatted = [whole_part, decimal_part].compact.join(decimal_mark)
 
       symbol_position = symbol_position_from(rules)
 

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -336,7 +336,8 @@ class Money
     def regexp_format(formatted, rules, decimal_mark, symbol_value)
       regexp_decimal = Regexp.escape(decimal_mark)
       if rules[:south_asian_number_formatting]
-        /(\d+?)(?=(\d\d)+(\d)(?:\.))/
+        # from http://blog.revathskumar.com/2014/11/regex-comma-seperated-indian-currency-format.html
+        /(\d+?)(?=(\d\d)+(\d)(?!\d))(\.\d+)?/
       else
         # Symbols may contain decimal marks (E.g "դր.")
         if formatted.sub(symbol_value.to_s, "") =~ /#{regexp_decimal}/

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -405,6 +405,11 @@ describe Money, "formatting" do
         expect(Money.new(1000000000, 'INDIAN_BAR').format(:south_asian_number_formatting => true, :symbol => false)).to eq "1,00,000.0000"
         expect(Money.new(10000000).format(:south_asian_number_formatting => true)).to eq "$1,00,000.00"
       end
+
+      specify "(:south_asian_number_formatting => true and no_cents_if_whole => true) works as documented" do
+        expect(Money.new(10000000, 'INR').format(:south_asian_number_formatting => true, :symbol => false, :no_cents_if_whole => true)).to eq "1,00,000"
+        expect(Money.new(1000000000, 'INDIAN_BAR').format(:south_asian_number_formatting => true, :symbol => false, :no_cents_if_whole => true)).to eq "1,00,000"
+      end
     end
 
     describe ":thousands_separator option" do


### PR DESCRIPTION
Current regexp for south asian number formatting does not support whole numbers. This PR replaces it with the one that supports it, however there's an issue with INDIAN_BAR currency because it uses 4 decimal points causing regexp to match it as the whole part.

A potential solution would be a slight redesign of formatting logic — treat the whole part separate from the decimal part combining them after.

If anyone can come up with a better regexp I'd really appreciate it.