### PR TITLE
Respect i18n in #to_s

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -351,8 +351,7 @@ class Money
   # @example
   #   Money.ca_dollar(100).to_s #=> "1.00"
   def to_s
-    format decimal_mark: currency.decimal_mark,
-           thousands_separator: '',
+    format thousands_separator: '',
            no_cents_if_whole: currency.decimal_places == 0,
            symbol: false,
            ignore_defaults: true

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -482,6 +482,15 @@ YAML
       expect(Money.new(10_00, "BRL").to_s).to eq "10,00"
     end
 
+    context "using i18n" do
+      before { I18n.backend.store_translations(:en, number: { format: { separator: "." } }) }
+      after { reset_i18n }
+
+      it "respects decimal mark" do
+        expect(Money.new(10_00, "BRL").to_s).to eq "10.00"
+      end
+    end
+
     context "with defaults set" do
       before { Money.default_formatting_rules = { with_currency: true } }
       after { Money.default_formatting_rules = nil }


### PR DESCRIPTION
There has been a couple of problems with using `currency.decimal_mark` when calling `to_s`. Primarily the inconsistency with how `money-rails` validates input, relying on i18n for determining acceptable decimal mark.

This PR restores the behaviour to be similar to the original. Following the path of least resistance here, since it turned out that this wasn't covered by enough unit-tests and the refactor did alter the behaviour in some cases.