### PR TITLE
Add html_wrap_decimal formatter rule

### DIFF
--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -170,6 +170,9 @@ class Money
     # @option rules [Boolean] :html_wrap_symbol (false) Wraps the currency symbol
     #  in a html <span> tag.
     #
+    # @option rules [Boolean] :html_wrap_decimal (false) Wraps the decimal in a
+    #  html <span> tag.
+    #
     # @example
     #   Money.new(10000, "USD").format(disambiguate: false)
     #   #=> "<span class=\"currency_symbol\">$100.00</span>
@@ -216,7 +219,11 @@ class Money
       whole_part = format_whole_part(whole_part)
 
       # Assemble the final formatted amount
-      formatted = [whole_part, decimal_part].compact.join(decimal_mark)
+      formatted = if rules[:html_wrap_decimal]
+        ["#{whole_part}<span class=\"decimal\">", "#{decimal_part}</span>"].compact.join(decimal_mark)
+      else
+        [whole_part, decimal_part].compact.join(decimal_mark)
+      end
 
       sign = money.negative? ? '-' : ''
 

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -488,6 +488,13 @@ describe Money, "formatting" do
       end
     end
 
+    describe ":html_wrap_decimal option" do
+      specify "(html_wrap_decimal: true) works as documented" do
+        string = Money.ca_dollar(570).format(html_wrap_decimal: true)
+        expect(string).to eq "$5<span class=\"decimal\">.70</span>"
+      end
+    end
+
     describe ":symbol_position option" do
       it "inserts currency symbol before the amount when set to :before" do
         expect(Money.euro(1_234_567_12).format(symbol_position: :before)).to eq "€1.234.567,12"


### PR DESCRIPTION
I needed for my project to use different style for decimal number, so I added html_wrap_decimal option to formatter. It allows to do things like this:

<img width="217" alt="screen shot 2018-06-01 at 13 13 53" src="https://user-images.githubusercontent.com/1409998/40835943-a84b2702-659d-11e8-95be-e32159c0cc1c.png">


