### PR TITLE
 Wrap all amount parts when html option is used

### DIFF
--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -132,10 +132,16 @@ class Money
     #   Money.new(100000, "FOO").format #=> "$1,000.00"
     #
     # @option rules [Boolean] :html (false) Whether the currency should be
-    #  HTML-formatted.
+    #  HTML-formatted. Only useful in combination with +:with_currency+.
     #
     # @example
     #   Money.ca_dollar(570).format(html: true, with_currency: true)
+    #   #=> "$5.70 <span class=\"currency\">CAD</span>"
+    #
+    # @option rules [Boolean] :html_wrap (false) Whether all currency parts should be HTML-formatted.
+    #
+    # @example
+    #   Money.ca_dollar(570).format(html_wrap: true, with_currency: true)
     #   #=> "<span class=\"money-currency-symbol\">$</span><span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">70</span> <span class=\"money-currency\">CAD</span>"
     #
     # @option rules [Boolean] :sign_before_symbol (false) Whether the sign should be
@@ -209,8 +215,12 @@ class Money
     def to_s
       return free_text if show_free_text?
 
+      if rules[:html]
+        warn "[DEPRECATION] `html` is deprecated - use `html_wrap` instead. Please note that `html_wrap` will wrap all parts of currency and if you use `with_currency` option, currency element class changes from `currency` to `money-currency`."
+      end
+
       if rules[:html_wrap_symbol]
-        warn "[DEPRECATION] `html_wrap_symbol` is deprecated. Symbol will always be wrapped if `html: true` option is present."
+        warn "[DEPRECATION] `html_wrap_symbol` is deprecated - use `html_wrap` instead. Please note that `html_wrap` will wrap all parts of currency."
       end
 
       whole_part, decimal_part = extract_whole_and_decimal_parts
@@ -220,11 +230,11 @@ class Money
       whole_part = format_whole_part(whole_part)
 
       # Assemble the final formatted amount
-      formatted = if rules[:html]
+      formatted = if rules[:html_wrap]
         if decimal_part.nil?
-          "<span class=\"money-whole\">#{whole_part}</span>"
+          html_wrap(whole_part, "whole")
         else
-          "<span class=\"money-whole\">#{whole_part}</span><span class=\"money-decimal-mark\">#{decimal_mark}</span><span class=\"money-decimal\">#{decimal_part}</span>"
+          [html_wrap(whole_part, "whole"), html_wrap(decimal_mark, "decimal-mark"), html_wrap(decimal_part, "decimal")].join
         end
       else
         [whole_part, decimal_part].compact.join(decimal_mark)
@@ -244,7 +254,11 @@ class Money
       symbol_value = symbol_value_from(rules)
 
       if symbol_value && !symbol_value.empty?
-        symbol_value = "<span class=\"money-currency-symbol\">#{symbol_value}</span>" if rules[:html]
+        if rules[:html_wrap_symbol]
+          symbol_value = "<span class=\"currency_symbol\">#{symbol_value}</span>"
+        elsif rules[:html_wrap]
+          symbol_value = html_wrap(symbol_value, "currency-symbol")
+        end
         symbol_position = symbol_position_from(rules)
 
         formatted = if symbol_position == :before
@@ -260,9 +274,14 @@ class Money
 
       if rules[:with_currency]
         formatted << " "
-        formatted << '<span class="money-currency">' if rules[:html]
-        formatted << currency.to_s
-        formatted << '</span>' if rules[:html]
+
+        if rules[:html]
+          formatted << "<span class=\"currency\">#{currency.to_s}</span>"
+        elsif rules[:html_wrap]
+          formatted << html_wrap(currency.to_s, "currency")
+        else
+          formatted << currency.to_s
+        end
       end
       formatted
     end
@@ -292,6 +311,10 @@ class Money
 
     def show_free_text?
       money.zero? && rules[:display_free]
+    end
+
+    def html_wrap(string, class_name)
+      "<span class=\"money-#{class_name}\">#{string}</span>"
     end
 
     def free_text
@@ -371,7 +394,7 @@ class Money
         else
           ""
         end
-      elsif rules[:html]
+      elsif rules[:html] || rules[:html_wrap]
         currency.html_entity == '' ? currency.symbol : currency.html_entity
       elsif rules[:disambiguate] && currency.disambiguate_symbol
         currency.disambiguate_symbol

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -136,7 +136,7 @@ class Money
     #
     # @example
     #   Money.ca_dollar(570).format(html: true, with_currency: true)
-    #   #=> "<span class\"money-currency-symbol\">$</span><span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">70</span> <span class=\"money-currency\">CAD</span>"
+    #   #=> "<span class=\"money-currency-symbol\">$</span><span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">70</span> <span class=\"money-currency\">CAD</span>"
     #
     # @option rules [Boolean] :sign_before_symbol (false) Whether the sign should be
     #  before the currency symbol.

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -136,7 +136,7 @@ class Money
     #
     # @example
     #   Money.ca_dollar(570).format(html: true, with_currency: true)
