### PR TITLE
Add :format option for Formatter

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -179,7 +179,7 @@ class Money
   #   fee = Money.rounding_mode(BigDecimal::ROUND_HALF_UP) do
   #     Money.new(1200) * BigDecimal('0.029')
   #   end
-  def self.rounding_mode(mode=nil)
+  def self.rounding_mode(mode = nil)
     if mode.nil?
       Thread.current[:money_rounding_mode] || @rounding_mode
     else

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -234,7 +234,11 @@ class Money
         if decimal_part.nil?
           html_wrap(whole_part, "whole")
         else
-          [html_wrap(whole_part, "whole"), html_wrap(decimal_mark, "decimal-mark"), html_wrap(decimal_part, "decimal")].join
+          [
+            html_wrap(whole_part, "whole"),
+            html_wrap(decimal_mark, "decimal-mark"),
+            html_wrap(decimal_part, "decimal")
+          ].join
         end
       else
         [whole_part, decimal_part].compact.join(decimal_mark)
@@ -322,15 +326,8 @@ class Money
     end
 
     def format_whole_part(value)
-      # Determine thousands_separator
-      thousands_separator_value = if rules.has_key?(:thousands_separator)
-                                    rules[:thousands_separator] || ''
-                                  else
-                                    thousands_separator
-                                  end
-
       # Apply thousands_separator
-      value.gsub regexp_format, "\\1#{thousands_separator_value}"
+      value.gsub regexp_format, "\\1#{thousands_separator}"
     end
 
     def extract_whole_and_decimal_parts

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -661,6 +661,42 @@ describe Money, "formatting" do
       end
     end
 
+    describe ':format option' do
+      let(:money) { Money.new(99_99, 'USD') }
+
+      it 'uses provided format as a template' do
+        expect(money.format(format: '%n')).to eq('99.99')
+        expect(money.format(format: '%u')).to eq('$')
+        expect(money.format(format: '%u%n')).to eq('$99.99')
+        expect(money.format(format: '%n%u')).to eq('99.99$')
+        expect(money.format(format: '%u %n')).to eq('$ 99.99')
+        expect(money.format(format: 'Your balance is: %u%n')).to eq('Your balance is: $99.99')
+      end
+
+      it 'ignores :symbol_position in favour of format' do
+        expect(money.format(format: '%u%n', symbol_position: :after)).to eq('$99.99')
+        expect(money.format(format: '%n%u', symbol_position: :before)).to eq('99.99$')
+      end
+
+      it 'ignores :symbol_before_without_space in favour of format' do
+        expect(money.format(format: '%u %n', symbol_position: :before, symbol_before_without_space: true)).to eq('$ 99.99')
+        expect(money.format(format: '%u%n', symbol_position: :before, symbol_before_without_space: false)).to eq('$99.99')
+      end
+
+      it 'ignores :symbol_after_without_space in favour of format' do
+        expect(money.format(format: '%n %u', symbol_position: :after, symbol_after_without_space: true)).to eq('99.99 $')
+        expect(money.format(format: '%n%u', symbol_position: :after, symbol_after_without_space: false)).to eq('99.99$')
+      end
+
+      it 'works with sign' do
+        money = Money.new(-99_99, 'USD')
+
+        expect(money.format(format: '%n%u', sign_before_symbol: false)).to eq('-99.99$')
+        expect(money.format(format: '%u%n', sign_before_symbol: false)).to eq('$-99.99')
+        expect(money.format(format: '%u%n', sign_before_symbol: true)).to eq('-$99.99')
+      end
+    end
+
     context "when the monetary value is 0" do
       let(:money) { Money.us_dollar(0) }
 


### PR DESCRIPTION
This PR adds support for providing formatting template to the `.format` call. It works the same way as the `format` option in I18n.

`%u` will get replaced by the symbol (if present) and `%n` will get replaced by the number.

Related options (`:symbol_position`, `:symbol_before_without_space` and `:symbol_after_without_space`) work the before, however when `:format` is supplied these are ignored.