### PR TITLE
Support i18n 1.1

### DIFF
--- a/money.gemspec
+++ b/money.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = "A Ruby Library for dealing with money and currency conversion."
   s.license     = "MIT"
 
-  s.add_dependency 'i18n', [">= 0.6.4", '< 1.1']
+  s.add_dependency 'i18n', [">= 0.6.4", '<= 1.1']
 
   s.add_development_dependency "bundler", "~> 1.3"
   s.add_development_dependency "rake"


### PR DESCRIPTION
i18n version 1.1 was released a couple of days ago. The tests ran without failures with this new release, so adjusted the version requirement.