### PR TITLE
Use Formatter for #to_s

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -351,19 +351,10 @@ class Money
   # @example
   #   Money.ca_dollar(100).to_s #=> "1.00"
   def to_s
-    unit, subunit, fraction = strings_from_fractional
-
-    str = if currency.decimal_places == 0
-            if fraction == ""
-              unit
-            else
-              "#{unit}#{currency.decimal_mark}#{fraction}"
-            end
-          else
-            "#{unit}#{currency.decimal_mark}#{pad_subunit(subunit)}#{fraction}"
-          end
-
-    fractional < 0 ? "-#{str}" : str
+    format decimal_mark: currency.decimal_mark,
+           thousands_separator: '',
+           no_cents_if_whole: currency.decimal_places == 0,
+           symbol: false
   end
 
   # Return the amount of money as a BigDecimal.
@@ -573,32 +564,6 @@ class Money
     else
       BigDecimal(num.to_s.empty? ? 0 : num.to_s)
     end
-  end
-
-  def strings_from_fractional
-    unit, subunit = fractional().abs.divmod(currency.subunit_to_unit)
-
-    if self.class.infinite_precision
-      strings_for_infinite_precision(unit, subunit)
-    else
-      strings_for_base_precision(unit, subunit)
-    end
-  end
-
-  def strings_for_infinite_precision(unit, subunit)
-    subunit, fraction = subunit.divmod(BigDecimal("1"))
-    fraction = fraction.to_s("F")[2..-1] # want fractional part "0.xxx"
-    fraction = "" if fraction =~ /^0+$/
-
-    [unit.to_i.to_s, subunit.to_i.to_s, fraction]
-  end
-
-  def strings_for_base_precision(unit, subunit)
-    [unit.to_s, subunit.to_s, ""]
-  end
-
-  def pad_subunit(subunit)
-    subunit.rjust(currency.decimal_places, '0')
   end
 
   def amounts_from_splits(splits)

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -312,7 +312,7 @@ class Money
     end
 
     def format_decimal_part(value)
-      return nil if currency.decimal_places == 0
+      return nil if currency.decimal_places == 0 && !Money.infinite_precision
       return nil if rules[:no_cents]
       return nil if rules[:no_cents_if_whole] && value.to_i == 0
 

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -144,8 +144,18 @@ describe Money, "formatting" do
       expect(Money.new(10_00, "BHD").format).to eq "ب.د1.000"
     end
 
-    it "does not display a decimal when :subunit_to_unit is 1" do
-      expect(Money.new(10_00, "VUV").format).to eq "Vt1,000"
+    context "when :subunit_to_unit is 1" do
+      it "does not display a decimal part" do
+        expect(Money.new(10_00, "VUV").format).to eq "Vt1,000"
+      end
+
+      it "does not displays a decimal part when infinite_precision is false" do
+        expect(Money.new(10_00.1, "VUV").format).to eq "Vt1,000"
+      end
+
+      it "displays a decimal part when infinite_precision is true", :infinite_precision do
+        expect(Money.new(10_00.1, "VUV").format).to eq "Vt1,000.1"
+      end
     end
 
     it "respects the thousands_separator and decimal_mark defaults" do


### PR DESCRIPTION
There's a good part of duplicated logic between the `Formatter` and `#to_s`. This change re-implements `#to_s` to use the `Formatter` as keeping 2 different solutions in place might result in confusing differences.

There's a potential issue of a decimal part being shown when displaying a currency with `subunit_to_unit = 1` and `infinite_precision = true`.