### PR TITLE
Remove use_i18n option

### DIFF
--- a/lib/money/locale_backend/legacy.rb
+++ b/lib/money/locale_backend/legacy.rb
@@ -1,27 +1,10 @@
 require 'money/locale_backend/base'
-require 'money/locale_backend/i18n'
 
 class Money
   module LocaleBackend
     class Legacy < Base
-      def initialize
-        raise NotSupported, 'I18n not found' if Money.use_i18n && !defined?(::I18n)
-      end
-
       def lookup(key, currency)
-        if Money.use_i18n
-          warn '[DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :i18n` instead'
-
-          i18n_backend.lookup(key, nil) || currency.public_send(key)
-        else
-          currency.public_send(key)
-        end
-      end
-
-      private
-
-      def i18n_backend
-        @i18n_backend ||= Money::LocaleBackend::I18n.new
+        currency.public_send(key)
       end
     end
   end

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -110,10 +110,6 @@ class Money
     #     Money.new(0, "USD").format                          # => "free"
     #     Money.new(0, "USD").format(display_free: false)  # => "$0.00"
     #
-    # @!attribute [rw] use_i18n
-    #   @return [Boolean] Use this to disable i18n even if it's used by other
-    #     objects in your app.
-    #
     # @!attribute [rw] infinite_precision
     #   @return [Boolean] Use this to enable infinite precision cents
     #
@@ -121,8 +117,7 @@ class Money
     #   @return [Integer] Use this to specify precision for converting Rational
     #     to BigDecimal
     attr_accessor :default_bank, :default_formatting_rules,
-      :use_i18n, :infinite_precision, :conversion_precision,
-      :locale_backend
+      :infinite_precision, :conversion_precision, :locale_backend
 
     # @attr_writer rounding_mode Use this to specify the rounding mode
     #
@@ -147,23 +142,12 @@ class Money
     @locale_backend = value ? LocaleBackend.find(value) : nil
   end
 
-  def self.use_i18n=(value)
-    if value
-      warn '[DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :i18n` instead'
-    end
-
-    @use_i18n = value
-  end
-
   def self.setup_defaults
     # Set the default bank for creating new +Money+ objects.
     self.default_bank = Bank::VariableExchange.instance
 
     # Set the default currency for creating new +Money+ object.
     self.default_currency = Currency.new("USD")
-
-    # Default to using i18n
-    @use_i18n = true
 
     # Default to using legacy locale backend
     self.locale_backend = :legacy

--- a/spec/locale_backend/i18n_spec.rb
+++ b/spec/locale_backend/i18n_spec.rb
@@ -9,12 +9,7 @@ describe Money::LocaleBackend::I18n do
     end
   end
 
-  describe '#lookup' do
-    after do
-      reset_i18n
-      I18n.locale = :en
-    end
-
+  describe '#lookup', :i18n do
     subject { described_class.new }
 
     context 'with number.currency.format defined' do

--- a/spec/locale_backend/legacy_spec.rb
+++ b/spec/locale_backend/legacy_spec.rb
@@ -1,74 +1,16 @@
 # encoding: utf-8
 
 describe Money::LocaleBackend::Legacy do
-  after { Money.use_i18n = true }
-
-  describe '#initialize' do
-    it 'raises an error when use_i18n is true and I18n is not defined' do
-      Money.use_i18n = true
-      hide_const('I18n')
-
-      expect { described_class.new }.to raise_error(Money::LocaleBackend::NotSupported)
-    end
-
-    it 'does not raise error when use_i18n is false and I18n is not defined' do
-      Money.use_i18n = false
-      hide_const('I18n')
-
-      expect { described_class.new }.not_to raise_error
-    end
-  end
-
   describe '#lookup' do
     subject { described_class.new }
     let(:currency) { Money::Currency.new('USD') }
 
-    context 'use_i18n is true and i18n lookup is successful' do
-      before do
-        allow(subject.send(:i18n_backend))
-          .to receive(:lookup)
-          .with(:thousands_separator, nil)
-          .and_return('.')
-
-        allow(subject.send(:i18n_backend))
-          .to receive(:lookup)
-          .with(:decimal_mark, nil)
-          .and_return(',')
-      end
-
-      it 'returns thousands_separator from I18n' do
-        expect(subject.lookup(:thousands_separator, currency)).to eq('.')
-      end
-
-      it 'returns decimal_mark based from I18n' do
-        expect(subject.lookup(:decimal_mark, currency)).to eq(',')
-      end
+    it 'returns thousands_separator as defined in currency' do
+      expect(subject.lookup(:thousands_separator, currency)).to eq(',')
     end
 
