### PR TITLE
Fix formatting links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,17 @@ implementations.
 - [russian_central_bank](https://github.com/rmustafin/russian_central_bank)
 - [money-uphold-bank](https://github.com/subvisual/money-uphold-bank)
 
+## Formatting
+
+There are several formatting rules for when `Money#format` is called. For more information, check out the [formatting module source](https://github.com/RubyMoney/money/blob/master/lib/money/money/formatter.rb), or read the latest release's [rdoc version](http://www.rubydoc.info/gems/money/Money/Formatter).
+
+If you wish to format money according to the EU's [Rules for expressing monetary units](http://publications.europa.eu/code/en/en-370303.htm#position) in either English, Irish, Latvian or Maltese:
+
+```ruby
+m = Money.new('123', :gbp) # => #<Money fractional:123 currency:GBP>
+m.format(symbol: m.currency.to_s + ' ') # => "GBP 1.23"
+```
+
 ## Ruby on Rails
 
 To integrate money in a Rails application use [money-rails](https://github.com/RubyMoney/money-rails).
@@ -429,16 +440,6 @@ If you get a runtime error such as:
 Set the following:
 ``` ruby
 I18n.enforce_available_locales = false
-```
-
-## Formatting
-
-There are several formatting rules for when `Money#format` is called. For more information, check out the [formatting module source](https://github.com/RubyMoney/money/blob/master/lib/money/money/formatting.rb), or read the latest release's [rdoc version](http://www.rubydoc.info/gems/money/Money/Formatting).
-
-If you wish to format money according to the EU's [Rules for expressing monetary units](http://publications.europa.eu/code/en/en-370303.htm#position) in either English, Irish, Latvian or Maltese:
-```ruby
-m = Money.new('123', :gbp) # => #<Money fractional:123 currency:GBP>
-m.format( symbol: m.currency.to_s + ' ') # => "GBP 1.23"
 ```
 
 ## Heuristics


### PR DESCRIPTION
These links have changed since the `Formatting` got renamed to `Formatter`