### PR TITLE
Custom round precision when using `infinite_precision`

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -536,9 +536,9 @@ class Money
   # @see
   #   Money.infinite_precision
   #
-  def round(rounding_mode = self.class.rounding_mode)
+  def round(rounding_mode = self.class.rounding_mode, rounding_precision = 0)
     if self.class.infinite_precision
-      self.class.new(fractional.round(0, rounding_mode), self.currency)
+      self.class.new(fractional.round(rounding_precision, rounding_mode), self.currency)
     else
       self
     end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -733,6 +733,15 @@ YAML
           expect(rounded).to be_a special_money_class
         end
       end
+
+      context "when using a specific rounding precision" do
+        let(:money) { Money.new(15.7526, 'NZD') }
+
+        it "uses the provided rounding precision" do
+          rounded = money.round(BigDecimal::ROUND_DOWN, 3)
+          expect(rounded.fractional).to eq 15.752
+        end
+      end
     end
   end
 


### PR DESCRIPTION
I want to be able to use `infinite_precision` for most of my Money values (derived from formulas), but sometimes set the precision along the way to be used in calculations down the line.

This PR adds an optional rounding precision along with the already optional rounding strategy.

