### PR TITLE
Add locale_backend abstraction for translation lookups

### DIFF
--- a/lib/money/locale_backend/base.rb
+++ b/lib/money/locale_backend/base.rb
@@ -1,0 +1,7 @@
+require 'money/locale_backend/errors'
+
+class Money
+  module LocaleBackend
+    class Base; end
+  end
+end

--- a/lib/money/locale_backend/errors.rb
+++ b/lib/money/locale_backend/errors.rb
@@ -1,0 +1,6 @@
+class Money
+  module LocaleBackend
+    class NotSupported < StandardError; end
+    class Unknown < ArgumentError; end
+  end
+end

--- a/lib/money/locale_backend/i18n.rb
+++ b/lib/money/locale_backend/i18n.rb
@@ -1,0 +1,24 @@
+require 'money/locale_backend/base'
+
+class Money
+  module LocaleBackend
+    class I18n < Base
+      KEY_MAP = {
+        thousands_separator: :delimiter,
+        decimal_mark: :separator
+      }.freeze
+
+      def initialize
+        raise NotSupported, 'I18n not found' unless defined?(::I18n)
+      end
+
+      def lookup(key, _)
+        i18n_key = KEY_MAP[key]
+
+        ::I18n.t i18n_key, scope: 'number.currency.format', raise: true
+      rescue ::I18n::MissingTranslationData
+        ::I18n.t i18n_key, scope: 'number.format', default: nil
+      end
+    end
+  end
+end

--- a/lib/money/locale_backend/legacy.rb
+++ b/lib/money/locale_backend/legacy.rb
@@ -1,0 +1,26 @@
+require 'money/locale_backend/base'
+require 'money/locale_backend/i18n'
+
+class Money
+  module LocaleBackend
+    class Legacy < Base
+      def initialize
+        raise NotSupported, 'I18n not found' if Money.use_i18n && !defined?(::I18n)
+      end
+
+      def lookup(key, currency)
+        if Money.use_i18n
+          i18n_backend.lookup(key, nil) || currency.public_send(key)
+        else
+          currency.public_send(key)
+        end
+      end
+
+      private
+
+      def i18n_backend
+        @i18n_backend ||= Money::LocaleBackend::I18n.new
+      end
+    end
+  end
+end

--- a/lib/money/locale_backend/legacy.rb
+++ b/lib/money/locale_backend/legacy.rb
@@ -10,6 +10,8 @@ class Money
 
       def lookup(key, currency)
         if Money.use_i18n
+          warn '[DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :i18n` instead'
+
           i18n_backend.lookup(key, nil) || currency.public_send(key)
         else
           currency.public_send(key)

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -5,6 +5,7 @@ require "money/money/arithmetic"
 require "money/money/constructors"
 require "money/money/formatter"
 require "money/money/allocation"
+require "money/money/locale_backend"
 
 # "Money is any object or record that is generally accepted as payment for
 # goods and services and repayment of debts in a given socio-economic context
@@ -120,7 +121,8 @@ class Money
     #   @return [Integer] Use this to specify precision for converting Rational
     #     to BigDecimal
     attr_accessor :default_bank, :default_formatting_rules,
-      :use_i18n, :infinite_precision, :conversion_precision
+      :use_i18n, :infinite_precision, :conversion_precision,
+      :locale_backend
 
     # @attr_writer rounding_mode Use this to specify the rounding mode
     #
@@ -141,6 +143,10 @@ class Money
     end
   end
 
+  def self.locale_backend=(value)
+    @locale_backend = LocaleBackend.find(value)
+  end
+
   def self.setup_defaults
     # Set the default bank for creating new +Money+ objects.
     self.default_bank = Bank::VariableExchange.instance
@@ -150,6 +156,9 @@ class Money
 
     # Default to using i18n
     self.use_i18n = true
+
+    # Default to using legacy locale backend
+    self.locale_backend = :legacy
 
     # Default to not using infinite precision cents
     self.infinite_precision = false
@@ -540,7 +549,7 @@ class Money
   # @return [String]
   #
   def thousands_separator
