### PR TITLE
Add R18n locale backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,14 @@ If you wish to disable this feature and use defaults instead:
 Money.locale_backend = nil
 ```
 
+## R18n
+
+If you want to use thousands separator and decimal mark from `R18n`:
+
+```ruby
+Money.locale_backend = :r18n
+```
+
 ## Collection
 
 In case you're working with collections of `Money` instances, have a look at [money-collection](https://github.com/RubyMoney/money-collection)

--- a/lib/money/locale_backend/r18n.rb
+++ b/lib/money/locale_backend/r18n.rb
@@ -1,0 +1,22 @@
+require 'money/locale_backend/base'
+
+class Money
+  module LocaleBackend
+    # Locale backend for R18n
+    # https://github.com/ai/r18n
+    class R18n < Base
+      KEY_MAP = {
+        thousands_separator: :number_group,
+        decimal_mark: :number_decimal
+      }.freeze
+
+      def initialize
+        raise NotSupported, 'R18n not found' unless defined?(::R18n)
+      end
+
+      def lookup(key, _currency)
+        ::R18n.get.locale.public_send KEY_MAP[key]
+      end
+    end
+  end
+end

--- a/lib/money/money/locale_backend.rb
+++ b/lib/money/money/locale_backend.rb
@@ -3,12 +3,14 @@
 require 'money/locale_backend/errors'
 require 'money/locale_backend/legacy'
 require 'money/locale_backend/i18n'
+require 'money/locale_backend/r18n'
 
 class Money
   module LocaleBackend
     BACKENDS = {
       legacy: Money::LocaleBackend::Legacy,
-      i18n: Money::LocaleBackend::I18n
+      i18n: Money::LocaleBackend::I18n,
+      r18n: Money::LocaleBackend::R18n
     }.freeze
 
     def self.find(name)

--- a/money.gemspec
+++ b/money.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'i18n', [">= 0.6.4", '<= 2']
 
   s.add_development_dependency "bundler", "~> 1.3"
+  s.add_development_dependency "r18n-core", "~> 3.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.4"
   s.add_development_dependency "yard", "~> 0.9.11"

--- a/spec/locale_backend/r18n_spec.rb
+++ b/spec/locale_backend/r18n_spec.rb
@@ -1,0 +1,60 @@
+# encoding: utf-8
+
+describe Money::LocaleBackend::R18n do
+  describe '#initialize' do
+    it 'raises an error when R18n is not defined' do
+      hide_const('R18n')
+
+      expect { described_class.new }.to raise_error(Money::LocaleBackend::NotSupported)
+    end
+  end
+
+  describe '#lookup' do
+    before do
+      R18n.default_loader = Class.new do
+        def available
+          %i[de].map { |locale| R18n.locale locale }
+        end
+
+        def load(_locale)
+          {}
+        end
+      end
+    end
+
+    after do
+      R18n.reset!
+      R18n.set :en
+    end
+
+    subject { described_class.new }
+
+    context 'with available locale' do
+      before do
+        R18n.set :de
+      end
+
+      it 'returns thousands_separator based on the current locale' do
+        expect(subject.lookup(:thousands_separator, nil)).to eq('.')
+      end
+
+      it 'returns decimal_mark based on the current locale' do
+        expect(subject.lookup(:decimal_mark, nil)).to eq(',')
+      end
+    end
+
+    context 'with unavailable locale' do
+      before do
+        R18n.set :unavailable
+      end
+
+      it 'returns thousands_separator based on the current locale' do
+        expect(subject.lookup(:thousands_separator, nil)).to eq(',')
+      end
+
+      it 'returns decimal_mark based on the current locale' do
+        expect(subject.lookup(:decimal_mark, nil)).to eq('.')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ $LOAD_PATH.unshift File.dirname(__FILE__)
 require "rspec"
 require "money"
 
+require "r18n-core"
+
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
 I18n.enforce_available_locales = false


### PR DESCRIPTION
https://github.com/ai/r18n

Replace `Money.use_i18n` [Boolean] with `Money.i18n_backend` [Symbol]

Drop Ruby 1.9 support