### PR TITLE
Add explicit "per currency" localisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,48 @@ If you wish to disable this feature and use defaults instead:
 Money.locale_backend = nil
 ```
 
+### Deprecation
+
+The current default behaviour always checks the I18n locale first, falling back to "per currency"
+localization. This is now deprecated and will be removed in favour of explicitly defined behaviour
+in the next major release.
+
+If you would like to use I18n localization (formatting depends on the locale):
+
+```ruby
+Money.locale_backend = :i18n
+
+# example (using default localization from rails-i18n):
+I18n.locale = :en
+Money.new(10_000_00, 'USD').format # => $10,000.00
+Money.new(10_000_00, 'EUR').format # => €10,000.00
+
+I18n.locale = :es
+Money.new(10_000_00, 'USD').format # => $10.000,00
+Money.new(10_000_00, 'EUR').format # => €10.000,00
+```
+
+For the legacy behaviour of "per currency" localization (formatting depends only on currency):
+
+```ruby
+Money.locale_backend = :currency
+
+# example:
+Money.new(10_000_00, 'USD').format # => $10,000.00
+Money.new(10_000_00, 'EUR').format # => €10.000,00
+```
+
+In case you don't need localization and would like to use default values (can be redefined using
+`Money.default_formatting_rules`):
+
+```ruby
+Money.locale_backend = nil
+
+# example:
+Money.new(10_000_00, 'USD').format # => $10000.00
+Money.new(10_000_00, 'EUR').format # => €10000.00
+```
+
 ## Collection
 
 In case you're working with collections of `Money` instances, have a look at [money-collection](https://github.com/RubyMoney/money-collection)

--- a/lib/money/locale_backend/currency.rb
+++ b/lib/money/locale_backend/currency.rb
@@ -1,0 +1,11 @@
+require 'money/locale_backend/base'
+
+class Money
+  module LocaleBackend
+    class Currency < Base
+      def lookup(key, currency)
+        currency.public_send(key) if currency.respond_to?(key)
+      end
+    end
+  end
+end

--- a/lib/money/locale_backend/legacy.rb
+++ b/lib/money/locale_backend/legacy.rb
@@ -9,9 +9,9 @@ class Money
       end
 
       def lookup(key, currency)
-        if Money.use_i18n
-          warn '[DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :i18n` instead'
+        warn '[DEPRECATION] You are using the default localization behaviour that will change in the next major release. Find out more - https://github.com/RubyMoney/money#deprecation'
 
+        if Money.use_i18n
           i18n_backend.lookup(key, nil) || currency.public_send(key)
         else
           currency.public_send(key)

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -149,7 +149,9 @@ class Money
 
   def self.use_i18n=(value)
     if value
-      warn '[DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :i18n` instead'
+      warn '[DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :i18n` instead for locale based formatting'
+    else
+      warn '[DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :currency` instead for currency based formatting'
     end
 
     @use_i18n = value

--- a/lib/money/money/locale_backend.rb
+++ b/lib/money/money/locale_backend.rb
@@ -3,12 +3,14 @@
 require 'money/locale_backend/errors'
 require 'money/locale_backend/legacy'
 require 'money/locale_backend/i18n'
+require 'money/locale_backend/currency'
 
 class Money
   module LocaleBackend
     BACKENDS = {
       legacy: Money::LocaleBackend::Legacy,
-      i18n: Money::LocaleBackend::I18n
+      i18n: Money::LocaleBackend::I18n,
+      currency: Money::LocaleBackend::Currency
     }.freeze
 
     def self.find(name)

--- a/spec/locale_backend/currency_spec.rb
+++ b/spec/locale_backend/currency_spec.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+
+describe Money::LocaleBackend::Currency do
+  describe '#lookup' do
+    let(:currency) { Money::Currency.new('EUR') }
+
+    it 'returns thousands_separator as defined in currency' do
+      expect(subject.lookup(:thousands_separator, currency)).to eq('.')
+    end
+
+    it 'returns decimal_mark based as defined in currency' do
+      expect(subject.lookup(:decimal_mark, currency)).to eq(',')
+    end
+  end
+end


### PR DESCRIPTION
This will allow to not rely on `use_i18n` at all, making the deprecation cleaner. It also makes the messaging clearer.

Fixes #816 