-    Money::Formatter.new(self, {}).thousands_separator
+    self.class.locale_backend.lookup(:thousands_separator, currency)
   end
 
   # Returns a decimal mark according to the locale
@@ -548,7 +557,7 @@ class Money
   # @return [String]
   #
   def decimal_mark
-    Money::Formatter.new(self, {}).decimal_mark
+    self.class.locale_backend.lookup(:decimal_mark, currency)
   end
 
   private

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -147,6 +147,14 @@ class Money
     @locale_backend = value ? LocaleBackend.find(value) : nil
   end
 
+  def self.use_i18n=(value)
+    if value
+      warn '[DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :i18n` instead'
+    end
+
+    @use_i18n = value
+  end
+
   def self.setup_defaults
     # Set the default bank for creating new +Money+ objects.
     self.default_bank = Bank::VariableExchange.instance
@@ -155,7 +163,7 @@ class Money
     self.default_currency = Currency.new("USD")
 
     # Default to using i18n
-    self.use_i18n = true
+    @use_i18n = true
 
     # Default to using legacy locale backend
     self.locale_backend = :legacy

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -144,7 +144,7 @@ class Money
   end
 
   def self.locale_backend=(value)
-    @locale_backend = LocaleBackend.find(value)
+    @locale_backend = value ? LocaleBackend.find(value) : nil
   end
 
   def self.setup_defaults
@@ -549,7 +549,8 @@ class Money
   # @return [String]
   #
   def thousands_separator
-    self.class.locale_backend.lookup(:thousands_separator, currency)
+    (locale_backend && locale_backend.lookup(:thousands_separator, currency)) ||
+      Money::Formatter::DEFAULTS[:thousands_separator]
   end
 
   # Returns a decimal mark according to the locale
@@ -557,7 +558,8 @@ class Money
   # @return [String]
   #
   def decimal_mark
-    self.class.locale_backend.lookup(:decimal_mark, currency)
+    (locale_backend && locale_backend.lookup(:decimal_mark, currency)) ||
+      Money::Formatter::DEFAULTS[:decimal_mark]
   end
 
   private
@@ -576,5 +578,9 @@ class Money
     else
       value.round(0, self.class.rounding_mode).to_i
     end
+  end
+
+  def locale_backend
+    self.class.locale_backend
   end
 end

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -293,25 +293,22 @@ class Money
     end
 
     def thousands_separator
-      if rules.has_key?(:thousands_separator)
-        rules[:thousands_separator] || ''
-      else
-        i18n_format_for(:thousands_separator, :delimiter, ',')
-      end
+      lookup :thousands_separator
     end
 
     def decimal_mark
-      if rules.has_key?(:decimal_mark)
-        rules[:decimal_mark] || '.'
-      else
-        i18n_format_for(:decimal_mark, :separator, '.')
-      end
+      lookup :decimal_mark
     end
 
     alias_method :delimiter, :thousands_separator
     alias_method :separator, :decimal_mark
 
     private
+
+    DEFAULTS = {
+      thousands_separator: '',
+      decimal_mark: '.'
+    }.freeze
 
     attr_reader :money, :currency, :rules
 
@@ -359,16 +356,10 @@ class Money
       value.empty? ? nil : value
     end
 
-    def i18n_format_for(method, name, character)
-      if Money.use_i18n
-        begin
-          I18n.t name, scope: "number.currency.format", raise: true
-        rescue I18n::MissingTranslationData
-          I18n.t name, scope: "number.format", default: (currency.send(method) || character)
-        end
-      else
-        currency.send(method) || character
-      end
+    def lookup(key)
+      return rules[key] || DEFAULTS[key] if rules.has_key?(key)
+
+      (Money.locale_backend && Money.locale_backend.lookup(key, currency)) || DEFAULTS[key]
     end
 
     def regexp_format

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -3,6 +3,11 @@ require 'money/money/formatting_rules'
 
 class Money
   class Formatter
+    DEFAULTS = {
+      thousands_separator: '',
+      decimal_mark: '.'
+    }.freeze
+
     # Creates a formatted price string according to several rules.
     #
     # @param [Hash] rules The options used to format the string.