-    context 'use_i18n is true but i18n lookup is unsuccessful' do
-      before do
-        allow(subject.send(:i18n_backend)).to receive(:lookup).and_return(nil)
-      end
-
-      it 'returns thousands_separator as defined in currency' do
-        expect(subject.lookup(:thousands_separator, currency)).to eq(',')
-      end
-
-      it 'returns decimal_mark based as defined in currency' do
-        expect(subject.lookup(:decimal_mark, currency)).to eq('.')
-      end
-    end
-
-    context 'use_i18n is false' do
-      before { Money.use_i18n = false }
-
-      it 'returns thousands_separator as defined in currency' do
-        expect(subject.lookup(:thousands_separator, currency)).to eq(',')
-      end
-
-      it 'returns decimal_mark based as defined in currency' do
-        expect(subject.lookup(:decimal_mark, currency)).to eq('.')
-      end
+    it 'returns decimal_mark based as defined in currency' do
+      expect(subject.lookup(:decimal_mark, currency)).to eq('.')
     end
   end
 end

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -31,48 +31,11 @@ describe Money, "formatting" do
     end
   end
 
-  context "with i18n but use_i18n = false" do
-    before :each do
-      reset_i18n
-      I18n.locale = :de
-      I18n.backend.store_translations(
-          :de,
-          number: { currency: { format: { delimiter: ".", separator: "," } } }
-      )
-      Money.use_i18n = false
-    end
-
-    after :each do
-      reset_i18n
-      I18n.locale = :en
-      Money.use_i18n = true
-    end
-
-    subject(:money) { Money.empty("USD") }
-
-    it "should use ',' as the thousands separator" do
-      expect(money.thousands_separator).to eq ','
-    end
-
-    it "should use '.' as the decimal mark" do
-      expect(money.decimal_mark).to eq '.'
-    end
-  end
-
-  context "with i18n" do
-    after :each do
-      reset_i18n
-      I18n.locale = :en
-    end
-
+  context "with i18n", :i18n do
     context "with number.format.*" do
-      before :each do
-        reset_i18n
+      before do
         I18n.locale = :de
-        I18n.backend.store_translations(
-            :de,
-            number: { format: { delimiter: ".", separator: "," } }
-        )
+        I18n.backend.store_translations(:de, number: { format: { delimiter: ".", separator: "," } })
       end
 
       subject(:money) { Money.empty("USD") }
@@ -87,13 +50,9 @@ describe Money, "formatting" do
     end
 
     context "with number.currency.format.*" do
-      before :each do
-        reset_i18n
+      before do
         I18n.locale = :de
-        I18n.backend.store_translations(
-            :de,
-            number: { currency: { format: { delimiter: ".", separator: "," } } }
-        )
+        I18n.backend.store_translations(:de, number: { currency: { format: { delimiter: ".", separator: "," } } })
       end
 
       subject(:money) { Money.empty("USD") }
@@ -107,14 +66,10 @@ describe Money, "formatting" do
       end
     end
 
-    context "with number.currency.symbol.*" do
-      before :each do
-        reset_i18n
+    context "with number.currency.symbol.*", :i18n do
+      before do
         I18n.locale = :de
-        I18n.backend.store_translations(
-            :de,
-            number: { currency: { symbol: { CAD: "CAD$" } } }
-        )
+        I18n.backend.store_translations(:de, number: { currency: { symbol: { CAD: "CAD$" } } })
       end
 
       subject(:money) { Money.empty("CAD") }
@@ -527,18 +482,12 @@ describe Money, "formatting" do
         expect(Money.new(100000, "ZWD").format).to eq "$1,000.00"
       end
 
-      context "without i18n" do
-        before { Money.use_i18n = false }
+      it "should respect explicit overriding of thousands_separator/delimiter when decimal_mark/separator collide and there’s no decimal component for currencies that have no subunit" do
+        expect(Money.new(300_000, 'ISK').format(thousands_separator: ",", decimal_mark: '.')).to eq "kr300,000"
+      end
 
-        it "should respect explicit overriding of thousands_separator/delimiter when decimal_mark/separator collide and there’s no decimal component for currencies that have no subunit" do
-          expect(Money.new(300_000, 'ISK').format(thousands_separator: ",", decimal_mark: '.')).to eq "kr300,000"
-        end
-
-        it "should respect explicit overriding of thousands_separator/delimiter when decimal_mark/separator collide and there’s no decimal component for currencies with subunits that drop_trailing_zeros" do
-          expect(Money.new(300_000, 'USD').format(thousands_separator: ".", decimal_mark: ',', drop_trailing_zeros: true)).to eq "$3.000"
-        end
-
-        after { Money.use_i18n = true}
+      it "should respect explicit overriding of thousands_separator/delimiter when decimal_mark/separator collide and there’s no decimal component for currencies with subunits that drop_trailing_zeros" do
+        expect(Money.new(300_000, 'USD').format(thousands_separator: ".", decimal_mark: ',', drop_trailing_zeros: true)).to eq "$3.000"
       end
     end
 
