### PR TITLE
Make an alias for configure to tap

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -132,6 +132,7 @@ class Money
     #     default value is Currency.new("USD"). The value must be a valid
     #     +Money::Currency+ instance.
     attr_writer :rounding_mode, :default_currency
+    alias configure tap
 
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -877,4 +877,19 @@ YAML
       expect(Money.default_currency).to eq Money::Currency.new(:eur)
     end
   end
+
+  describe "#configure" do
+    after(:all) do
+      Money.setup_defaults
+    end
+    it "makes configurations in a block" do
+      expect do
+        Money.configure do |config|
+          config.default_currency = Money::Currency.new(:eur)
+          config.default_bank = Money::Bank::VariableExchange.instance
+          config.disallow_currency_conversion!
+        end
+      end.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
This is a quick fix idea  for the issue #806 and a test just to document the way it could be used. Just making an `alias` it would be possible to configure in block.