@@ -304,11 +309,6 @@ class Money
     alias_method :separator, :decimal_mark
 
     private
-
-    DEFAULTS = {
-      thousands_separator: '',
-      decimal_mark: '.'
-    }.freeze
 
     attr_reader :money, :currency, :rules
 

--- a/lib/money/money/locale_backend.rb
+++ b/lib/money/money/locale_backend.rb
@@ -1,0 +1,20 @@
+# encoding: UTF-8
+
+require 'money/locale_backend/errors'
+require 'money/locale_backend/legacy'
+require 'money/locale_backend/i18n'
+
+class Money
+  module LocaleBackend
+    BACKENDS = {
+      legacy: Money::LocaleBackend::Legacy,
+      i18n: Money::LocaleBackend::I18n
+    }.freeze
+
+    def self.find(name)
+      raise Unknown, "Unknown locale backend: #{name}" unless BACKENDS.key?(name)
+
+      BACKENDS[name].new
+    end
+  end
+end

--- a/spec/locale_backend/i18n_spec.rb
+++ b/spec/locale_backend/i18n_spec.rb
@@ -1,0 +1,62 @@
+# encoding: utf-8
+
+describe Money::LocaleBackend::I18n do
+  describe '#initialize' do
+    it 'raises an error when I18n is not defined' do
+      hide_const('I18n')
+
+      expect { described_class.new }.to raise_error(Money::LocaleBackend::NotSupported)
+    end
+  end
+
+  describe '#lookup' do
+    after do
+      reset_i18n
+      I18n.locale = :en
+    end
+
+    subject { described_class.new }
+
+    context 'with number.currency.format defined' do
+      before do
+        I18n.locale = :de
+        I18n.backend.store_translations(:de, number: {
+          currency: { format: { delimiter: '.', separator: ',' } }
+        })
+      end
+
+      it 'returns thousands_separator based on the current locale' do
+        expect(subject.lookup(:thousands_separator, nil)).to eq('.')
+      end
+
+      it 'returns decimal_mark based on the current locale' do
+        expect(subject.lookup(:decimal_mark, nil)).to eq(',')
+      end
+    end
+
+    context 'with number.format defined' do
+      before do
+        I18n.locale = :de
+        I18n.backend.store_translations(:de, number: { format: { delimiter: '.', separator: ',' } })
+      end
+
+      it 'returns thousands_separator based on the current locale' do
+        expect(subject.lookup(:thousands_separator, nil)).to eq('.')
+      end
+
+      it 'returns decimal_mark based on the current locale' do
+        expect(subject.lookup(:decimal_mark, nil)).to eq(',')
+      end
+    end
+
+    context 'with no translation defined' do
+      it 'returns thousands_separator based on the current locale' do
+        expect(subject.lookup(:thousands_separator, nil)).to eq(nil)
+      end
+
+      it 'returns decimal_mark based on the current locale' do
+        expect(subject.lookup(:decimal_mark, nil)).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/locale_backend/legacy_spec.rb
+++ b/spec/locale_backend/legacy_spec.rb
@@ -1,0 +1,74 @@
+# encoding: utf-8
+
+describe Money::LocaleBackend::Legacy do
+  after { Money.use_i18n = true }
+
+  describe '#initialize' do
+    it 'raises an error when use_i18n is true and I18n is not defined' do
+      Money.use_i18n = true
+      hide_const('I18n')
+
+      expect { described_class.new }.to raise_error(Money::LocaleBackend::NotSupported)
+    end
+
+    it 'does not raise error when use_i18n is false and I18n is not defined' do
+      Money.use_i18n = false
+      hide_const('I18n')
+
+      expect { described_class.new }.not_to raise_error
+    end
+  end
+
+  describe '#lookup' do
+    subject { described_class.new }
+    let(:currency) { Money::Currency.new('USD') }
+
+    context 'use_i18n is true and i18n lookup is successful' do
+      before do
+        allow(subject.send(:i18n_backend))
+          .to receive(:lookup)
+          .with(:thousands_separator, nil)
+          .and_return('.')
+
+        allow(subject.send(:i18n_backend))
+          .to receive(:lookup)
+          .with(:decimal_mark, nil)
+          .and_return(',')
+      end
+
+      it 'returns thousands_separator from I18n' do
+        expect(subject.lookup(:thousands_separator, currency)).to eq('.')
+      end
+
+      it 'returns decimal_mark based from I18n' do
+        expect(subject.lookup(:decimal_mark, currency)).to eq(',')
+      end
+    end
+
+    context 'use_i18n is true but i18n lookup is unsuccessful' do
+      before do
+        allow(subject.send(:i18n_backend)).to receive(:lookup).and_return(nil)
+      end
+
+      it 'returns thousands_separator as defined in currency' do
+        expect(subject.lookup(:thousands_separator, currency)).to eq(',')
+      end
+
+      it 'returns decimal_mark based as defined in currency' do
+        expect(subject.lookup(:decimal_mark, currency)).to eq('.')
+      end
+    end
+
+    context 'use_i18n is false' do
+      before { Money.use_i18n = false }
+
+      it 'returns thousands_separator as defined in currency' do
+        expect(subject.lookup(:thousands_separator, currency)).to eq(',')
+      end
+
+      it 'returns decimal_mark based as defined in currency' do
+        expect(subject.lookup(:decimal_mark, currency)).to eq('.')
+      end
+    end
+  end
+end

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -18,6 +18,19 @@ describe Money, "formatting" do
     end
   end
 
