### PR TITLE
Respect rounding mode when infinite_precision is false

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -522,7 +522,7 @@ class Money
   #
   def round(rounding_mode = self.class.rounding_mode, rounding_precision = 0)
     rounded_amount = as_d(@fractional).round(rounding_precision, rounding_mode)
-    self.class.new(rounded_amount, self.currency)
+    self.class.new(rounded_amount, currency, bank)
   end
 
   # Creates a formatted price string according to several rules.

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -521,11 +521,8 @@ class Money
   #   Money.infinite_precision
   #
   def round(rounding_mode = self.class.rounding_mode, rounding_precision = 0)
-    if self.class.infinite_precision
-      self.class.new(fractional.round(rounding_precision, rounding_mode), self.currency)
-    else
-      self
-    end
+    rounded_amount = as_d(@fractional).round(rounding_precision, rounding_mode)
+    self.class.new(rounded_amount, self.currency)
   end
 
   # Creates a formatted price string according to several rules.

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -789,6 +789,13 @@ YAML
       end
     end
 
+    it 'preserves assigned bank' do
+      bank = Money::Bank::VariableExchange.new
+      rounded = Money.new(1_00, 'USD', bank).round
+
+      expect(rounded.bank).to eq(bank)
+    end
+
     context "when using a subclass of Money" do
       let(:special_money_class) { Class.new(Money) }
       let(:money) { special_money_class.new(15.75, 'NZD') }


### PR DESCRIPTION
We used to return `self` when `infinite_precision` was set to `false`. This can cause issues as the result might change based on the global `rounding_mode` setting — the result of keeping the `fractional` part unchanged and only relying on the `rounding_mode` to adjust the return value.

Another manifestation of this problem might come in accumulating error during arithmetics operations:

```ruby
money_1 = Money.new(10.9).round(BigDecimal::ROUND_DOWN)
money_2 = Money.new(10.9).round(BigDecimal::ROUND_DOWN)

expect(money_1 + money_2).to eq(Money.new(20))
```

This would have returned `22` before the fix.

More examples and discussion in #638