@@ -614,6 +563,13 @@ describe Money, "formatting" do
         expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: true)).to eq "$1.00"
         expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: true)).to eq "$1.10"
         expect(Money.new(BigDecimal('1.7'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar0.4"
+
+        expect(Money.new(BigDecimal('12.1'), "EUR").format(rounded_infinite_precision: true)).to eq "€0,12"
+        expect(Money.new(BigDecimal('12.5'), "EUR").format(rounded_infinite_precision: true)).to eq "€0,13"
+        expect(Money.new(BigDecimal('100.1'), "EUR").format(rounded_infinite_precision: true)).to eq "€1,00"
+        expect(Money.new(BigDecimal('109.5'), "EUR").format(rounded_infinite_precision: true)).to eq "€1,10"
+        expect(Money.new(BigDecimal('100012.1'), "EUR").format(rounded_infinite_precision: true)).to eq "€1.000,12"
+        expect(Money.new(BigDecimal('100012.5'), "EUR").format(rounded_infinite_precision: true)).to eq "€1.000,13"
       end
 
       it "does not round fractional when set to false" do
@@ -626,40 +582,10 @@ describe Money, "formatting" do
         expect(Money.new(BigDecimal('1.7'), "MGA").format(rounded_infinite_precision: false)).to eq "Ar0.34"
       end
 
-      describe "with i18n = false" do
+      describe "with i18n = true", :i18n do
         before do
-          Money.use_i18n = false
-        end
-
-        after do
-          Money.use_i18n = true
-        end
-
-        it 'does round fractional when set to true' do
-          expect(Money.new(BigDecimal('12.1'), "EUR").format(rounded_infinite_precision: true)).to eq "€0,12"
-          expect(Money.new(BigDecimal('12.5'), "EUR").format(rounded_infinite_precision: true)).to eq "€0,13"
-          expect(Money.new(BigDecimal('100.1'), "EUR").format(rounded_infinite_precision: true)).to eq "€1,00"
-          expect(Money.new(BigDecimal('109.5'), "EUR").format(rounded_infinite_precision: true)).to eq "€1,10"
-
-          expect(Money.new(BigDecimal('100012.1'), "EUR").format(rounded_infinite_precision: true)).to eq "€1.000,12"
-          expect(Money.new(BigDecimal('100012.5'), "EUR").format(rounded_infinite_precision: true)).to eq "€1.000,13"
-        end
-      end
-
-      describe "with i18n = true" do
-        before do
-          Money.use_i18n = true
-          reset_i18n
           I18n.locale = :de
-          I18n.backend.store_translations(
-              :de,
-              number: { currency: { format: { delimiter: ".", separator: "," } } }
-          )
-        end
-
-        after do
-          reset_i18n
-          I18n.locale = :en
+          I18n.backend.store_translations(:de, number: { currency: { format: { delimiter: ".", separator: "," } } })
         end
 
         it 'does round fractional when set to true' do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -477,9 +477,8 @@ YAML
       expect(Money.new(10_00, "BRL").to_s).to eq "10,00"
     end
 
-    context "using i18n" do
+    context "using i18n", :i18n do
       before { I18n.backend.store_translations(:en, number: { format: { separator: "." } }) }
-      after { reset_i18n }
 
       it "respects decimal mark" do
         expect(Money.new(10_00, "BRL").to_s).to eq "10.00"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,16 +17,19 @@ RSpec.configure do |c|
   c.run_all_when_everything_filtered = true
 end
 
-def reset_i18n
-  I18n.backend = I18n::Backend::Simple.new
+RSpec.shared_context 'with i18n locale backend', :i18n do
+  around do |example|
+    Money.locale_backend = :i18n
+
+    example.run
+
+    Money.locale_backend = :legacy
+    I18n.backend = I18n::Backend::Simple.new
+    I18n.locale = :en
+  end
 end
 
-RSpec.shared_context "with infinite precision", :infinite_precision do
-  before do
-    Money.infinite_precision = true
-  end
-
-  after do
-    Money.infinite_precision = false
-  end
+RSpec.shared_context 'with infinite precision', :infinite_precision do
+  before { Money.infinite_precision = true }
+  after { Money.infinite_precision = false }
 end


### PR DESCRIPTION
This should now be fully replaced with `Money.locale_backend`