### PR TITLE
Do not restrict allocations sum

### DIFF
--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -591,6 +591,18 @@ YAML
       expect(moneys[1]).to eq Money.us_dollar(3)
     end
 
+    it "handles small splits" do
+      moneys = Money.us_dollar(5).allocate([0.03, 0.07])
+      expect(moneys[0]).to eq Money.us_dollar(2)
+      expect(moneys[1]).to eq Money.us_dollar(3)
+    end
+
+    it "handles large splits" do
+      moneys = Money.us_dollar(5).allocate([3, 7])
+      expect(moneys[0]).to eq Money.us_dollar(2)
+      expect(moneys[1]).to eq Money.us_dollar(3)
+    end
+
     it "does not lose pennies" do
       moneys = Money.us_dollar(100).allocate([0.333, 0.333, 0.333])
       expect(moneys[0].cents).to eq 34
@@ -629,10 +641,6 @@ YAML
         expect(Money.us_dollar(10_00).allocate(ratios).map(&:fractional)).to eq([6_67, 3_33])
         expect(Money.us_dollar(-10_00).allocate(ratios).map(&:fractional)).to eq([-6_67, -3_33])
       end
-    end
-
-    it "requires total to be less then 1" do
-      expect { Money.us_dollar(0.05).allocate([0.5, 0.6]) }.to raise_error(ArgumentError)
     end
 
     it "keeps subclasses intact" do


### PR DESCRIPTION
`Money#split(num)` handles even splits, but if we want a weighted distribution `Money#allocate(splits)` has the condition that the splits sum to a number less than 1 (including any fraction or negative number). This seems like an arbitrary restriction given that the code works fine for any splits at all.