### PR TITLE
Fix issue with summing non-default/USD currency 'Money' objects

### DIFF
--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -126,7 +126,7 @@ class Money
       define_method(op) do |other|
         unless other.is_a?(Money)
           if other.zero?
-            return other.is_a?(CoercedNumeric) ? Money.empty.public_send(op, self) : self
+            return other.is_a?(CoercedNumeric) ? Money.empty(currency).public_send(op, self) : self
           end
           raise TypeError
         end

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -631,6 +631,11 @@ describe Money do
   end
 
   describe "#coerce" do
+    it 'allows non-default currency money objects to be summed' do
+      result = 0 + Money.new(4, 'EUR') + Money.new(5, 'EUR')
+      expect(result).to eq Money.new(9, 'EUR')
+    end
+
     it "allows mathematical operations by coercing arguments" do
       result = 2 * Money.new(4, 'USD')
       expect(result).to eq Money.new(8, 'USD')


### PR DESCRIPTION
When attempting to upgrade the 'money' gem in one of our projects to [version 6.11.0](https://github.com/RubyMoney/money/releases/tag/v6.11.0), I noticed that some tests started failing. I could pinpoint these failures to some functionality that summed non-USD (or non-default) currency `Money` objects.

You could reproduce it as follows:

```ruby
[Money.from_amount(10.00, 'EUR'), Money.from_amount(5.00, 'EUR')].sum
```

I have added a failing spec, and then fixed it by passing the 'currency' to the `Money.empty` initializer.
