### PR TITLE
Respect symbol_first i18n setting when formatting amount

### DIFF
--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -375,7 +375,7 @@ class Money
         else
           raise ArgumentError, ":symbol_position must be ':before' or ':after'"
         end
-      elsif currency.symbol_first?
+      elsif i18n_format_for(:symbol_first, :symbol_first, false)
         :before
       else
         :after

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -58,7 +58,7 @@ describe Money, "formatting" do
         I18n.locale = :de
         I18n.backend.store_translations(
             :de,
-            number: { format: { delimiter: ".", separator: "," } }
+            number: { format: { delimiter: ".", separator: ",", symbol_first: false } }
         )
       end
 
@@ -70,6 +70,11 @@ describe Money, "formatting" do
 
       it "should use ',' as the decimal mark" do
         expect(money.decimal_mark).to eq ','
+      end
+
+      it "respects the symbol_first i18n setting" do
+        I18n.with_locale(:de) { expect(money.format).to eq '0,00 $' }
+        I18n.with_locale(:en) { expect(money.format).to eq '$0.00' }
       end
     end
 


### PR DESCRIPTION
Previously only the separators were localized, but the symbol position
remained unchanged and based on the currency.
In most cases, when you localize an amount, the currency setting is less
important than the user preference (i.e. through locale).

Although this is not a rails default currency i18n setting, it would be
very helpful if it was respected correctly.

The fallback remains to the currency setting, so this change is
backwards compatible unless the "number.format.currency.symbol_first"
key is set.

spec is included, tests are green.