### PR TITLE
Adding inheritance for currencies

### DIFF
--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -173,6 +173,29 @@ class Money
         @stringified_keys = stringify_keys
       end
 
+      # Inherit a new currency from existing one
+      #
+      # @param parent_iso_code [String] the international 3-letter code as defined
+      # @param curr [Hash] information about the new currency
+      # @option priority [Numeric] a numerical value you can use to sort/group
+      #   the currency list
+      # @option iso_code [String] the international 3-letter code as defined
+      #   by the ISO 4217 standard
+      # @option iso_numeric [Integer] the international 3-digit code as
+      #   defined by the ISO 4217 standard
+      # @option name [String] the currency name
+      # @option symbol [String] the currency symbol (UTF-8 encoded)
+      # @option subunit [String] the name of the fractional monetary unit
+      # @option subunit_to_unit [Numeric] the proportion between the unit and
+      #   the subunit
+      # @option separator [String] character between the whole and fraction
+      #   amounts
+      # @option delimiter [String] character between each thousands place
+      def inherit(parent_iso_code, curr)
+        parent_iso_code = parent_iso_code.downcase.to_sym
+        curr = @table.fetch(parent_iso_code, {}).dup.merge(curr)
+        register(curr)
+      end
 
       # Unregister a currency.
       #

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -176,24 +176,10 @@ class Money
       # Inherit a new currency from existing one
       #
       # @param parent_iso_code [String] the international 3-letter code as defined
-      # @param curr [Hash] information about the new currency
-      # @option priority [Numeric] a numerical value you can use to sort/group
-      #   the currency list
-      # @option iso_code [String] the international 3-letter code as defined
-      #   by the ISO 4217 standard
-      # @option iso_numeric [Integer] the international 3-digit code as
-      #   defined by the ISO 4217 standard
-      # @option name [String] the currency name
-      # @option symbol [String] the currency symbol (UTF-8 encoded)
-      # @option subunit [String] the name of the fractional monetary unit
-      # @option subunit_to_unit [Numeric] the proportion between the unit and
-      #   the subunit
-      # @option separator [String] character between the whole and fraction
-      #   amounts
-      # @option delimiter [String] character between each thousands place
+      # @param curr [Hash] See {register} method for hash structure 
       def inherit(parent_iso_code, curr)
         parent_iso_code = parent_iso_code.downcase.to_sym
-        curr = @table.fetch(parent_iso_code, {}).dup.merge(curr)
+        curr = @table.fetch(parent_iso_code, {}).merge(curr)
         register(curr)
       end
 

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -115,6 +115,32 @@ class Money
     end
 
 
+    describe ".inherit" do
+      after do
+        Currency.unregister(iso_code: "XXX") if Currency.find("XXX")
+        Currency.unregister(iso_code: "YYY") if Currency.find("YYY")
+      end
+
+      it "inherit a new currency" do
+        Currency.register(
+          iso_code: "XXX",
+          name: "Golden Doubloon",
+          symbol: "%",
+          subunit_to_unit: 100
+        )
+        Currency.inherit("XXX",
+          iso_code: "YYY",
+          symbol: "@"
+        )
+        new_currency = Currency.find("YYY")
+        expect(new_currency).not_to be_nil
+        expect(new_currency.name).to eq "Golden Doubloon"
+        expect(new_currency.symbol).to eq "@"
+        expect(new_currency.subunit_to_unit).to eq 100
+      end
+    end
+
+
     describe ".unregister" do
       it "unregisters a currency" do
         Currency.register(iso_code: "XXX")


### PR DESCRIPTION
Hey, sometimes you need to create inherited currencies, where there are couple of changes. As for me, working with cryptocurrencies, I often need almost same currency with just different precision.

```ruby
Money::Currency.register(
  priority: 1,
  iso_code: 'BTC',
  iso_numeric: 4217,
  name: 'Bitcoin',
  symbol: 'BTC',
  symbol_first: false,
  subunit: 'Satoshi',
  subunit_to_unit: 1_0000,
  thousands_separator: '.',
  decimal_mark: ','
)
```

It is really useful to have inheritance interface
```ruby
Money::Currency.inherit(:btc, {
  iso_code: 'BTC8',
  subunit_to_unit: 1_0000_0000
})
```

Let me know what you think about that? 

P.S. Not making any changelog changes because I'm not bumping version. Please mention me, if you would like me to do that. 