-    #   #=> "<span class\"money-currency\">$</span><span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">70</span> <span class=\"currency\">CAD</span>"
+    #   #=> "<span class\"money-currency-symbol\">$</span><span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">70</span> <span class=\"money-currency\">CAD</span>"
     #
     # @option rules [Boolean] :sign_before_symbol (false) Whether the sign should be
     #  before the currency symbol.

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -266,7 +266,7 @@ describe Money, "formatting" do
       it "doesn't incorrectly format HTML" do
         money = ::Money.new(1999, "RUB")
         output = money.format(html: true, no_cents: true)
-        expect(output).to eq "19 &#x20BD;"
+        expect(output).to eq "<span class=\"money-whole\">19</span> <span class=\"money-currency-symbol\">&#x20BD;</span>"
       end
     end
 
@@ -471,20 +471,18 @@ describe Money, "formatting" do
 
     describe ":html option" do
       specify "(html: true) works as documented" do
+        string = Money.ca_dollar(570).format(html: true)
+        expect(string).to eq "<span class=\"money-currency-symbol\">$</span><span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">70</span>"
+      end
+
+      specify "(html: true, with_currency: true)" do
         string = Money.ca_dollar(570).format(html: true, with_currency: true)
-        expect(string).to eq "$5.70 <span class=\"currency\">CAD</span>"
+        expect(string).to eq "<span class=\"money-currency-symbol\">$</span><span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">70</span> <span class=\"money-currency\">CAD</span>"
       end
 
       specify "should fallback to symbol if entity is not available" do
         string = Money.new(570, 'DKK').format(html: true)
-        expect(string).to eq "5,70 kr."
-      end
-    end
-
-    describe ":html_wrap_symbol option" do
-      specify "(html_wrap_symbol: true) works as documented" do
-        string = Money.ca_dollar(570).format(html_wrap_symbol: true)
-        expect(string).to eq "<span class=\"currency_symbol\">$</span>5.70"
+        expect(string).to eq "<span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">,</span><span class=\"money-decimal\">70</span> <span class=\"money-currency-symbol\">kr.</span>"
       end
     end
 

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -266,6 +266,12 @@ describe Money, "formatting" do
       it "doesn't incorrectly format HTML" do
         money = ::Money.new(1999, "RUB")
         output = money.format(html: true, no_cents: true)
+        expect(output).to eq "19 &#x20BD;"
+      end
+
+      it "doesn't incorrectly format HTML (html_wrap)" do
+        money = ::Money.new(1999, "RUB")
+        output = money.format(html_wrap: true, no_cents: true)
         expect(output).to eq "<span class=\"money-whole\">19</span> <span class=\"money-currency-symbol\">&#x20BD;</span>"
       end
     end
@@ -471,17 +477,36 @@ describe Money, "formatting" do
 
     describe ":html option" do
       specify "(html: true) works as documented" do
-        string = Money.ca_dollar(570).format(html: true)
-        expect(string).to eq "<span class=\"money-currency-symbol\">$</span><span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">70</span>"
-      end
-
-      specify "(html: true, with_currency: true)" do
         string = Money.ca_dollar(570).format(html: true, with_currency: true)
-        expect(string).to eq "<span class=\"money-currency-symbol\">$</span><span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">70</span> <span class=\"money-currency\">CAD</span>"
+        expect(string).to eq "$5.70 <span class=\"currency\">CAD</span>"
       end
 
       specify "should fallback to symbol if entity is not available" do
         string = Money.new(570, 'DKK').format(html: true)
+        expect(string).to eq "5,70 kr."
+      end
+    end
+
+    describe ":html_wrap_symbol option" do
+      specify "(html_wrap_symbol: true) works as documented" do
+        string = Money.ca_dollar(570).format(html_wrap_symbol: true)
+        expect(string).to eq "<span class=\"currency_symbol\">$</span>5.70"
+      end
+    end
+
+    describe ":html_wrap option" do
+      specify "(html_wrap: true) works as documented" do
+        string = Money.ca_dollar(570).format(html_wrap: true)
+        expect(string).to eq "<span class=\"money-currency-symbol\">$</span><span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">70</span>"
+      end
+
+      specify "(html_wrap: true, with_currency: true)" do
+        string = Money.ca_dollar(570).format(html_wrap: true, with_currency: true)
+        expect(string).to eq "<span class=\"money-currency-symbol\">$</span><span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">70</span> <span class=\"money-currency\">CAD</span>"
+      end
+
+      specify "should fallback to symbol if entity is not available" do
+        string = Money.new(570, 'DKK').format(html_wrap: true)
         expect(string).to eq "<span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">,</span><span class=\"money-decimal\">70</span> <span class=\"money-currency-symbol\">kr.</span>"
       end
     end


### PR DESCRIPTION
In response of #775 

When using formatter's `html: true` option, all amount's string parts
will be wrapped in html elements (symbol, whole part, decimal mark,
decimal part and, if `with_currency` is true, currency).

Also deprecated html_wrap_symbol option, since it will be always wrapped
with `html: true` option.

@antstorm I'm not sure about deprecation part though, because we potentially introduce breaking change here. Are you going to make a major release or should we introduce temporary option which enables this new type of behaviour?