### PR TITLE
Refactor formatter

### DIFF
--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -207,18 +207,12 @@ class Money
     end
 
     def to_s
+      return free_text if show_free_text?
+
       thousands_separator = self.thousands_separator
       decimal_mark = self.decimal_mark
 
       escaped_decimal_mark = Regexp.escape(decimal_mark)
-
-      if money.fractional == 0
-        if rules[:display_free].respond_to?(:to_str)
-          return rules[:display_free]
-        elsif rules[:display_free]
-          return "free"
-        end
-      end
 
       symbol_value = symbol_value_from(rules)
 
@@ -313,6 +307,14 @@ class Money
     private
 
     attr_reader :money, :currency, :rules
+
+    def show_free_text?
+      money.zero? && rules[:display_free]
+    end
+
+    def free_text
+      rules[:display_free].respond_to?(:to_str) ? rules[:display_free] : 'free'
+    end
 
     def i18n_format_for(method, name, character)
       if Money.use_i18n

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -265,7 +265,7 @@ describe Money, "formatting" do
         expect(Money.new(10000, "VUV").format(:no_cents_if_whole => true, :symbol => false)).to eq "10,000"
         expect(Money.new(10034, "VUV").format(:no_cents_if_whole => true, :symbol => false)).to eq "10,034"
         expect(Money.new(10000, "MGA").format(:no_cents_if_whole => true, :symbol => false)).to eq "2,000"
-        expect(Money.new(10034, "MGA").format(:no_cents_if_whole => true, :symbol => false)).to eq "2,006.4"
+        expect(Money.new(10034, "MGA").format(:no_cents_if_whole => true, :symbol => false)).to eq "2,006.8"
         expect(Money.new(10000, "VND").format(:no_cents_if_whole => true, :symbol => false)).to eq "10.000"
         expect(Money.new(10034, "VND").format(:no_cents_if_whole => true, :symbol => false)).to eq "10.034"
         expect(Money.new(10000, "USD").format(:no_cents_if_whole => true, :symbol => false)).to eq "100"
@@ -278,7 +278,7 @@ describe Money, "formatting" do
         expect(Money.new(10000, "VUV").format(:no_cents_if_whole => false, :symbol => false)).to eq "10,000"
         expect(Money.new(10034, "VUV").format(:no_cents_if_whole => false, :symbol => false)).to eq "10,034"
         expect(Money.new(10000, "MGA").format(:no_cents_if_whole => false, :symbol => false)).to eq "2,000.0"
-        expect(Money.new(10034, "MGA").format(:no_cents_if_whole => false, :symbol => false)).to eq "2,006.4"
+        expect(Money.new(10034, "MGA").format(:no_cents_if_whole => false, :symbol => false)).to eq "2,006.8"
         expect(Money.new(10000, "VND").format(:no_cents_if_whole => false, :symbol => false)).to eq "10.000"
         expect(Money.new(10034, "VND").format(:no_cents_if_whole => false, :symbol => false)).to eq "10.034"
         expect(Money.new(10000, "USD").format(:no_cents_if_whole => false, :symbol => false)).to eq "100.00"
@@ -567,7 +567,7 @@ describe Money, "formatting" do
         expect(Money.new(BigDecimal('123.5'), "BHD").format(:rounded_infinite_precision => true)).to eq "ب.د0.124"
         expect(Money.new(BigDecimal('100.1'), "USD").format(:rounded_infinite_precision => true)).to eq "$1.00"
         expect(Money.new(BigDecimal('109.5'), "USD").format(:rounded_infinite_precision => true)).to eq "$1.10"
-        expect(Money.new(BigDecimal('1'), "MGA").format(:rounded_infinite_precision => true)).to eq "Ar0.2"
+        expect(Money.new(BigDecimal('1.7'), "MGA").format(:rounded_infinite_precision => true)).to eq "Ar0.4"
       end
 
       it "does not round fractional when set to false" do
@@ -577,7 +577,7 @@ describe Money, "formatting" do
         expect(Money.new(BigDecimal('123.5'), "BHD").format(:rounded_infinite_precision => false)).to eq "ب.د0.1235"
         expect(Money.new(BigDecimal('100.1'), "USD").format(:rounded_infinite_precision => false)).to eq "$1.001"
         expect(Money.new(BigDecimal('109.5'), "USD").format(:rounded_infinite_precision => false)).to eq "$1.095"
-        expect(Money.new(BigDecimal('1'), "MGA").format(:rounded_infinite_precision => false)).to eq "Ar0.1"
+        expect(Money.new(BigDecimal('1.7'), "MGA").format(:rounded_infinite_precision => false)).to eq "Ar0.34"
       end
 
       describe "with i18n = false" do


### PR DESCRIPTION
The former solution is really messy and ineffective — reformatting the value back and forth to get the correct result. This new solution establishes the correct numeric value first, splits it into whole and decimal parts, which are then formatted individually before being combined into the result.

While testing this I realised than MGA formatting was incorrect the whole time (this might need clarification from someone who's familiar with the currency better). I think it should be something like this:

1 Iraimbilanja = 0.2 arairy
1.5 Iraimbilanja = 0.3 ariary
6 Iraimbilanja = 1.2 ariary

You get the same result when using `.to_f` instead of a `.format`.