### PR TITLE
Switch to new ruby hash syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,7 +174,7 @@
 - Works on Ruby 1.8.7
 - Update deps
 - Depreciate Money.parse
-- Passing :symbol => false when formatting 'JPY' currency in :ja locale
+- Passing symbol: false when formatting 'JPY' currency in :ja locale
   will work as expected
 - Divide now obeys the specified rounding mode
 - Add Money#round method. This is helpful when working in infinite_precision mode and would like to perform rounding at specific points in your work flow.
@@ -357,7 +357,7 @@ Features
 
 Bugfixes
 --------
- - Fixed issue with #format(:no_cents => true) (thanks Romain & Julien)
+ - Fixed issue with #format(no_cents: true) (thanks Romain & Julien)
 
 Money 3.5.5
 ===========
@@ -444,7 +444,7 @@ Features
  - Deprecated `Money#format` with separate params instead of Hash. Deprecation
    target set to Money 3.5.0.
    ([#issue/31](http://github.com/RubyMoney/money/issues/31))
- - Deprecated `Money#new(0, :currency => "EUR")` in favor of
+ - Deprecated `Money#new(0, currency: "EUR")` in favor of
    `Money#new(0, "EUR")`. Deprecation target set to Money 3.5.0.
    ([#issue/31](http://github.com/RubyMoney/money/issues/31))
  - Throw ArgumentError when trying to multiply two Money objects together.

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'coveralls', '>= 0.8.17', :require => false
-gem 'pry', :require => false
+gem 'coveralls', '>= 0.8.17', require: false
+gem 'pry', require: false
 
 # JSON gem no longer supports ruby < 2.0.0
 if defined?(JRUBY_VERSION)

--- a/README.md
+++ b/README.md
@@ -119,15 +119,15 @@ below.
 
 ``` ruby
 curr = {
-  :priority            => 1,
-  :iso_code            => "USD",
-  :iso_numeric         => "840",
-  :name                => "United States Dollar",
-  :symbol              => "$",
-  :subunit             => "Cent",
-  :subunit_to_unit     => 100,
-  :decimal_mark        => ".",
-  :thousands_separator => ","
+  priority:            1,
+  iso_code:            "USD",
+  iso_numeric:         "840",
+  name:                "United States Dollar",
+  symbol:              "$",
+  subunit:             "Cent",
+  subunit_to_unit:     100,
+  decimal_mark:        ".",
+  thousands_separator: ","
 }
 
 Money::Currency.register(curr)
@@ -317,12 +317,12 @@ The following example implements an `ActiveRecord` store to save exchange rates 
 # for Rails 5 replace ActiveRecord::Base with ApplicationRecord
 class ExchangeRate < ActiveRecord::Base
   def self.get_rate(from_iso_code, to_iso_code)
-    rate = find_by(:from => from_iso_code, :to => to_iso_code)
+    rate = find_by(from: from_iso_code, to: to_iso_code)
     rate.present? ? rate.rate : nil
   end
 
   def self.add_rate(from_iso_code, to_iso_code, rate)
-    exrate = find_or_initialize_by(:from => from_iso_code, :to => to_iso_code)
+    exrate = find_or_initialize_by(from: from_iso_code, to: to_iso_code)
     exrate.rate = rate
     exrate.save!
   end

--- a/lib/money/bank/variable_exchange.rb
+++ b/lib/money/bank/variable_exchange.rb
@@ -47,7 +47,7 @@ class Money
       # Available formats for importing/exporting rates.
       RATE_FORMATS = [:json, :ruby, :yaml].freeze
       SERIALIZER_SEPARATOR = '_TO_'.freeze
-      FORMAT_SERIALIZERS = {:json => JSON, :ruby => Marshal, :yaml => YAML}.freeze
+      FORMAT_SERIALIZERS = {json: JSON, ruby: Marshal, yaml: YAML}.freeze
 
       # Initializes a new +Money::Bank::VariableExchange+ object.
       # It defaults to using an in-memory, thread safe store instance for

--- a/lib/money/currency/loader.rb
+++ b/lib/money/currency/loader.rb
@@ -17,7 +17,7 @@ class Money
       def parse_currency_file(filename)
         json = File.read("#{DATA_PATH}/#{filename}")
         json.force_encoding(::Encoding::UTF_8) if defined?(::Encoding)
-        JSON.parse(json, :symbolize_names => true)
+        JSON.parse(json, symbolize_names: true)
       end
     end
   end

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -104,9 +104,9 @@ class Money
     #   @see +Money::Formatting#format+ for more details.
     #
     #   @example
-    #     Money.default_formatting_rules = { :display_free => true }
+    #     Money.default_formatting_rules = { display_free: true }
     #     Money.new(0, "USD").format                          # => "free"
-    #     Money.new(0, "USD").format(:display_free => false)  # => "$0.00"
+    #     Money.new(0, "USD").format(display_free: false)  # => "$0.00"
     #
     # @!attribute [rw] use_i18n
     #   @return [Boolean] Use this to disable i18n even if it's used by other

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -13,8 +13,8 @@ class Money
     #  amount of money should be formatted of "free" or as the supplied string.
     #
     # @example
-    #   Money.us_dollar(0).format(:display_free => true)     #=> "free"
-    #   Money.us_dollar(0).format(:display_free => "gratis") #=> "gratis"
+    #   Money.us_dollar(0).format(display_free: true)     #=> "free"
+    #   Money.us_dollar(0).format(display_free: "gratis") #=> "gratis"
     #   Money.us_dollar(0).format                            #=> "$0.00"
     #
     # @option rules [Boolean] :with_currency (false) Whether the currency name
@@ -22,29 +22,29 @@ class Money
     #
     # @example
     #   Money.ca_dollar(100).format #=> "$1.00"
-    #   Money.ca_dollar(100).format(:with_currency => true) #=> "$1.00 CAD"
-    #   Money.us_dollar(85).format(:with_currency => true)  #=> "$0.85 USD"
+    #   Money.ca_dollar(100).format(with_currency: true) #=> "$1.00 CAD"
+    #   Money.us_dollar(85).format(with_currency: true)  #=> "$0.85 USD"
     #
     # @option rules [Boolean] :rounded_infinite_precision (false) Whether the
     #  amount of money should be rounded when using {infinite_precision}
     #
     # @example
     #   Money.us_dollar(100.1).format #=> "$1.001"
-    #   Money.us_dollar(100.1).format(:rounded_infinite_precision => true) #=> "$1"
-    #   Money.us_dollar(100.9).format(:rounded_infinite_precision => true) #=> "$1.01"
+    #   Money.us_dollar(100.1).format(rounded_infinite_precision: true) #=> "$1"
+    #   Money.us_dollar(100.9).format(rounded_infinite_precision: true) #=> "$1.01"
     #
     # @option rules [Boolean] :no_cents (false) Whether cents should be omitted.
     #
     # @example
-    #   Money.ca_dollar(100).format(:no_cents => true) #=> "$1"
-    #   Money.ca_dollar(599).format(:no_cents => true) #=> "$5"
+    #   Money.ca_dollar(100).format(no_cents: true) #=> "$1"
+    #   Money.ca_dollar(599).format(no_cents: true) #=> "$5"
     #
     # @option rules [Boolean] :no_cents_if_whole (false) Whether cents should be
     #  omitted if the cent value is zero
     #
     # @example
-    #   Money.ca_dollar(10000).format(:no_cents_if_whole => true) #=> "$100"
-    #   Money.ca_dollar(10034).format(:no_cents_if_whole => true) #=> "$100.34"
+    #   Money.ca_dollar(10000).format(no_cents_if_whole: true) #=> "$100"
+    #   Money.ca_dollar(10034).format(no_cents_if_whole: true) #=> "$100.34"
     #
     # @option rules [Boolean, String, nil] :symbol (true) Whether a money symbol
     #  should be prepended to the result string. The default is true. This method
@@ -56,26 +56,26 @@ class Money
     #   Money.new(100, "EUR") #=> "€1.00"
     #
     #   # Same thing.
-    #   Money.new(100, "USD").format(:symbol => true) #=> "$1.00"
-    #   Money.new(100, "GBP").format(:symbol => true) #=> "£1.00"
-    #   Money.new(100, "EUR").format(:symbol => true) #=> "€1.00"
+    #   Money.new(100, "USD").format(symbol: true) #=> "$1.00"
+    #   Money.new(100, "GBP").format(symbol: true) #=> "£1.00"
+    #   Money.new(100, "EUR").format(symbol: true) #=> "€1.00"
     #
     #   # You can specify a false expression or an empty string to disable
     #   # prepending a money symbol.§
-    #   Money.new(100, "USD").format(:symbol => false) #=> "1.00"
-    #   Money.new(100, "GBP").format(:symbol => nil)   #=> "1.00"
-    #   Money.new(100, "EUR").format(:symbol => "")    #=> "1.00"
+    #   Money.new(100, "USD").format(symbol: false) #=> "1.00"
+    #   Money.new(100, "GBP").format(symbol: nil)   #=> "1.00"
+    #   Money.new(100, "EUR").format(symbol: "")    #=> "1.00"
     #
     #   # If the symbol for the given currency isn't known, then it will default
     #   # to "¤" as symbol.
-    #   Money.new(100, "AWG").format(:symbol => true) #=> "¤1.00"
+    #   Money.new(100, "AWG").format(symbol: true) #=> "¤1.00"
     #
     #   # You can specify a string as value to enforce using a particular symbol.
-    #   Money.new(100, "AWG").format(:symbol => "ƒ") #=> "ƒ1.00"
+    #   Money.new(100, "AWG").format(symbol: "ƒ") #=> "ƒ1.00"
     #
     #   # You can specify a indian currency format
-    #   Money.new(10000000, "INR").format(:south_asian_number_formatting => true) #=> "1,00,000.00"
-    #   Money.new(10000000).format(:south_asian_number_formatting => true) #=> "$1,00,000.00"
+    #   Money.new(10000000, "INR").format(south_asian_number_formatting: true) #=> "1,00,000.00"
+    #   Money.new(10000000).format(south_asian_number_formatting: true) #=> "$1,00,000.00"
     #
     # @option rules [Boolean, nil] :symbol_before_without_space (true) Whether
     #   a space between the money symbol and the amount should be inserted when
@@ -87,10 +87,10 @@ class Money
     #   Money.new(100, "USD").format #=> "$1.00"
     #
     #   # Same thing.
-    #   Money.new(100, "USD").format(:symbol_before_without_space => true) #=> "$1.00"
+    #   Money.new(100, "USD").format(symbol_before_without_space: true) #=> "$1.00"
     #
     #   # If set to false, will insert a space.
-    #   Money.new(100, "USD").format(:symbol_before_without_space => false) #=> "$ 1.00"
+    #   Money.new(100, "USD").format(symbol_before_without_space: false) #=> "$ 1.00"
     #
     # @option rules [Boolean, nil] :symbol_after_without_space (false) Whether
     #   a space between the amount and the money symbol should be inserted when
@@ -99,17 +99,17 @@ class Money
     #
     # @example
     #   # Default is to insert a space.
-    #   Money.new(100, "USD").format(:symbol_position => :after) #=> "1.00 $"
+    #   Money.new(100, "USD").format(symbol_position: :after) #=> "1.00 $"
     #
     #   # If set to true, will not insert a space.
-    #   Money.new(100, "USD").format(:symbol_position => :after, :symbol_after_without_space => true) #=> "1.00$"
+    #   Money.new(100, "USD").format(symbol_position: :after, symbol_after_without_space: true) #=> "1.00$"
     #
     # @option rules [Boolean, String, nil] :decimal_mark (true) Whether the
     #  currency should be separated by the specified character or '.'
     #
     # @example
     #   # If a string is specified, it's value is used.
-    #   Money.new(100, "USD").format(:decimal_mark => ",") #=> "$1,00"
+    #   Money.new(100, "USD").format(decimal_mark: ",") #=> "$1,00"
     #
     #   # If the decimal_mark for a given currency isn't known, then it will default
     #   # to "." as decimal_mark.
@@ -120,12 +120,12 @@ class Money
     #
     # @example
     #   # If false is specified, no thousands_separator is used.
-    #   Money.new(100000, "USD").format(:thousands_separator => false) #=> "1000.00"
-    #   Money.new(100000, "USD").format(:thousands_separator => nil)   #=> "1000.00"
-    #   Money.new(100000, "USD").format(:thousands_separator => "")    #=> "1000.00"
+    #   Money.new(100000, "USD").format(thousands_separator: false) #=> "1000.00"
+    #   Money.new(100000, "USD").format(thousands_separator: nil)   #=> "1000.00"
+    #   Money.new(100000, "USD").format(thousands_separator: "")    #=> "1000.00"
     #
     #   # If a string is specified, it's value is used.
-    #   Money.new(100000, "USD").format(:thousands_separator => ".") #=> "$1.000.00"
+    #   Money.new(100000, "USD").format(thousands_separator: ".") #=> "$1.000.00"
     #
     #   # If the thousands_separator for a given currency isn't known, then it will
     #   # default to "," as thousands_separator.
@@ -135,7 +135,7 @@ class Money
     #  HTML-formatted. Only useful in combination with +:with_currency+.
     #
     # @example
-    #   Money.ca_dollar(570).format(:html => true, :with_currency => true)
+    #   Money.ca_dollar(570).format(html: true, with_currency: true)
     #   #=> "$5.70 <span class=\"currency\">CAD</span>"
     #
     # @option rules [Boolean] :sign_before_symbol (false) Whether the sign should be
@@ -143,8 +143,8 @@ class Money
     #
     # @example
     #   # You can specify to display the sign before the symbol for negative numbers
-    #   Money.new(-100, "GBP").format(:sign_before_symbol => true)  #=> "-£1.00"
-    #   Money.new(-100, "GBP").format(:sign_before_symbol => false) #=> "£-1.00"
+    #   Money.new(-100, "GBP").format(sign_before_symbol: true)  #=> "-£1.00"
+    #   Money.new(-100, "GBP").format(sign_before_symbol: false) #=> "£-1.00"
     #   Money.new(-100, "GBP").format                               #=> "£-1.00"
     #
     # @option rules [Boolean] :sign_positive (false) Whether positive numbers should be
@@ -152,34 +152,34 @@ class Money
     #
     # @example
     #   # You can specify to display the sign with positive numbers
-    #   Money.new(100, "GBP").format(:sign_positive => true,  :sign_before_symbol => true)  #=> "+£1.00"
-    #   Money.new(100, "GBP").format(:sign_positive => true,  :sign_before_symbol => false) #=> "£+1.00"
-    #   Money.new(100, "GBP").format(:sign_positive => false, :sign_before_symbol => true)  #=> "£1.00"
-    #   Money.new(100, "GBP").format(:sign_positive => false, :sign_before_symbol => false) #=> "£1.00"
+    #   Money.new(100, "GBP").format(sign_positive: true,  sign_before_symbol: true)  #=> "+£1.00"
+    #   Money.new(100, "GBP").format(sign_positive: true,  sign_before_symbol: false) #=> "£+1.00"
+    #   Money.new(100, "GBP").format(sign_positive: false, sign_before_symbol: true)  #=> "£1.00"
+    #   Money.new(100, "GBP").format(sign_positive: false, sign_before_symbol: false) #=> "£1.00"
     #   Money.new(100, "GBP").format                               #=> "£+1.00"
     #
     # @option rules [Boolean] :disambiguate (false) Prevents the result from being ambiguous
     #  due to equal symbols for different currencies. Uses the `disambiguate_symbol`.
     #
     # @example
-    #   Money.new(10000, "USD").format(:disambiguate => false)   #=> "$100.00"
-    #   Money.new(10000, "CAD").format(:disambiguate => false)   #=> "$100.00"
-    #   Money.new(10000, "USD").format(:disambiguate => true)    #=> "$100.00"
-    #   Money.new(10000, "CAD").format(:disambiguate => true)    #=> "C$100.00"
+    #   Money.new(10000, "USD").format(disambiguate: false)   #=> "$100.00"
+    #   Money.new(10000, "CAD").format(disambiguate: false)   #=> "$100.00"
+    #   Money.new(10000, "USD").format(disambiguate: true)    #=> "$100.00"
+    #   Money.new(10000, "CAD").format(disambiguate: true)    #=> "C$100.00"
     #
     # @option rules [Boolean] :html_wrap_symbol (false) Wraps the currency symbol
     #  in a html <span> tag.
     #
     # @example
-    #   Money.new(10000, "USD").format(:disambiguate => false)
+    #   Money.new(10000, "USD").format(disambiguate: false)
     #   #=> "<span class=\"currency_symbol\">$100.00</span>
     #
     # @option rules [Symbol] :symbol_position (:before) `:before` if the currency
     #   symbol goes before the amount, `:after` if it goes after.
     #
     # @example
-    #   Money.new(10000, "USD").format(:symbol_position => :before) #=> "$100.00"
-    #   Money.new(10000, "USD").format(:symbol_position => :after)  #=> "100.00 $"
+    #   Money.new(10000, "USD").format(symbol_position: :before) #=> "$100.00"
+    #   Money.new(10000, "USD").format(symbol_position: :after)  #=> "100.00 $"
     #
     # @option rules [Boolean] :translate (true) `true` Checks for custom
     #   symbol definitions using I18n.
@@ -191,11 +191,11 @@ class Money
     #   #     currency:
     #   #       symbol:
     #   #         CAD: "CAD$"
-    #   Money.new(10000, "CAD").format(:translate => true) #=> "CAD$100.00"
+    #   Money.new(10000, "CAD").format(translate: true) #=> "CAD$100.00"
     #
     # @example
-    #   Money.new(89000, :btc).format(:drop_trailing_zeros => true) #=> B⃦0.00089
-    #   Money.new(110, :usd).format(:drop_trailing_zeros => true)   #=> $1.1
+    #   Money.new(89000, :btc).format(drop_trailing_zeros: true) #=> B⃦0.00089
+    #   Money.new(110, :usd).format(drop_trailing_zeros: true)   #=> $1.1
     #
     # Note that the default rules can be defined through {Money.default_formatting_rules} hash.
     #
@@ -328,9 +328,9 @@ class Money
     def i18n_format_for(method, name, character)
       if Money.use_i18n
         begin
-          I18n.t name, :scope => "number.currency.format", :raise => true
+          I18n.t name, scope: "number.currency.format", raise: true
         rescue I18n::MissingTranslationData
-          I18n.t name, :scope =>"number.format", :default => (currency.send(method) || character)
+          I18n.t name, scope: "number.format", default: (currency.send(method) || character)
         end
       else
         currency.send(method) || character

--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -52,7 +52,7 @@ class Money
 
     def translate_formatting_rules(rules)
       begin
-        rules[:symbol] = I18n.t currency.iso_code, :scope => "number.currency.symbol", :raise => true
+        rules[:symbol] = I18n.t currency.iso_code, scope: "number.currency.symbol", raise: true
       rescue I18n::MissingTranslationData
         # Do nothing
       end

--- a/spec/bank/variable_exchange_spec.rb
+++ b/spec/bank/variable_exchange_spec.rb
@@ -151,7 +151,7 @@ class Money
 
         it "delegates options to store, options are a no-op" do
           expect(subject.store).to receive(:get_rate).with('USD', 'EUR')
-          subject.get_rate('USD', 'EUR', :without_mutex => true)
+          subject.get_rate('USD', 'EUR', without_mutex: true)
         end
       end
 
@@ -201,7 +201,7 @@ class Money
 
         it "delegates execution to store, options are a no-op" do
           expect(subject.store).to receive(:transaction)
-          subject.export_rates(:yaml, nil, :foo => 1)
+          subject.export_rates(:yaml, nil, foo: 1)
         end
 
       end
@@ -243,7 +243,7 @@ class Money
         it "delegates execution to store#transaction" do
           expect(subject.store).to receive(:transaction)
           s = "--- \nUSD_TO_EUR: 1.25\nUSD_TO_JPY: 2.55\n"
-          subject.import_rates(:yaml, s, :foo => 1)
+          subject.import_rates(:yaml, s, foo: 1)
         end
 
       end

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -6,7 +6,7 @@ class Money
     FOO = '{ "priority": 1, "iso_code": "FOO", "iso_numeric": "840", "name": "United States Dollar", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 1000, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "smallest_denomination": 1 }'
 
     def register_foo(opts={})
-      foo_attrs = JSON.parse(FOO, :symbolize_names => true)
+      foo_attrs = JSON.parse(FOO, symbolize_names: true)
       # Pass an array of attribute names to 'skip' to remove them from the 'FOO'
       # json before registering foo as a currency.
       Array(opts[:skip]).each { |attr| foo_attrs.delete(attr) }
@@ -14,7 +14,7 @@ class Money
     end
 
     def unregister_foo
-      Currency.unregister(JSON.parse(FOO, :symbolize_names => true))
+      Currency.unregister(JSON.parse(FOO, symbolize_names: true))
     end
 
     describe "UnknownCurrency" do
@@ -82,7 +82,7 @@ class Money
         expect(Currency.all.first.priority).to eq 1
       end
       it "raises a MissingAttributeError if any currency has no priority" do
-        register_foo(:skip => :priority)
+        register_foo(skip: :priority)
 
         expect{Money::Currency.all}.to \
           raise_error(Money::Currency::MissingAttributeError, /foo.*priority/)

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -247,10 +247,10 @@ describe Money do
   describe "#*" do
     it "multiplies Money by Integer and returns Money" do
       ts = [
-        {:a => Money.new( 10, :USD), :b =>  4, :c => Money.new( 40, :USD)},
-        {:a => Money.new( 10, :USD), :b => -4, :c => Money.new(-40, :USD)},
-        {:a => Money.new(-10, :USD), :b =>  4, :c => Money.new(-40, :USD)},
-        {:a => Money.new(-10, :USD), :b => -4, :c => Money.new( 40, :USD)},
+        {a: Money.new( 10, :USD), b: 4, c: Money.new( 40, :USD)},
+        {a: Money.new( 10, :USD), b: -4, c: Money.new(-40, :USD)},
+        {a: Money.new(-10, :USD), b: 4, c: Money.new(-40, :USD)},
+        {a: Money.new(-10, :USD), b: -4, c: Money.new( 40, :USD)},
       ]
       ts.each do |t|
         expect(t[:a] * t[:b]).to eq t[:c]
@@ -280,10 +280,10 @@ describe Money do
   describe "#/" do
     it "divides Money by Integer and returns Money" do
       ts = [
-        {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 3, :USD)},
-        {:a => Money.new( 13, :USD), :b => -4, :c => Money.new(-3, :USD)},
-        {:a => Money.new(-13, :USD), :b =>  4, :c => Money.new(-3, :USD)},
-        {:a => Money.new(-13, :USD), :b => -4, :c => Money.new( 3, :USD)},
+        {a: Money.new( 13, :USD), b: 4, c: Money.new( 3, :USD)},
+        {a: Money.new( 13, :USD), b: -4, c: Money.new(-3, :USD)},
+        {a: Money.new(-13, :USD), b: 4, c: Money.new(-3, :USD)},
+        {a: Money.new(-13, :USD), b: -4, c: Money.new( 3, :USD)},
       ]
       ts.each do |t|
         expect(t[:a] / t[:b]).to eq t[:c]
@@ -335,10 +335,10 @@ describe Money do
 
     it "divides Money by Money (same currency) and returns Float" do
       ts = [
-        {:a => Money.new( 13, :USD), :b => Money.new( 4, :USD), :c =>  3.25},
-        {:a => Money.new( 13, :USD), :b => Money.new(-4, :USD), :c => -3.25},
-        {:a => Money.new(-13, :USD), :b => Money.new( 4, :USD), :c => -3.25},
-        {:a => Money.new(-13, :USD), :b => Money.new(-4, :USD), :c =>  3.25},
+        {a: Money.new( 13, :USD), b: Money.new( 4, :USD), c: 3.25},
+        {a: Money.new( 13, :USD), b: Money.new(-4, :USD), c: -3.25},
+        {a: Money.new(-13, :USD), b: Money.new( 4, :USD), c: -3.25},
+        {a: Money.new(-13, :USD), b: Money.new(-4, :USD), c: 3.25},
       ]
       ts.each do |t|
         expect(t[:a] / t[:b]).to eq t[:c]
@@ -347,10 +347,10 @@ describe Money do
 
     it "divides Money by Money (different currency) and returns Float" do
       ts = [
-        {:a => Money.new( 13, :USD), :b => Money.new( 4, :EUR), :c =>  1.625},
-        {:a => Money.new( 13, :USD), :b => Money.new(-4, :EUR), :c => -1.625},
-        {:a => Money.new(-13, :USD), :b => Money.new( 4, :EUR), :c => -1.625},
-        {:a => Money.new(-13, :USD), :b => Money.new(-4, :EUR), :c =>  1.625},
+        {a: Money.new( 13, :USD), b: Money.new( 4, :EUR), c: 1.625},
+        {a: Money.new( 13, :USD), b: Money.new(-4, :EUR), c: -1.625},
+        {a: Money.new(-13, :USD), b: Money.new( 4, :EUR), c: -1.625},
+        {a: Money.new(-13, :USD), b: Money.new(-4, :EUR), c: 1.625},
       ]
       ts.each do |t|
         expect(t[:b]).to receive(:exchange_to).once.with(t[:a].currency).and_return(Money.new(t[:b].cents * 2, :USD))
@@ -361,10 +361,10 @@ describe Money do
     context "with infinite_precision", :infinite_precision do
       it "uses BigDecimal division" do
         ts = [
-          {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 3.25, :USD)},
-          {:a => Money.new( 13, :USD), :b => -4, :c => Money.new(-3.25, :USD)},
-          {:a => Money.new(-13, :USD), :b =>  4, :c => Money.new(-3.25, :USD)},
-          {:a => Money.new(-13, :USD), :b => -4, :c => Money.new( 3.25, :USD)},
+          {a: Money.new( 13, :USD), b: 4, c: Money.new( 3.25, :USD)},
+          {a: Money.new( 13, :USD), b: -4, c: Money.new(-3.25, :USD)},
+          {a: Money.new(-13, :USD), b: 4, c: Money.new(-3.25, :USD)},
+          {a: Money.new(-13, :USD), b: -4, c: Money.new( 3.25, :USD)},
         ]
         ts.each do |t|
           expect(t[:a] / t[:b]).to eq t[:c]
@@ -378,10 +378,10 @@ describe Money do
   describe "#div" do
     it "divides Money by Integer and returns Money" do
       ts = [
-          {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 3, :USD)},
-          {:a => Money.new( 13, :USD), :b => -4, :c => Money.new(-3, :USD)},
-          {:a => Money.new(-13, :USD), :b =>  4, :c => Money.new(-3, :USD)},
-          {:a => Money.new(-13, :USD), :b => -4, :c => Money.new( 3, :USD)},
+          {a: Money.new( 13, :USD), b: 4, c: Money.new( 3, :USD)},
+          {a: Money.new( 13, :USD), b: -4, c: Money.new(-3, :USD)},
+          {a: Money.new(-13, :USD), b: 4, c: Money.new(-3, :USD)},
+          {a: Money.new(-13, :USD), b: -4, c: Money.new( 3, :USD)},
       ]
       ts.each do |t|
         expect(t[:a].div(t[:b])).to eq t[:c]
@@ -390,10 +390,10 @@ describe Money do
 
     it "divides Money by Money (same currency) and returns Float" do
       ts = [
-          {:a => Money.new( 13, :USD), :b => Money.new( 4, :USD), :c =>  3.25},
-          {:a => Money.new( 13, :USD), :b => Money.new(-4, :USD), :c => -3.25},
-          {:a => Money.new(-13, :USD), :b => Money.new( 4, :USD), :c => -3.25},
-          {:a => Money.new(-13, :USD), :b => Money.new(-4, :USD), :c =>  3.25},
+          {a: Money.new( 13, :USD), b: Money.new( 4, :USD), c: 3.25},
+          {a: Money.new( 13, :USD), b: Money.new(-4, :USD), c: -3.25},
+          {a: Money.new(-13, :USD), b: Money.new( 4, :USD), c: -3.25},
+          {a: Money.new(-13, :USD), b: Money.new(-4, :USD), c: 3.25},
       ]
       ts.each do |t|
         expect(t[:a].div(t[:b])).to eq t[:c]
@@ -402,10 +402,10 @@ describe Money do
 
     it "divides Money by Money (different currency) and returns Float" do
       ts = [
-          {:a => Money.new( 13, :USD), :b => Money.new( 4, :EUR), :c =>  1.625},
-          {:a => Money.new( 13, :USD), :b => Money.new(-4, :EUR), :c => -1.625},
-          {:a => Money.new(-13, :USD), :b => Money.new( 4, :EUR), :c => -1.625},
-          {:a => Money.new(-13, :USD), :b => Money.new(-4, :EUR), :c =>  1.625},
+          {a: Money.new( 13, :USD), b: Money.new( 4, :EUR), c: 1.625},
+          {a: Money.new( 13, :USD), b: Money.new(-4, :EUR), c: -1.625},
+          {a: Money.new(-13, :USD), b: Money.new( 4, :EUR), c: -1.625},
+          {a: Money.new(-13, :USD), b: Money.new(-4, :EUR), c: 1.625},
       ]
       ts.each do |t|
         expect(t[:b]).to receive(:exchange_to).once.with(t[:a].currency).and_return(Money.new(t[:b].cents * 2, :USD))
@@ -416,10 +416,10 @@ describe Money do
     context "with infinite_precision", :infinite_precision do
       it "uses BigDecimal division" do
         ts = [
-          {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 3.25, :USD)},
-          {:a => Money.new( 13, :USD), :b => -4, :c => Money.new(-3.25, :USD)},
-          {:a => Money.new(-13, :USD), :b =>  4, :c => Money.new(-3.25, :USD)},
-          {:a => Money.new(-13, :USD), :b => -4, :c => Money.new( 3.25, :USD)},
+          {a: Money.new( 13, :USD), b: 4, c: Money.new( 3.25, :USD)},
+          {a: Money.new( 13, :USD), b: -4, c: Money.new(-3.25, :USD)},
+          {a: Money.new(-13, :USD), b: 4, c: Money.new(-3.25, :USD)},
+          {a: Money.new(-13, :USD), b: -4, c: Money.new( 3.25, :USD)},
         ]
         ts.each do |t|
           expect(t[:a].div(t[:b])).to eq t[:c]
@@ -431,10 +431,10 @@ describe Money do
   describe "#divmod" do
     it "calculates division and modulo with Integer" do
       ts = [
-          {:a => Money.new( 13, :USD), :b =>  4, :c => [Money.new( 3, :USD), Money.new( 1, :USD)]},
-          {:a => Money.new( 13, :USD), :b => -4, :c => [Money.new(-4, :USD), Money.new(-3, :USD)]},
-          {:a => Money.new(-13, :USD), :b =>  4, :c => [Money.new(-4, :USD), Money.new( 3, :USD)]},
-          {:a => Money.new(-13, :USD), :b => -4, :c => [Money.new( 3, :USD), Money.new(-1, :USD)]},
+          {a: Money.new( 13, :USD), b: 4, c: [Money.new( 3, :USD), Money.new( 1, :USD)]},
+          {a: Money.new( 13, :USD), b: -4, c: [Money.new(-4, :USD), Money.new(-3, :USD)]},
+          {a: Money.new(-13, :USD), b: 4, c: [Money.new(-4, :USD), Money.new( 3, :USD)]},
+          {a: Money.new(-13, :USD), b: -4, c: [Money.new( 3, :USD), Money.new(-1, :USD)]},
       ]
       ts.each do |t|
         expect(t[:a].divmod(t[:b])).to eq t[:c]
@@ -443,10 +443,10 @@ describe Money do
 
     it "calculates division and modulo with Money (same currency)" do
       ts = [
-          {:a => Money.new( 13, :USD), :b => Money.new( 4, :USD), :c => [ 3, Money.new( 1, :USD)]},
-          {:a => Money.new( 13, :USD), :b => Money.new(-4, :USD), :c => [-4, Money.new(-3, :USD)]},
-          {:a => Money.new(-13, :USD), :b => Money.new( 4, :USD), :c => [-4, Money.new( 3, :USD)]},
-          {:a => Money.new(-13, :USD), :b => Money.new(-4, :USD), :c => [ 3, Money.new(-1, :USD)]},
+          {a: Money.new( 13, :USD), b: Money.new( 4, :USD), c: [ 3, Money.new( 1, :USD)]},
+          {a: Money.new( 13, :USD), b: Money.new(-4, :USD), c: [-4, Money.new(-3, :USD)]},
+          {a: Money.new(-13, :USD), b: Money.new( 4, :USD), c: [-4, Money.new( 3, :USD)]},
+          {a: Money.new(-13, :USD), b: Money.new(-4, :USD), c: [ 3, Money.new(-1, :USD)]},
       ]
       ts.each do |t|
         expect(t[:a].divmod(t[:b])).to eq t[:c]
@@ -455,10 +455,10 @@ describe Money do
 
     it "calculates division and modulo with Money (different currency)" do
       ts = [
-          {:a => Money.new( 13, :USD), :b => Money.new( 4, :EUR), :c => [ 1, Money.new( 5, :USD)]},
-          {:a => Money.new( 13, :USD), :b => Money.new(-4, :EUR), :c => [-2, Money.new(-3, :USD)]},
-          {:a => Money.new(-13, :USD), :b => Money.new( 4, :EUR), :c => [-2, Money.new( 3, :USD)]},
-          {:a => Money.new(-13, :USD), :b => Money.new(-4, :EUR), :c => [ 1, Money.new(-5, :USD)]},
+          {a: Money.new( 13, :USD), b: Money.new( 4, :EUR), c: [ 1, Money.new( 5, :USD)]},
+          {a: Money.new( 13, :USD), b: Money.new(-4, :EUR), c: [-2, Money.new(-3, :USD)]},
+          {a: Money.new(-13, :USD), b: Money.new( 4, :EUR), c: [-2, Money.new( 3, :USD)]},
+          {a: Money.new(-13, :USD), b: Money.new(-4, :EUR), c: [ 1, Money.new(-5, :USD)]},
       ]
       ts.each do |t|
         expect(t[:b]).to receive(:exchange_to).once.with(t[:a].currency).and_return(Money.new(t[:b].cents * 2, :USD))
@@ -469,10 +469,10 @@ describe Money do
     context "with infinite_precision", :infinite_precision do
       it "uses BigDecimal division" do
         ts = [
-            {:a => Money.new( 13, :USD), :b =>  4, :c => [Money.new( 3, :USD), Money.new( 1, :USD)]},
-            {:a => Money.new( 13, :USD), :b => -4, :c => [Money.new(-4, :USD), Money.new(-3, :USD)]},
-            {:a => Money.new(-13, :USD), :b =>  4, :c => [Money.new(-4, :USD), Money.new( 3, :USD)]},
-            {:a => Money.new(-13, :USD), :b => -4, :c => [Money.new( 3, :USD), Money.new(-1, :USD)]},
+            {a: Money.new( 13, :USD), b: 4, c: [Money.new( 3, :USD), Money.new( 1, :USD)]},
+            {a: Money.new( 13, :USD), b: -4, c: [Money.new(-4, :USD), Money.new(-3, :USD)]},
+            {a: Money.new(-13, :USD), b: 4, c: [Money.new(-4, :USD), Money.new( 3, :USD)]},
+            {a: Money.new(-13, :USD), b: -4, c: [Money.new( 3, :USD), Money.new(-1, :USD)]},
         ]
         ts.each do |t|
           expect(t[:a].divmod(t[:b])).to eq t[:c]
@@ -497,10 +497,10 @@ describe Money do
   describe "#modulo" do
     it "calculates modulo with Integer" do
       ts = [
-          {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 1, :USD)},
-          {:a => Money.new( 13, :USD), :b => -4, :c => Money.new(-3, :USD)},
-          {:a => Money.new(-13, :USD), :b =>  4, :c => Money.new( 3, :USD)},
-          {:a => Money.new(-13, :USD), :b => -4, :c => Money.new(-1, :USD)},
+          {a: Money.new( 13, :USD), b: 4, c: Money.new( 1, :USD)},
+          {a: Money.new( 13, :USD), b: -4, c: Money.new(-3, :USD)},
+          {a: Money.new(-13, :USD), b: 4, c: Money.new( 3, :USD)},
+          {a: Money.new(-13, :USD), b: -4, c: Money.new(-1, :USD)},
       ]
       ts.each do |t|
         expect(t[:a].modulo(t[:b])).to eq t[:c]
@@ -509,10 +509,10 @@ describe Money do
 
     it "calculates modulo with Money (same currency)" do
       ts = [
-          {:a => Money.new( 13, :USD), :b => Money.new( 4, :USD), :c => Money.new( 1, :USD)},
-          {:a => Money.new( 13, :USD), :b => Money.new(-4, :USD), :c => Money.new(-3, :USD)},
-          {:a => Money.new(-13, :USD), :b => Money.new( 4, :USD), :c => Money.new( 3, :USD)},
-          {:a => Money.new(-13, :USD), :b => Money.new(-4, :USD), :c => Money.new(-1, :USD)},
+          {a: Money.new( 13, :USD), b: Money.new( 4, :USD), c: Money.new( 1, :USD)},
+          {a: Money.new( 13, :USD), b: Money.new(-4, :USD), c: Money.new(-3, :USD)},
+          {a: Money.new(-13, :USD), b: Money.new( 4, :USD), c: Money.new( 3, :USD)},
+          {a: Money.new(-13, :USD), b: Money.new(-4, :USD), c: Money.new(-1, :USD)},
       ]
       ts.each do |t|
         expect(t[:a].modulo(t[:b])).to eq t[:c]
@@ -521,10 +521,10 @@ describe Money do
 
     it "calculates modulo with Money (different currency)" do
       ts = [
-          {:a => Money.new( 13, :USD), :b => Money.new( 4, :EUR), :c => Money.new( 5, :USD)},
-          {:a => Money.new( 13, :USD), :b => Money.new(-4, :EUR), :c => Money.new(-3, :USD)},
-          {:a => Money.new(-13, :USD), :b => Money.new( 4, :EUR), :c => Money.new( 3, :USD)},
-          {:a => Money.new(-13, :USD), :b => Money.new(-4, :EUR), :c => Money.new(-5, :USD)},
+          {a: Money.new( 13, :USD), b: Money.new( 4, :EUR), c: Money.new( 5, :USD)},
+          {a: Money.new( 13, :USD), b: Money.new(-4, :EUR), c: Money.new(-3, :USD)},
+          {a: Money.new(-13, :USD), b: Money.new( 4, :EUR), c: Money.new( 3, :USD)},
+          {a: Money.new(-13, :USD), b: Money.new(-4, :EUR), c: Money.new(-5, :USD)},
       ]
       ts.each do |t|
         expect(t[:b]).to receive(:exchange_to).once.with(t[:a].currency).and_return(Money.new(t[:b].cents * 2, :USD))
@@ -536,10 +536,10 @@ describe Money do
   describe "#%" do
     it "calculates modulo with Integer" do
       ts = [
-          {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 1, :USD)},
-          {:a => Money.new( 13, :USD), :b => -4, :c => Money.new(-3, :USD)},
-          {:a => Money.new(-13, :USD), :b =>  4, :c => Money.new( 3, :USD)},
-          {:a => Money.new(-13, :USD), :b => -4, :c => Money.new(-1, :USD)},
+          {a: Money.new( 13, :USD), b: 4, c: Money.new( 1, :USD)},
+          {a: Money.new( 13, :USD), b: -4, c: Money.new(-3, :USD)},
+          {a: Money.new(-13, :USD), b: 4, c: Money.new( 3, :USD)},
+          {a: Money.new(-13, :USD), b: -4, c: Money.new(-1, :USD)},
       ]
       ts.each do |t|
         expect(t[:a] % t[:b]).to eq t[:c]
@@ -548,10 +548,10 @@ describe Money do
 
     it "calculates modulo with Money (same currency)" do
       ts = [
-          {:a => Money.new( 13, :USD), :b => Money.new( 4, :USD), :c => Money.new( 1, :USD)},
-          {:a => Money.new( 13, :USD), :b => Money.new(-4, :USD), :c => Money.new(-3, :USD)},
-          {:a => Money.new(-13, :USD), :b => Money.new( 4, :USD), :c => Money.new( 3, :USD)},
-          {:a => Money.new(-13, :USD), :b => Money.new(-4, :USD), :c => Money.new(-1, :USD)},
+          {a: Money.new( 13, :USD), b: Money.new( 4, :USD), c: Money.new( 1, :USD)},
+          {a: Money.new( 13, :USD), b: Money.new(-4, :USD), c: Money.new(-3, :USD)},
+          {a: Money.new(-13, :USD), b: Money.new( 4, :USD), c: Money.new( 3, :USD)},
+          {a: Money.new(-13, :USD), b: Money.new(-4, :USD), c: Money.new(-1, :USD)},
       ]
       ts.each do |t|
         expect(t[:a] % t[:b]).to eq t[:c]
@@ -560,10 +560,10 @@ describe Money do
 
     it "calculates modulo with Money (different currency)" do
       ts = [
-          {:a => Money.new( 13, :USD), :b => Money.new( 4, :EUR), :c => Money.new( 5, :USD)},
-          {:a => Money.new( 13, :USD), :b => Money.new(-4, :EUR), :c => Money.new(-3, :USD)},
-          {:a => Money.new(-13, :USD), :b => Money.new( 4, :EUR), :c => Money.new( 3, :USD)},
-          {:a => Money.new(-13, :USD), :b => Money.new(-4, :EUR), :c => Money.new(-5, :USD)},
+          {a: Money.new( 13, :USD), b: Money.new( 4, :EUR), c: Money.new( 5, :USD)},
+          {a: Money.new( 13, :USD), b: Money.new(-4, :EUR), c: Money.new(-3, :USD)},
+          {a: Money.new(-13, :USD), b: Money.new( 4, :EUR), c: Money.new( 3, :USD)},
+          {a: Money.new(-13, :USD), b: Money.new(-4, :EUR), c: Money.new(-5, :USD)},
       ]
       ts.each do |t|
         expect(t[:b]).to receive(:exchange_to).once.with(t[:a].currency).and_return(Money.new(t[:b].cents * 2, :USD))
@@ -575,10 +575,10 @@ describe Money do
   describe "#remainder" do
     it "calculates remainder with Integer" do
       ts = [
-          {:a => Money.new( 13, :USD), :b =>  4, :c => Money.new( 1, :USD)},
-          {:a => Money.new( 13, :USD), :b => -4, :c => Money.new( 1, :USD)},
-          {:a => Money.new(-13, :USD), :b =>  4, :c => Money.new(-1, :USD)},
-          {:a => Money.new(-13, :USD), :b => -4, :c => Money.new(-1, :USD)},
+          {a: Money.new( 13, :USD), b: 4, c: Money.new( 1, :USD)},
+          {a: Money.new( 13, :USD), b: -4, c: Money.new( 1, :USD)},
+          {a: Money.new(-13, :USD), b: 4, c: Money.new(-1, :USD)},
+          {a: Money.new(-13, :USD), b: -4, c: Money.new(-1, :USD)},
       ]
       ts.each do |t|
         expect(t[:a].remainder(t[:b])).to eq t[:c]

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -24,7 +24,7 @@ describe Money, "formatting" do
       I18n.locale = :de
       I18n.backend.store_translations(
           :de,
-          :number => { :currency => { :format => { :delimiter => ".", :separator => "," } } }
+          number: { currency: { format: { delimiter: ".", separator: "," } } }
       )
       Money.use_i18n = false
     end
@@ -58,7 +58,7 @@ describe Money, "formatting" do
         I18n.locale = :de
         I18n.backend.store_translations(
             :de,
-            :number => { :format => { :delimiter => ".", :separator => "," } }
+            number: { format: { delimiter: ".", separator: "," } }
         )
       end
 
@@ -79,7 +79,7 @@ describe Money, "formatting" do
         I18n.locale = :de
         I18n.backend.store_translations(
             :de,
-            :number => { :currency => { :format => { :delimiter => ".", :separator => "," } } }
+            number: { currency: { format: { delimiter: ".", separator: "," } } }
         )
       end
 
@@ -100,24 +100,24 @@ describe Money, "formatting" do
         I18n.locale = :de
         I18n.backend.store_translations(
             :de,
-            :number => { :currency => { :symbol => { :CAD => "CAD$" } } }
+            number: { currency: { symbol: { CAD: "CAD$" } } }
         )
       end
 
       subject(:money) { Money.empty("CAD") }
 
       it "should use 'CAD$' as the currency symbol" do
-        expect(money.format(:translate => true)).to eq("CAD$0.00")
+        expect(money.format(translate: true)).to eq("CAD$0.00")
       end
     end
 
     context "with overridden i18n settings" do
       it "should respect explicit overriding of thousands_separator/delimiter when decimal_mark/separator collide and there’s no decimal component for currencies that have no subunit" do
-        expect(Money.new(300_000, 'ISK').format(:thousands_separator => ".", decimal_mark: ',')).to eq "kr300.000"
+        expect(Money.new(300_000, 'ISK').format(thousands_separator: ".", decimal_mark: ',')).to eq "kr300.000"
       end
 
       it "should respect explicit overriding of thousands_separator/delimiter when decimal_mark/separator collide and there’s no decimal component for currencies with subunits that drop_trailing_zeros" do
-        expect(Money.new(300_000, 'USD').format(:thousands_separator => ".", decimal_mark: ',', drop_trailing_zeros: true)).to eq "$3.000"
+        expect(Money.new(300_000, 'USD').format(thousands_separator: ".", decimal_mark: ',', drop_trailing_zeros: true)).to eq "$3.000"
       end
     end
   end
@@ -129,7 +129,7 @@ describe Money, "formatting" do
       it "formats Japanese currency in Japanese properly" do
         money = Money.new(1000, "JPY")
         expect(money.format).to eq "1,000円"
-        expect(money.format(:symbol => false)).to eq "1,000"
+        expect(money.format(symbol: false)).to eq "1,000"
       end
 
       after  { I18n.locale = @_locale }
@@ -196,17 +196,17 @@ describe Money, "formatting" do
 
     it "inserts commas into the result if the amount is sufficiently large" do
       expect(Money.us_dollar(1_000_000_000_12).format).to eq "$1,000,000,000.12"
-      expect(Money.us_dollar(1_000_000_000_12).format(:no_cents => true)).to eq "$1,000,000,000"
+      expect(Money.us_dollar(1_000_000_000_12).format(no_cents: true)).to eq "$1,000,000,000"
     end
 
     it "inserts thousands separator into the result if the amount is sufficiently large and the currency symbol is at the end" do
       expect(Money.euro(1_234_567_12).format).to eq "€1.234.567,12"
-      expect(Money.euro(1_234_567_12).format(:no_cents => true)).to eq "€1.234.567"
+      expect(Money.euro(1_234_567_12).format(no_cents: true)).to eq "€1.234.567"
     end
 
     context 'when default_formatting_rules defines (display_free: true)' do
       before do
-        Money.default_formatting_rules = { :display_free => "you won't pay a thing" }
+        Money.default_formatting_rules = { display_free: "you won't pay a thing" }
       end
 
       after do
@@ -221,7 +221,7 @@ describe Money, "formatting" do
 
       context 'with rule (display_free: false) provided' do
         it 'acknowledges provided rule' do
-          expect(Money.new(0, 'USD').format(:display_free => false)).to eq '$0.00'
+          expect(Money.new(0, 'USD').format(display_free: false)).to eq '$0.00'
         end
       end
     end
@@ -233,79 +233,79 @@ describe Money, "formatting" do
 
       context 'acknowledges provided rule' do
         it 'acknowledges provided rule' do
-          expect(Money.new(100, 'USD').format(:with_currency => true)).to eq '$1.00 USD'
+          expect(Money.new(100, 'USD').format(with_currency: true)).to eq '$1.00 USD'
         end
       end
     end
 
     describe ":with_currency option" do
       specify "(:with_currency option => true) works as documented" do
-        expect(Money.ca_dollar(100).format(:with_currency => true)).to eq "$1.00 CAD"
-        expect(Money.us_dollar(85).format(:with_currency => true)).to eq "$0.85 USD"
+        expect(Money.ca_dollar(100).format(with_currency: true)).to eq "$1.00 CAD"
+        expect(Money.us_dollar(85).format(with_currency: true)).to eq "$0.85 USD"
       end
     end
 
     describe ":no_cents option" do
       specify "(:with_currency option => true) works as documented" do
-        expect(Money.ca_dollar(100).format(:no_cents => true)).to eq "$1"
-        expect(Money.ca_dollar(599).format(:no_cents => true)).to eq "$5"
-        expect(Money.ca_dollar(570).format(:no_cents => true, :with_currency => true)).to eq "$5 CAD"
-        expect(Money.ca_dollar(39000).format(:no_cents => true)).to eq "$390"
+        expect(Money.ca_dollar(100).format(no_cents: true)).to eq "$1"
+        expect(Money.ca_dollar(599).format(no_cents: true)).to eq "$5"
+        expect(Money.ca_dollar(570).format(no_cents: true, with_currency: true)).to eq "$5 CAD"
+        expect(Money.ca_dollar(39000).format(no_cents: true)).to eq "$390"
       end
 
       it "respects :subunit_to_unit currency property" do
-        expect(Money.new(10_00, "BHD").format(:no_cents => true)).to eq "ب.د1"
+        expect(Money.new(10_00, "BHD").format(no_cents: true)).to eq "ب.د1"
       end
 
       it "inserts thousand separators if symbol contains decimal mark and no_cents is true" do
-        expect(Money.new(100000000, "AMD").format(:no_cents => true)).to eq "1,000,000 դր."
-        expect(Money.new(100000000, "USD").format(:no_cents => true)).to eq "$1,000,000"
-        expect(Money.new(100000000, "RUB").format(:no_cents => true)).to eq "1.000.000 ₽"
+        expect(Money.new(100000000, "AMD").format(no_cents: true)).to eq "1,000,000 դր."
+        expect(Money.new(100000000, "USD").format(no_cents: true)).to eq "$1,000,000"
+        expect(Money.new(100000000, "RUB").format(no_cents: true)).to eq "1.000.000 ₽"
       end
 
       it "doesn't incorrectly format HTML" do
         money = ::Money.new(1999, "RUB")
-        output = money.format(:html => true, :no_cents => true)
+        output = money.format(html: true, no_cents: true)
         expect(output).to eq "19 &#x20BD;"
       end
     end
 
     describe ":no_cents_if_whole option" do
-      specify "(:no_cents_if_whole => true) works as documented" do
-        expect(Money.new(10000, "VUV").format(:no_cents_if_whole => true, :symbol => false)).to eq "10,000"
-        expect(Money.new(10034, "VUV").format(:no_cents_if_whole => true, :symbol => false)).to eq "10,034"
-        expect(Money.new(10000, "MGA").format(:no_cents_if_whole => true, :symbol => false)).to eq "2,000"
-        expect(Money.new(10034, "MGA").format(:no_cents_if_whole => true, :symbol => false)).to eq "2,006.8"
-        expect(Money.new(10000, "VND").format(:no_cents_if_whole => true, :symbol => false)).to eq "10.000"
-        expect(Money.new(10034, "VND").format(:no_cents_if_whole => true, :symbol => false)).to eq "10.034"
-        expect(Money.new(10000, "USD").format(:no_cents_if_whole => true, :symbol => false)).to eq "100"
-        expect(Money.new(10034, "USD").format(:no_cents_if_whole => true, :symbol => false)).to eq "100.34"
-        expect(Money.new(10000, "IQD").format(:no_cents_if_whole => true, :symbol => false)).to eq "10"
-        expect(Money.new(10034, "IQD").format(:no_cents_if_whole => true, :symbol => false)).to eq "10.034"
+      specify "(no_cents_if_whole: true) works as documented" do
+        expect(Money.new(10000, "VUV").format(no_cents_if_whole: true, symbol: false)).to eq "10,000"
+        expect(Money.new(10034, "VUV").format(no_cents_if_whole: true, symbol: false)).to eq "10,034"
+        expect(Money.new(10000, "MGA").format(no_cents_if_whole: true, symbol: false)).to eq "2,000"
+        expect(Money.new(10034, "MGA").format(no_cents_if_whole: true, symbol: false)).to eq "2,006.8"
+        expect(Money.new(10000, "VND").format(no_cents_if_whole: true, symbol: false)).to eq "10.000"
+        expect(Money.new(10034, "VND").format(no_cents_if_whole: true, symbol: false)).to eq "10.034"
+        expect(Money.new(10000, "USD").format(no_cents_if_whole: true, symbol: false)).to eq "100"
+        expect(Money.new(10034, "USD").format(no_cents_if_whole: true, symbol: false)).to eq "100.34"
+        expect(Money.new(10000, "IQD").format(no_cents_if_whole: true, symbol: false)).to eq "10"
+        expect(Money.new(10034, "IQD").format(no_cents_if_whole: true, symbol: false)).to eq "10.034"
       end
 
-      specify "(:no_cents_if_whole => false) works as documented" do
-        expect(Money.new(10000, "VUV").format(:no_cents_if_whole => false, :symbol => false)).to eq "10,000"
-        expect(Money.new(10034, "VUV").format(:no_cents_if_whole => false, :symbol => false)).to eq "10,034"
-        expect(Money.new(10000, "MGA").format(:no_cents_if_whole => false, :symbol => false)).to eq "2,000.0"
-        expect(Money.new(10034, "MGA").format(:no_cents_if_whole => false, :symbol => false)).to eq "2,006.8"
-        expect(Money.new(10000, "VND").format(:no_cents_if_whole => false, :symbol => false)).to eq "10.000"
-        expect(Money.new(10034, "VND").format(:no_cents_if_whole => false, :symbol => false)).to eq "10.034"
-        expect(Money.new(10000, "USD").format(:no_cents_if_whole => false, :symbol => false)).to eq "100.00"
-        expect(Money.new(10034, "USD").format(:no_cents_if_whole => false, :symbol => false)).to eq "100.34"
-        expect(Money.new(10000, "IQD").format(:no_cents_if_whole => false, :symbol => false)).to eq "10.000"
-        expect(Money.new(10034, "IQD").format(:no_cents_if_whole => false, :symbol => false)).to eq "10.034"
+      specify "(no_cents_if_whole: false) works as documented" do
+        expect(Money.new(10000, "VUV").format(no_cents_if_whole: false, symbol: false)).to eq "10,000"
+        expect(Money.new(10034, "VUV").format(no_cents_if_whole: false, symbol: false)).to eq "10,034"
+        expect(Money.new(10000, "MGA").format(no_cents_if_whole: false, symbol: false)).to eq "2,000.0"
+        expect(Money.new(10034, "MGA").format(no_cents_if_whole: false, symbol: false)).to eq "2,006.8"
+        expect(Money.new(10000, "VND").format(no_cents_if_whole: false, symbol: false)).to eq "10.000"
+        expect(Money.new(10034, "VND").format(no_cents_if_whole: false, symbol: false)).to eq "10.034"
+        expect(Money.new(10000, "USD").format(no_cents_if_whole: false, symbol: false)).to eq "100.00"
+        expect(Money.new(10034, "USD").format(no_cents_if_whole: false, symbol: false)).to eq "100.34"
+        expect(Money.new(10000, "IQD").format(no_cents_if_whole: false, symbol: false)).to eq "10.000"
+        expect(Money.new(10034, "IQD").format(no_cents_if_whole: false, symbol: false)).to eq "10.034"
       end
     end
 
     describe ":symbol option" do
-      specify "(:symbol => a symbol string) uses the given value as the money symbol" do
-        expect(Money.new(100, "GBP").format(:symbol => "£")).to eq "£1.00"
+      specify "(symbol: a symbol string) uses the given value as the money symbol" do
+        expect(Money.new(100, "GBP").format(symbol: "£")).to eq "£1.00"
       end
 
-      specify "(:symbol => true) returns symbol based on the given currency code" do
+      specify "(symbol: true) returns symbol based on the given currency code" do
         one = Proc.new do |currency|
-          Money.new(100, currency).format(:symbol => true)
+          Money.new(100, currency).format(symbol: true)
         end
 
         # Pounds
@@ -342,26 +342,26 @@ describe Money, "formatting" do
         expect(one["GHC"]).to eq "₵1.00"
       end
 
-      specify "(:symbol => true) returns $ when currency code is not recognized" do
+      specify "(symbol: true) returns $ when currency code is not recognized" do
         currency = Money::Currency.new("EUR")
         expect(currency).to receive(:symbol).and_return(nil)
-        expect(Money.new(100, currency).format(:symbol => true)).to eq "¤1,00"
+        expect(Money.new(100, currency).format(symbol: true)).to eq "¤1,00"
       end
 
-      specify "(:symbol => some non-Boolean value that evaluates to true) returns symbol based on the given currency code" do
-        expect(Money.new(100, "GBP").format(:symbol => true)).to eq "£1.00"
-        expect(Money.new(100, "EUR").format(:symbol => true)).to eq "€1,00"
-        expect(Money.new(100, "SEK").format(:symbol => true)).to eq "1,00 kr"
+      specify "(symbol: some non-Boolean value that evaluates to true) returns symbol based on the given currency code" do
+        expect(Money.new(100, "GBP").format(symbol: true)).to eq "£1.00"
+        expect(Money.new(100, "EUR").format(symbol: true)).to eq "€1,00"
+        expect(Money.new(100, "SEK").format(symbol: true)).to eq "1,00 kr"
       end
 
-      specify "(:symbol => "", nil or false) returns the amount without a symbol" do
+      specify "(symbol: "", nil or false) returns the amount without a symbol" do
         money = Money.new(100, "GBP")
-        expect(money.format(:symbol => "")).to eq "1.00"
-        expect(money.format(:symbol => nil)).to eq "1.00"
-        expect(money.format(:symbol => false)).to eq "1.00"
+        expect(money.format(symbol: "")).to eq "1.00"
+        expect(money.format(symbol: nil)).to eq "1.00"
+        expect(money.format(symbol: false)).to eq "1.00"
 
         money = Money.new(100, "JPY")
-        expect(money.format(:symbol => false)).to eq "100"
+        expect(money.format(symbol: false)).to eq "100"
       end
 
       it "defaults :symbol to true" do
@@ -375,19 +375,19 @@ describe Money, "formatting" do
         expect(money.format).to eq "€1,00"
       end
 
-      specify "(:symbol => false) returns a signed amount without a symbol" do
+      specify "(symbol: false) returns a signed amount without a symbol" do
         money = Money.new(-100, "EUR")
-        expect(money.format(:symbol => false)).to eq "-1,00"
+        expect(money.format(symbol: false)).to eq "-1,00"
 
         money = Money.new(100, "EUR")
-        expect(money.format(:symbol => false,
-                     :sign_positive => true)).to eq "+1,00"
+        expect(money.format(symbol: false,
+                     sign_positive: true)).to eq "+1,00"
       end
     end
 
     describe ":decimal_mark option" do
-      specify "(:decimal_mark => a decimal_mark string) works as documented" do
-        expect(Money.us_dollar(100).format(:decimal_mark => ",")).to eq "$1,00"
+      specify "(decimal_mark: a decimal_mark string) works as documented" do
+        expect(Money.us_dollar(100).format(decimal_mark: ",")).to eq "$1,00"
       end
 
       it "defaults to '.' if currency isn't recognized" do
@@ -396,51 +396,51 @@ describe Money, "formatting" do
     end
 
     describe ":separator option" do
-      specify "(:separator => a separator string) works as documented" do
-        expect(Money.us_dollar(100).format(:separator  => ",")).to eq "$1,00"
+      specify "(separator: a separator string) works as documented" do
+        expect(Money.us_dollar(100).format(separator:  ",")).to eq "$1,00"
       end
     end
 
     describe ":south_asian_number_formatting delimiter" do
       before(:each) do
-        Money::Currency.register(JSON.parse(INDIAN_BAR, :symbolize_names => true))
+        Money::Currency.register(JSON.parse(INDIAN_BAR, symbolize_names: true))
       end
 
       after(:each) do
-        Money::Currency.unregister(JSON.parse(INDIAN_BAR, :symbolize_names => true))
+        Money::Currency.unregister(JSON.parse(INDIAN_BAR, symbolize_names: true))
       end
 
-      specify "(:south_asian_number_formatting => true) works as documented" do
-        expect(Money.new(10000000, 'INR').format(:south_asian_number_formatting => true, :symbol => false)).to eq "1,00,000.00"
-        expect(Money.new(1000000000, 'INDIAN_BAR').format(:south_asian_number_formatting => true, :symbol => false)).to eq "1,00,000.0000"
-        expect(Money.new(10000000).format(:south_asian_number_formatting => true)).to eq "$1,00,000.00"
+      specify "(south_asian_number_formatting: true) works as documented" do
+        expect(Money.new(10000000, 'INR').format(south_asian_number_formatting: true, symbol: false)).to eq "1,00,000.00"
+        expect(Money.new(1000000000, 'INDIAN_BAR').format(south_asian_number_formatting: true, symbol: false)).to eq "1,00,000.0000"
+        expect(Money.new(10000000).format(south_asian_number_formatting: true)).to eq "$1,00,000.00"
       end
 
-      specify "(:south_asian_number_formatting => true and no_cents_if_whole => true) works as documented" do
-        expect(Money.new(10000000, 'INR').format(:south_asian_number_formatting => true, :symbol => false, :no_cents_if_whole => true)).to eq "1,00,000"
-        expect(Money.new(1000000000, 'INDIAN_BAR').format(:south_asian_number_formatting => true, :symbol => false, :no_cents_if_whole => true)).to eq "1,00,000"
+      specify "(south_asian_number_formatting: true and no_cents_if_whole => true) works as documented" do
+        expect(Money.new(10000000, 'INR').format(south_asian_number_formatting: true, symbol: false, no_cents_if_whole: true)).to eq "1,00,000"
+        expect(Money.new(1000000000, 'INDIAN_BAR').format(south_asian_number_formatting: true, symbol: false, no_cents_if_whole: true)).to eq "1,00,000"
       end
     end
 
     describe ":thousands_separator option" do
-      specify "(:thousands_separator => a thousands_separator string) works as documented" do
-        expect(Money.us_dollar(100000).format(:thousands_separator => ".")).to eq "$1.000.00"
-        expect(Money.us_dollar(200000).format(:thousands_separator => "")).to eq "$2000.00"
+      specify "(thousands_separator: a thousands_separator string) works as documented" do
+        expect(Money.us_dollar(100000).format(thousands_separator: ".")).to eq "$1.000.00"
+        expect(Money.us_dollar(200000).format(thousands_separator: "")).to eq "$2000.00"
       end
 
-      specify "(:thousands_separator => false or nil) works as documented" do
-        expect(Money.us_dollar(100000).format(:thousands_separator => false)).to eq "$1000.00"
-        expect(Money.us_dollar(200000).format(:thousands_separator => nil)).to eq "$2000.00"
+      specify "(thousands_separator: false or nil) works as documented" do
+        expect(Money.us_dollar(100000).format(thousands_separator: false)).to eq "$1000.00"
+        expect(Money.us_dollar(200000).format(thousands_separator: nil)).to eq "$2000.00"
       end
 
-      specify "(:delimiter => a delimiter string) works as documented" do
-        expect(Money.us_dollar(100000).format(:delimiter => ".")).to eq "$1.000.00"
-        expect(Money.us_dollar(200000).format(:delimiter => "")).to eq "$2000.00"
+      specify "(delimiter: a delimiter string) works as documented" do
+        expect(Money.us_dollar(100000).format(delimiter: ".")).to eq "$1.000.00"
+        expect(Money.us_dollar(200000).format(delimiter: "")).to eq "$2000.00"
       end
 
-      specify "(:delimiter => false or nil) works as documented" do
-        expect(Money.us_dollar(100000).format(:delimiter => false)).to eq "$1000.00"
-        expect(Money.us_dollar(200000).format(:delimiter => nil)).to eq "$2000.00"
+      specify "(delimiter: false or nil) works as documented" do
+        expect(Money.us_dollar(100000).format(delimiter: false)).to eq "$1000.00"
+        expect(Money.us_dollar(200000).format(delimiter: nil)).to eq "$2000.00"
       end
 
       it "defaults to ',' if currency isn't recognized" do
@@ -451,11 +451,11 @@ describe Money, "formatting" do
         before { Money.use_i18n = false }
 
         it "should respect explicit overriding of thousands_separator/delimiter when decimal_mark/separator collide and there’s no decimal component for currencies that have no subunit" do
-          expect(Money.new(300_000, 'ISK').format(:thousands_separator => ",", decimal_mark: '.')).to eq "kr300,000"
+          expect(Money.new(300_000, 'ISK').format(thousands_separator: ",", decimal_mark: '.')).to eq "kr300,000"
         end
 
         it "should respect explicit overriding of thousands_separator/delimiter when decimal_mark/separator collide and there’s no decimal component for currencies with subunits that drop_trailing_zeros" do
-          expect(Money.new(300_000, 'USD').format(:thousands_separator => ".", decimal_mark: ',', drop_trailing_zeros: true)).to eq "$3.000"
+          expect(Money.new(300_000, 'USD').format(thousands_separator: ".", decimal_mark: ',', drop_trailing_zeros: true)).to eq "$3.000"
         end
 
         after { Money.use_i18n = true}
@@ -463,131 +463,131 @@ describe Money, "formatting" do
     end
 
     describe ":thousands_separator and :decimal_mark option" do
-      specify "(:thousands_separator => a thousands_separator string, :decimal_mark => a decimal_mark string) works as documented" do
+      specify "(thousands_separator: a thousands_separator string, decimal_mark: a decimal_mark string) works as documented" do
         expect(Money.new(123_456_789, "USD").format(thousands_separator: ".", decimal_mark: ",")).to eq("$1.234.567,89")
         expect(Money.new(987_654_321, "USD").format(thousands_separator: " ", decimal_mark: ".")).to eq("$9 876 543.21")
       end
     end
 
     describe ":html option" do
-      specify "(:html => true) works as documented" do
-        string = Money.ca_dollar(570).format(:html => true, :with_currency => true)
+      specify "(html: true) works as documented" do
+        string = Money.ca_dollar(570).format(html: true, with_currency: true)
         expect(string).to eq "$5.70 <span class=\"currency\">CAD</span>"
       end
 
       specify "should fallback to symbol if entity is not available" do
-        string = Money.new(570, 'DKK').format(:html => true)
+        string = Money.new(570, 'DKK').format(html: true)
         expect(string).to eq "5,70 kr."
       end
     end
 
     describe ":html_wrap_symbol option" do
-      specify "(:html_wrap_symbol => true) works as documented" do
-        string = Money.ca_dollar(570).format(:html_wrap_symbol => true)
+      specify "(html_wrap_symbol: true) works as documented" do
+        string = Money.ca_dollar(570).format(html_wrap_symbol: true)
         expect(string).to eq "<span class=\"currency_symbol\">$</span>5.70"
       end
     end
 
     describe ":symbol_position option" do
       it "inserts currency symbol before the amount when set to :before" do
-        expect(Money.euro(1_234_567_12).format(:symbol_position => :before)).to eq "€1.234.567,12"
+        expect(Money.euro(1_234_567_12).format(symbol_position: :before)).to eq "€1.234.567,12"
       end
 
       it "inserts currency symbol after the amount when set to :after" do
-        expect(Money.us_dollar(1_000_000_000_12).format(:symbol_position => :after)).to eq "1,000,000,000.12 $"
+        expect(Money.us_dollar(1_000_000_000_12).format(symbol_position: :after)).to eq "1,000,000,000.12 $"
       end
 
       it "raises an ArgumentError when passed an invalid option" do
-        expect{Money.euro(0).format(:symbol_position => :befor)}.to raise_error(ArgumentError)
+        expect{Money.euro(0).format(symbol_position: :befor)}.to raise_error(ArgumentError)
       end
     end
 
     describe ":sign_before_symbol option" do
-      specify "(:sign_before_symbol => true) works as documented" do
-        expect(Money.us_dollar(-100000).format(:sign_before_symbol => true)).to eq "-$1,000.00"
+      specify "(sign_before_symbol: true) works as documented" do
+        expect(Money.us_dollar(-100000).format(sign_before_symbol: true)).to eq "-$1,000.00"
       end
 
-      specify "(:sign_before_symbol => false) works as documented" do
-        expect(Money.us_dollar(-100000).format(:sign_before_symbol => false)).to eq "$-1,000.00"
-        expect(Money.us_dollar(-100000).format(:sign_before_symbol => nil)).to eq "$-1,000.00"
+      specify "(sign_before_symbol: false) works as documented" do
+        expect(Money.us_dollar(-100000).format(sign_before_symbol: false)).to eq "$-1,000.00"
+        expect(Money.us_dollar(-100000).format(sign_before_symbol: nil)).to eq "$-1,000.00"
       end
     end
 
     describe ":symbol_before_without_space option" do
       it "does not insert space between currency symbol and amount when set to true" do
-        expect(Money.euro(1_234_567_12).format(:symbol_position => :before, :symbol_before_without_space => true)).to eq "€1.234.567,12"
+        expect(Money.euro(1_234_567_12).format(symbol_position: :before, symbol_before_without_space: true)).to eq "€1.234.567,12"
       end
 
       it "inserts space between currency symbol and amount when set to false" do
-        expect(Money.euro(1_234_567_12).format(:symbol_position => :before, :symbol_before_without_space => false)).to eq "€ 1.234.567,12"
+        expect(Money.euro(1_234_567_12).format(symbol_position: :before, symbol_before_without_space: false)).to eq "€ 1.234.567,12"
       end
 
       it "defaults to true" do
-        expect(Money.euro(1_234_567_12).format(:symbol_position => :before)).to eq "€1.234.567,12"
+        expect(Money.euro(1_234_567_12).format(symbol_position: :before)).to eq "€1.234.567,12"
       end
     end
 
     describe ":symbol_after_without_space option" do
       it "does not insert space between amount and currency symbol when set to true" do
-        expect(Money.euro(1_234_567_12).format(:symbol_position => :after, :symbol_after_without_space => true)).to eq "1.234.567,12€"
+        expect(Money.euro(1_234_567_12).format(symbol_position: :after, symbol_after_without_space: true)).to eq "1.234.567,12€"
       end
 
       it "inserts space between amount and currency symbol when set to false" do
-        expect(Money.euro(1_234_567_12).format(:symbol_position => :after, :symbol_after_without_space => false)).to eq "1.234.567,12 €"
+        expect(Money.euro(1_234_567_12).format(symbol_position: :after, symbol_after_without_space: false)).to eq "1.234.567,12 €"
       end
 
       it "defaults to false" do
-        expect(Money.euro(1_234_567_12).format(:symbol_position => :after)).to eq "1.234.567,12 €"
+        expect(Money.euro(1_234_567_12).format(symbol_position: :after)).to eq "1.234.567,12 €"
       end
     end
 
     describe ":sign_positive option" do
-      specify "(:sign_positive => true, :sign_before_symbol => true) works as documented" do
-        expect(Money.us_dollar(      0).format(:sign_positive => true, :sign_before_symbol => true)).to eq "$0.00"
-        expect(Money.us_dollar( 100000).format(:sign_positive => true, :sign_before_symbol => true)).to eq "+$1,000.00"
-        expect(Money.us_dollar(-100000).format(:sign_positive => true, :sign_before_symbol => true)).to eq "-$1,000.00"
+      specify "(sign_positive: true, sign_before_symbol: true) works as documented" do
+        expect(Money.us_dollar(      0).format(sign_positive: true, sign_before_symbol: true)).to eq "$0.00"
+        expect(Money.us_dollar( 100000).format(sign_positive: true, sign_before_symbol: true)).to eq "+$1,000.00"
+        expect(Money.us_dollar(-100000).format(sign_positive: true, sign_before_symbol: true)).to eq "-$1,000.00"
       end
 
-      specify "(:sign_positive => true, :sign_before_symbol => false) works as documented" do
-        expect(Money.us_dollar(      0).format(:sign_positive => true, :sign_before_symbol => false)).to eq "$0.00"
-        expect(Money.us_dollar( 100000).format(:sign_positive => true, :sign_before_symbol => false)).to eq "$+1,000.00"
-        expect(Money.us_dollar( 100000).format(:sign_positive => true, :sign_before_symbol => nil)).to eq "$+1,000.00"
-        expect(Money.us_dollar(-100000).format(:sign_positive => true, :sign_before_symbol => false)).to eq "$-1,000.00"
-        expect(Money.us_dollar(-100000).format(:sign_positive => true, :sign_before_symbol => nil)).to eq "$-1,000.00"
+      specify "(sign_positive: true, sign_before_symbol: false) works as documented" do
+        expect(Money.us_dollar(      0).format(sign_positive: true, sign_before_symbol: false)).to eq "$0.00"
+        expect(Money.us_dollar( 100000).format(sign_positive: true, sign_before_symbol: false)).to eq "$+1,000.00"
+        expect(Money.us_dollar( 100000).format(sign_positive: true, sign_before_symbol: nil)).to eq "$+1,000.00"
+        expect(Money.us_dollar(-100000).format(sign_positive: true, sign_before_symbol: false)).to eq "$-1,000.00"
+        expect(Money.us_dollar(-100000).format(sign_positive: true, sign_before_symbol: nil)).to eq "$-1,000.00"
       end
 
-      specify "(:sign_positive => false, :sign_before_symbol => true) works as documented" do
-        expect(Money.us_dollar( 100000).format(:sign_positive => false, :sign_before_symbol => true)).to eq "$1,000.00"
-        expect(Money.us_dollar(-100000).format(:sign_positive => false, :sign_before_symbol => true)).to eq "-$1,000.00"
+      specify "(sign_positive: false, sign_before_symbol: true) works as documented" do
+        expect(Money.us_dollar( 100000).format(sign_positive: false, sign_before_symbol: true)).to eq "$1,000.00"
+        expect(Money.us_dollar(-100000).format(sign_positive: false, sign_before_symbol: true)).to eq "-$1,000.00"
       end
 
-      specify "(:sign_positive => false, :sign_before_symbol => false) works as documented" do
-        expect(Money.us_dollar( 100000).format(:sign_positive => false, :sign_before_symbol => false)).to eq "$1,000.00"
-        expect(Money.us_dollar( 100000).format(:sign_positive => false, :sign_before_symbol => nil)).to eq "$1,000.00"
-        expect(Money.us_dollar(-100000).format(:sign_positive => false, :sign_before_symbol => false)).to eq "$-1,000.00"
-        expect(Money.us_dollar(-100000).format(:sign_positive => false, :sign_before_symbol => nil)).to eq "$-1,000.00"
+      specify "(sign_positive: false, sign_before_symbol: false) works as documented" do
+        expect(Money.us_dollar( 100000).format(sign_positive: false, sign_before_symbol: false)).to eq "$1,000.00"
+        expect(Money.us_dollar( 100000).format(sign_positive: false, sign_before_symbol: nil)).to eq "$1,000.00"
+        expect(Money.us_dollar(-100000).format(sign_positive: false, sign_before_symbol: false)).to eq "$-1,000.00"
+        expect(Money.us_dollar(-100000).format(sign_positive: false, sign_before_symbol: nil)).to eq "$-1,000.00"
       end
     end
 
     describe ":rounded_infinite_precision option", :infinite_precision do
       it "does round fractional when set to true" do
-        expect(Money.new(BigDecimal('12.1'), "USD").format(:rounded_infinite_precision => true)).to eq "$0.12"
-        expect(Money.new(BigDecimal('12.5'), "USD").format(:rounded_infinite_precision => true)).to eq "$0.13"
-        expect(Money.new(BigDecimal('123.1'), "BHD").format(:rounded_infinite_precision => true)).to eq "ب.د0.123"
-        expect(Money.new(BigDecimal('123.5'), "BHD").format(:rounded_infinite_precision => true)).to eq "ب.د0.124"
-        expect(Money.new(BigDecimal('100.1'), "USD").format(:rounded_infinite_precision => true)).to eq "$1.00"
-        expect(Money.new(BigDecimal('109.5'), "USD").format(:rounded_infinite_precision => true)).to eq "$1.10"
-        expect(Money.new(BigDecimal('1.7'), "MGA").format(:rounded_infinite_precision => true)).to eq "Ar0.4"
+        expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: true)).to eq "$0.12"
+        expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: true)).to eq "$0.13"
+        expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq "ب.د0.123"
+        expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq "ب.د0.124"
+        expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: true)).to eq "$1.00"
+        expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: true)).to eq "$1.10"
+        expect(Money.new(BigDecimal('1.7'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar0.4"
       end
 
       it "does not round fractional when set to false" do
-        expect(Money.new(BigDecimal('12.1'), "USD").format(:rounded_infinite_precision => false)).to eq "$0.121"
-        expect(Money.new(BigDecimal('12.5'), "USD").format(:rounded_infinite_precision => false)).to eq "$0.125"
-        expect(Money.new(BigDecimal('123.1'), "BHD").format(:rounded_infinite_precision => false)).to eq "ب.د0.1231"
-        expect(Money.new(BigDecimal('123.5'), "BHD").format(:rounded_infinite_precision => false)).to eq "ب.د0.1235"
-        expect(Money.new(BigDecimal('100.1'), "USD").format(:rounded_infinite_precision => false)).to eq "$1.001"
-        expect(Money.new(BigDecimal('109.5'), "USD").format(:rounded_infinite_precision => false)).to eq "$1.095"
-        expect(Money.new(BigDecimal('1.7'), "MGA").format(:rounded_infinite_precision => false)).to eq "Ar0.34"
+        expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: false)).to eq "$0.121"
+        expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: false)).to eq "$0.125"
+        expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: false)).to eq "ب.د0.1231"
+        expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: false)).to eq "ب.د0.1235"
+        expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: false)).to eq "$1.001"
+        expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: false)).to eq "$1.095"
+        expect(Money.new(BigDecimal('1.7'), "MGA").format(rounded_infinite_precision: false)).to eq "Ar0.34"
       end
 
       describe "with i18n = false" do
@@ -600,13 +600,13 @@ describe Money, "formatting" do
         end
 
         it 'does round fractional when set to true' do
-          expect(Money.new(BigDecimal('12.1'), "EUR").format(:rounded_infinite_precision => true)).to eq "€0,12"
-          expect(Money.new(BigDecimal('12.5'), "EUR").format(:rounded_infinite_precision => true)).to eq "€0,13"
-          expect(Money.new(BigDecimal('100.1'), "EUR").format(:rounded_infinite_precision => true)).to eq "€1,00"
-          expect(Money.new(BigDecimal('109.5'), "EUR").format(:rounded_infinite_precision => true)).to eq "€1,10"
+          expect(Money.new(BigDecimal('12.1'), "EUR").format(rounded_infinite_precision: true)).to eq "€0,12"
+          expect(Money.new(BigDecimal('12.5'), "EUR").format(rounded_infinite_precision: true)).to eq "€0,13"
+          expect(Money.new(BigDecimal('100.1'), "EUR").format(rounded_infinite_precision: true)).to eq "€1,00"
+          expect(Money.new(BigDecimal('109.5'), "EUR").format(rounded_infinite_precision: true)).to eq "€1,10"
 
-          expect(Money.new(BigDecimal('100012.1'), "EUR").format(:rounded_infinite_precision => true)).to eq "€1.000,12"
-          expect(Money.new(BigDecimal('100012.5'), "EUR").format(:rounded_infinite_precision => true)).to eq "€1.000,13"
+          expect(Money.new(BigDecimal('100012.1'), "EUR").format(rounded_infinite_precision: true)).to eq "€1.000,12"
+          expect(Money.new(BigDecimal('100012.5'), "EUR").format(rounded_infinite_precision: true)).to eq "€1.000,13"
         end
       end
 
@@ -617,7 +617,7 @@ describe Money, "formatting" do
           I18n.locale = :de
           I18n.backend.store_translations(
               :de,
-              :number => { :currency => { :format => { :delimiter => ".", :separator => "," } } }
+              number: { currency: { format: { delimiter: ".", separator: "," } } }
           )
         end
 
@@ -627,13 +627,13 @@ describe Money, "formatting" do
         end
 
         it 'does round fractional when set to true' do
-          expect(Money.new(BigDecimal('12.1'), "USD").format(:rounded_infinite_precision => true)).to eq "$0,12"
-          expect(Money.new(BigDecimal('12.5'), "USD").format(:rounded_infinite_precision => true)).to eq "$0,13"
-          expect(Money.new(BigDecimal('123.1'), "BHD").format(:rounded_infinite_precision => true)).to eq "ب.د0,123"
-          expect(Money.new(BigDecimal('123.5'), "BHD").format(:rounded_infinite_precision => true)).to eq "ب.د0,124"
-          expect(Money.new(BigDecimal('100.1'), "USD").format(:rounded_infinite_precision => true)).to eq "$1,00"
-          expect(Money.new(BigDecimal('109.5'), "USD").format(:rounded_infinite_precision => true)).to eq "$1,10"
-          expect(Money.new(BigDecimal('1'), "MGA").format(:rounded_infinite_precision => true)).to eq "Ar0,2"
+          expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: true)).to eq "$0,12"
+          expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: true)).to eq "$0,13"
+          expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq "ب.د0,123"
+          expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq "ب.د0,124"
+          expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: true)).to eq "$1,00"
+          expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: true)).to eq "$1,10"
+          expect(Money.new(BigDecimal('1'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar0,2"
         end
       end
     end
@@ -642,30 +642,30 @@ describe Money, "formatting" do
       let(:money) { Money.us_dollar(0) }
 
       it "returns 'free' when :display_free is true" do
-        expect(money.format(:display_free => true)).to eq 'free'
+        expect(money.format(display_free: true)).to eq 'free'
       end
 
       it "returns '$0.00' when :display_free is false or not given" do
         expect(money.format).to eq '$0.00'
-        expect(money.format(:display_free => false)).to eq '$0.00'
-        expect(money.format(:display_free => nil)).to eq '$0.00'
+        expect(money.format(display_free: false)).to eq '$0.00'
+        expect(money.format(display_free: nil)).to eq '$0.00'
       end
 
       it "returns the value specified by :display_free if it's a string-like object" do
-        expect(money.format(:display_free => 'gratis')).to eq 'gratis'
+        expect(money.format(display_free: 'gratis')).to eq 'gratis'
       end
     end
   end
 
   context "custom currencies with 4 decimal places" do
     before :each do
-      Money::Currency.register(JSON.parse(BAR, :symbolize_names => true))
-      Money::Currency.register(JSON.parse(EU4, :symbolize_names => true))
+      Money::Currency.register(JSON.parse(BAR, symbolize_names: true))
+      Money::Currency.register(JSON.parse(EU4, symbolize_names: true))
     end
 
     after :each do
-      Money::Currency.unregister(JSON.parse(BAR, :symbolize_names => true))
-      Money::Currency.unregister(JSON.parse(EU4, :symbolize_names => true))
+      Money::Currency.unregister(JSON.parse(BAR, symbolize_names: true))
+      Money::Currency.unregister(JSON.parse(EU4, symbolize_names: true))
     end
 
     it "respects custom subunit to unit, decimal and thousands separator" do
@@ -754,18 +754,18 @@ describe Money, "formatting" do
     end
 
     describe ":drop_trailing_zeros option" do
-      specify "(:drop_trailing_zeros => true) works as documented" do
-        expect(Money.new(89000, "BTC").format(:drop_trailing_zeros => true, :symbol => false)).to eq "0.00089"
-        expect(Money.new(100089000, "BTC").format(:drop_trailing_zeros => true, :symbol => false)).to eq "1.00089"
-        expect(Money.new(100000000, "BTC").format(:drop_trailing_zeros => true, :symbol => false)).to eq "1"
-        expect(Money.new(110, "AUD").format(:drop_trailing_zeros => true, :symbol => false)).to eq "1.1"
+      specify "(drop_trailing_zeros: true) works as documented" do
+        expect(Money.new(89000, "BTC").format(drop_trailing_zeros: true, symbol: false)).to eq "0.00089"
+        expect(Money.new(100089000, "BTC").format(drop_trailing_zeros: true, symbol: false)).to eq "1.00089"
+        expect(Money.new(100000000, "BTC").format(drop_trailing_zeros: true, symbol: false)).to eq "1"
+        expect(Money.new(110, "AUD").format(drop_trailing_zeros: true, symbol: false)).to eq "1.1"
       end
 
-      specify "(:drop_trailing_zeros => false) works as documented" do
-        expect(Money.new(89000, "BTC").format(:drop_trailing_zeros => false, :symbol => false)).to eq "0.00089000"
-        expect(Money.new(100089000, "BTC").format(:drop_trailing_zeros => false, :symbol => false)).to eq "1.00089000"
-        expect(Money.new(100000000, "BTC").format(:drop_trailing_zeros => false, :symbol => false)).to eq "1.00000000"
-        expect(Money.new(110, "AUD").format(:drop_trailing_zeros => false, :symbol => false)).to eq "1.10"
+      specify "(drop_trailing_zeros: false) works as documented" do
+        expect(Money.new(89000, "BTC").format(drop_trailing_zeros: false, symbol: false)).to eq "0.00089000"
+        expect(Money.new(100089000, "BTC").format(drop_trailing_zeros: false, symbol: false)).to eq "1.00089000"
+        expect(Money.new(100000000, "BTC").format(drop_trailing_zeros: false, symbol: false)).to eq "1.00000000"
+        expect(Money.new(110, "AUD").format(drop_trailing_zeros: false, symbol: false)).to eq "1.10"
       end
     end
   end

--- a/spec/rates_store/memory_spec.rb
+++ b/spec/rates_store/memory_spec.rb
@@ -15,7 +15,7 @@ describe Money::RatesStore::Memory do
     end
 
     context ':without_mutex' do
-      let(:subject) { Money::RatesStore::Memory.new(:without_mutex => true) }
+      let(:subject) { Money::RatesStore::Memory.new(without_mutex: true) }
 
       it "doesn't use mutex if requested not to" do
         expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
@@ -58,7 +58,7 @@ describe Money::RatesStore::Memory do
     end
 
     context 'no mutex' do
-      let(:subject) { Money::RatesStore::Memory.new(:without_mutex => true) }
+      let(:subject) { Money::RatesStore::Memory.new(without_mutex: true) }
 
       it 'does not use mutex' do
         expect(subject.instance_variable_get('@mutex')).not_to receive(:synchronize)
@@ -68,7 +68,7 @@ describe Money::RatesStore::Memory do
   end
 
   describe '#marshal_dump' do
-    let(:subject) { Money::RatesStore::Memory.new(:optional => true) }
+    let(:subject) { Money::RatesStore::Memory.new(optional: true) }
 
     it 'can reload' do
       bank = Money::Bank::VariableExchange.new(subject)


### PR DESCRIPTION
Switching to ruby new hash syntax as default across all the RubyMoney projects