### PR TITLE
Deprecate bolívar fuerte and add bolívar soberano

### DIFF
--- a/config/currency_backwards_compatible.json
+++ b/config/currency_backwards_compatible.json
@@ -90,6 +90,21 @@
     "iso_numeric": "795",
     "smallest_denomination": 1
   },
+  "vef": {
+    "priority": 100,
+    "iso_code": "VEF",
+    "name": "Venezuelan Bolívar",
+    "symbol": "Bs",
+    "alternate_symbols": ["Bs.F"],
+    "subunit": "Céntimo",
+    "subunit_to_unit": 100,
+    "symbol_first": true,
+    "html_entity": "",
+    "decimal_mark": ",",
+    "thousands_separator": ".",
+    "iso_numeric": "937",
+    "smallest_denomination": 1
+  },
   "yen": {
     "priority": 100,
     "iso_code": "JPY",

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -2271,19 +2271,19 @@
     "iso_numeric": "860",
     "smallest_denomination": 100
   },
-  "vef": {
+  "ves": {
     "priority": 100,
-    "iso_code": "VEF",
-    "name": "Venezuelan Bolívar",
+    "iso_code": "VES",
+    "name": "Venezuelan Bolívar Soberano",
     "symbol": "Bs",
-    "alternate_symbols": ["Bs.F"],
+    "alternate_symbols": ["Bs.S"],
     "subunit": "Céntimo",
     "subunit_to_unit": 100,
     "symbol_first": true,
     "html_entity": "",
     "decimal_mark": ",",
     "thousands_separator": ".",
-    "iso_numeric": "937",
+    "iso_numeric": "928",
     "smallest_denomination": 1
   },
   "vnd": {


### PR DESCRIPTION
As of August 20, 2018, the official currency of Venezuela is VES (the bolívar soberano), replacing VEF (bolívar fuerte). This PR adds VES to the list of supported currencies and adds VEF to the backwards compatible currencies.