### PR TITLE
Deprecate old `format` rules

### DIFF
--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -38,14 +38,21 @@ class Money
         rules = {}
       elsif rules.size == 1
         rules = rules.pop
-        rules = { rules => true } if rules.is_a?(Symbol)
+
+        if rules.is_a?(Symbol)
+          warn '[DEPRECATION] Use Hash when passing rules to Money#format.'
+          rules = { rules => true }
+        end
       end
+
       if !rules.include?(:decimal_mark) && rules.include?(:separator)
         rules[:decimal_mark] = rules[:separator]
       end
+
       if !rules.include?(:thousands_separator) && rules.include?(:delimiter)
         rules[:thousands_separator] = rules[:delimiter]
       end
+
       rules
     end
 

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -136,6 +136,10 @@ describe Money, "formatting" do
   end
 
   describe "#format" do
+    it 'supports the old formatting options' do
+      expect(Money.zero.format(:display_free)).to eq('free')
+    end
+
     context "Locale :ja" do
       before { @_locale = I18n.locale; I18n.locale = :ja }
 


### PR DESCRIPTION
This is a very old behaviour that isn't used anyways