### PR TITLE
Ignore formatting defaults for Money#to_s

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -354,7 +354,8 @@ class Money
     format decimal_mark: currency.decimal_mark,
            thousands_separator: '',
            no_cents_if_whole: currency.decimal_places == 0,
-           symbol: false
+           symbol: false,
+           ignore_defaults: true
   end
 
   # Return the amount of money as a BigDecimal.

--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -8,7 +8,7 @@ class Money
       # support for old format parameters
       @rules = normalize_formatting_rules(raw_rules)
 
-      @rules = default_formatting_rules.merge(@rules)
+      @rules = default_formatting_rules.merge(@rules) unless @rules[:ignore_defaults]
       @rules = localize_formatting_rules(@rules)
       @rules = translate_formatting_rules(@rules) if @rules[:translate]
     end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -482,6 +482,15 @@ YAML
       expect(Money.new(10_00, "BRL").to_s).to eq "10,00"
     end
 
+    context "with defaults set" do
+      before { Money.default_formatting_rules = { with_currency: true } }
+      after { Money.default_formatting_rules = nil }
+
+      it "ignores defaults" do
+        expect(Money.new(10_00, 'USD').to_s).to eq '10.00'
+      end
+    end
+
     context "with infinite_precision", :infinite_precision do
       it "shows fractional cents" do
         expect(Money.new(1.05, "USD").to_s).to eq "0.0105"


### PR DESCRIPTION
During `Money#to_s` refactoring (https://github.com/RubyMoney/money/commit/f260b9dc1dcdca28b67f6b3671c04241f0f89fce) a regression was introduced that would take default formatting rules into consideration. This PR fixes the regression.