### PR TITLE
Deprecate bolívar fuerte and add bolívar soberano

### DIFF
--- a/config/currency_backwards_compatible.json
+++ b/config/currency_backwards_compatible.json
@@ -169,5 +169,20 @@
     "thousands_separator": ",",
     "iso_numeric": "935",
     "smallest_denomination": 100
+  },
+  "vef": {
+    "priority": 100,
+    "iso_code": "VEF",
+    "name": "Venezuelan Bolívar",
+    "symbol": "Bs.F",
+    "alternate_symbols": ["Bs"],
+    "subunit": "Céntimo",
+    "subunit_to_unit": 100,
+    "symbol_first": true,
+    "html_entity": "",
+    "decimal_mark": ",",
+    "thousands_separator": ".",
+    "iso_numeric": "937",
+    "smallest_denomination": 1
   }
 }

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -2271,19 +2271,19 @@
     "iso_numeric": "860",
     "smallest_denomination": 100
   },
-  "vef": {
+  "ves": {
     "priority": 100,
-    "iso_code": "VEF",
-    "name": "Venezuelan Bolívar",
+    "iso_code": "VES",
+    "name": "Venezuelan Bolívar Soberano",
     "symbol": "Bs",
-    "alternate_symbols": ["Bs.F"],
+    "alternate_symbols": ["Bs.S"],
     "subunit": "Céntimo",
     "subunit_to_unit": 100,
     "symbol_first": true,
     "html_entity": "",
     "decimal_mark": ",",
     "thousands_separator": ".",
-    "iso_numeric": "937",
+    "iso_numeric": "928",
     "smallest_denomination": 1
   },
   "vnd": {

--- a/config/currency_non_iso.json
+++ b/config/currency_non_iso.json
@@ -125,20 +125,5 @@
     "thousands_separator": ",",
     "iso_numeric": "",
     "smallest_denomination": 1
-  },
-  "vef": {
-    "priority": 100,
-    "iso_code": "VEF",
-    "name": "Venezuelan Bolívar",
-    "symbol": "Bs",
-    "alternate_symbols": ["Bs.F"],
-    "subunit": "Céntimo",
-    "subunit_to_unit": 100,
-    "symbol_first": true,
-    "html_entity": "",
-    "decimal_mark": ",",
-    "thousands_separator": ".",
-    "iso_numeric": "937",
-    "smallest_denomination": 1
   }
 }

--- a/config/currency_non_iso.json
+++ b/config/currency_non_iso.json
@@ -125,5 +125,20 @@
     "thousands_separator": ",",
     "iso_numeric": "",
     "smallest_denomination": 1
+  },
+  "vef": {
+    "priority": 100,
+    "iso_code": "VEF",
+    "name": "Venezuelan Bolívar",
+    "symbol": "Bs",
+    "alternate_symbols": ["Bs.F"],
+    "subunit": "Céntimo",
+    "subunit_to_unit": 100,
+    "symbol_first": true,
+    "html_entity": "",
+    "decimal_mark": ",",
+    "thousands_separator": ".",
+    "iso_numeric": "937",
+    "smallest_denomination": 1
   }
 }


### PR DESCRIPTION
This pull request fixes https://github.com/RubyMoney/money/pull/801

Had to change the symbol of Venezuelan Bolívar to "Bs.F" instead of just "Bs", to correct "Format 'Bs1.999,98' for VEF is ambiguous with currency VES."