+  context 'without locale_backend' do
+    before { Money.locale_backend = nil }
+    after { Money.locale_backend = :legacy }
+
+    subject(:money) { Money.new(1099_99, 'USD') }
+
+    it 'falls back to using defaults' do
+      expect(money.thousands_separator).to eq('')
+      expect(money.decimal_mark).to eq('.')
+      expect(money.format).to eq('$1099.99')
+    end
+  end
+
   context "with i18n but use_i18n = false" do
     before :each do
       reset_i18n

--- a/spec/money/locale_backend_spec.rb
+++ b/spec/money/locale_backend_spec.rb
@@ -1,0 +1,14 @@
+# encoding: utf-8
+
+describe Money::LocaleBackend do
+  describe '.find' do
+    it 'returns an initialized backend' do
+      expect(described_class.find(:legacy)).to be_a(Money::LocaleBackend::Legacy)
+      expect(described_class.find(:i18n)).to be_a(Money::LocaleBackend::I18n)
+    end
+
+    it 'raises an error if a backend is unknown' do
+      expect { described_class.find(:foo) }.to raise_error(Money::LocaleBackend::Unknown)
+    end
+  end
+end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -1,6 +1,22 @@
 # encoding: utf-8
 
 describe Money do
+  describe '.locale_backend' do
+    after { Money.locale_backend = :legacy }
+
+    it 'sets the locale_backend' do
+      Money.locale_backend = :i18n
+
+      expect(Money.locale_backend).to be_a(Money::LocaleBackend::I18n)
+    end
+
+    it 'sets the locale_backend to nil' do
+      Money.locale_backend = nil
+
+      expect(Money.locale_backend).to eq(nil)
+    end
+  end
+
   describe ".new" do
     let(:initializing_value) { 1 }
     subject(:money) { Money.new(initializing_value) }


### PR DESCRIPTION
As identified many times before per-currency localisation is very misleading because money in the same currency should be formatted differently in different countries (the opposite is also true — amounts in different currencies should be formatted similarly in the same country).

This PR introduces a `LocaleBackend` abstraction that will be used for looking up translations. In order to retain the current behaviour a `Legacy` backend is added, however it will get deprecated soon along with the `use_i18n` flag.

You can choose not to use a locale backend, which will then fall back to using default values (`thousands_separator: '', decimal_mark: '.'`). This will be the default option in the future, breaking up the `i18n` dependency.

Rules submitted to `.format` call will always take priority, falling back to locale_backend and then the defaults in case a translation could not be looked up or a `locale_backend` in not defined.

This should also allow for creating you own `LocaleBackend`s.