### PR TITLE
Remove memoization for #empty/#zero

### DIFF
--- a/lib/money/money/constructors.rb
+++ b/lib/money/money/constructors.rb
@@ -10,9 +10,7 @@ class Money
     # @example
     #   Money.empty #=> #<Money @fractional=0>
     def empty(currency = default_currency)
-      @empty ||= {}
-      currency = Currency.new(currency)
-      @empty[currency] ||= new(0, currency).freeze
+      new(0, currency)
     end
     alias_method :zero, :empty
 

--- a/spec/money/constructors_spec.rb
+++ b/spec/money/constructors_spec.rb
@@ -7,26 +7,6 @@ describe Money::Constructors do
       expect(Money.empty).to eq Money.new(0)
     end
 
-    it "memoizes the result" do
-      expect(Money.empty.object_id).to eq Money.empty.object_id
-    end
-
-    it "memoizes a result for each currency" do
-      expect(Money.empty(:cad).object_id).to eq Money.empty(:cad).object_id
-    end
-
-    it "doesn't allow money to be modified for a currency" do
-      expect(Money.empty).to be_frozen
-    end
-
-    it "always use Currency object to memoize Money objects" do
-      Money.instance_variable_set(:@empty, {})
-      expect {
-        Money.zero(:usd)
-        Money.zero
-      }.to_not raise_error
-    end
-
     it "instantiates a subclass when inheritance is used" do
       special_money_class = Class.new(Money)
       expect(special_money_class.empty).to be_a special_money_class


### PR DESCRIPTION
Memoization of #empty can cause issues because the `default_bank` is used when initializing a Money object. In case it will get changed after `#empty` got memoized — the memoized result will no longer reflect the latest state:

```ruby
Money.zero.bank == Money.default_bank # => true
Money.default_bank = Money::Bank::VariableExchange.new
Money.zero.bank == Money.default_bank # => false
```

The performance implications of this in the real world might not be as dramatic and I would rather avoid dealing with cache invalidation if possible.

Fixes #779 