### PR TITLE
Add a lightweight constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ money = Money.new(1000, "USD")
 money.cents     #=> 1000
 money.currency  #=> Currency.new("USD")
 
+# Lightweight constructor (skip .new)
+Money(1000, "USD") #=> Money.new(1000, "USD")
+
 # Comparisons
 Money.new(1000, "USD") == Money.new(1000, "USD")   #=> true
 Money.new(1000, "USD") == Money.new(100, "USD")    #=> false

--- a/lib/money/money/constructors.rb
+++ b/lib/money/money/constructors.rb
@@ -1,3 +1,13 @@
+# A lightweight constructor allowing to instantiate Money without .new:
+#  - Money(10_00)
+#  - Money(10_00, 'USD')
+#
+#  The signature and return value are the same as .new
+#
+def Money(*args)
+  Money.new(*args)
+end
+
 class Money
   module Constructors
 

--- a/spec/money/constructors_spec.rb
+++ b/spec/money/constructors_spec.rb
@@ -1,6 +1,10 @@
 # encoding: utf-8
 
 describe Money::Constructors do
+  it 'adds a lightweight constructur' do
+    expect(Money(1_00)).to eq(Money.new(1_00))
+    expect(Money(1_00, 'EUR')).to eq(Money.new(1_00, 'EUR'))
+  end
 
   describe "::empty" do
     it "creates a new Money object of 0 cents" do


### PR DESCRIPTION
Adds a shortcut to create Money objects by skipping `.new` — `Money(10_00, 'USD')`. Might be handy for some developers. Acts as a synonym to `.new`, much like `BigDecimal(100)`