### PR TITLE
Improve versions-lock of `i18n` and `rspec` dependencies

### DIFF
--- a/money.gemspec
+++ b/money.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |s|
   s.description = "A Ruby Library for dealing with money and currency conversion."
   s.license     = "MIT"
 
-  s.add_dependency 'i18n', [">= 0.6.4", '<= 1.1']
+  s.add_dependency 'i18n', [">= 0.6.4", '<= 2']
 
   s.add_development_dependency "bundler", "~> 1.3"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec", "~> 3.4.0"
+  s.add_development_dependency "rspec", "~> 3.4"
   s.add_development_dependency "yard", "~> 0.9.11"
   s.add_development_dependency "kramdown", "~> 1.1"
 


### PR DESCRIPTION
I see no reason for locking at patch version and non-semver.