### PR TITLE
Localize :format

### DIFF
--- a/lib/money/locale_backend/currency.rb
+++ b/lib/money/locale_backend/currency.rb
@@ -4,7 +4,11 @@ class Money
   module LocaleBackend
     class Currency < Base
       def lookup(key, currency)
-        currency.public_send(key) if currency.respond_to?(key)
+        if currency.respond_to?(key)
+          currency.public_send(key)
+        elsif key == :format
+          currency.symbol_first? ? '%u%n' : '%n %u'
+        end
       end
     end
   end

--- a/lib/money/locale_backend/i18n.rb
+++ b/lib/money/locale_backend/i18n.rb
@@ -5,7 +5,8 @@ class Money
     class I18n < Base
       KEY_MAP = {
         thousands_separator: :delimiter,
-        decimal_mark: :separator
+        decimal_mark: :separator,
+        format: :format
       }.freeze
 
       def initialize
@@ -13,6 +14,8 @@ class Money
       end
 
       def lookup(key, _)
+        return unless KEY_MAP.key?(key)
+
         i18n_key = KEY_MAP[key]
 
         ::I18n.t i18n_key, scope: 'number.currency.format', raise: true

--- a/lib/money/locale_backend/r18n.rb
+++ b/lib/money/locale_backend/r18n.rb
@@ -15,6 +15,8 @@ class Money
       end
 
       def lookup(key, _currency)
+        return unless KEY_MAP.key?(key)
+
         ::R18n.get.locale.public_send KEY_MAP[key]
       end
     end

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -5,7 +5,8 @@ class Money
   class Formatter
     DEFAULTS = {
       thousands_separator: '',
-      decimal_mark: '.'
+      decimal_mark: '.',
+      format: '%u%n'
     }.freeze
 
     # Creates a formatted price string according to several rules.
@@ -243,7 +244,7 @@ class Money
           symbol_value = html_wrap(symbol_value, "currency-symbol")
         end
 
-        rules[:format]
+        lookup(:format)
           .gsub('%u', [sign_before, symbol_value].join)
           .gsub('%n', [sign, formatted_number].join)
       else

--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -11,7 +11,6 @@ class Money
       @rules = default_formatting_rules.merge(@rules) unless @rules[:ignore_defaults]
       @rules = localize_formatting_rules(@rules)
       @rules = translate_formatting_rules(@rules) if @rules[:translate]
-      @rules[:format] ||= determine_format_from_formatting_rules(@rules)
     end
 
     def [](key)
@@ -62,10 +61,6 @@ class Money
         rules[:format] = '%n%u'
       end
       rules
-    end
-
-    def determine_format_from_formatting_rules(rules)
-      currency.symbol_first? ? '%u%n' : '%n %u'
     end
   end
 end

--- a/spec/locale_backend/currency_spec.rb
+++ b/spec/locale_backend/currency_spec.rb
@@ -2,14 +2,22 @@
 
 describe Money::LocaleBackend::Currency do
   describe '#lookup' do
-    let(:currency) { Money::Currency.new('EUR') }
+    let(:usd) { Money::Currency.new('USD') }
+    let(:nok) { Money::Currency.new('NOK') }
 
     it 'returns thousands_separator as defined in currency' do
-      expect(subject.lookup(:thousands_separator, currency)).to eq('.')
+      expect(subject.lookup(:thousands_separator, usd)).to eq(',')
+      expect(subject.lookup(:thousands_separator, nok)).to eq('.')
     end
 
-    it 'returns decimal_mark based as defined in currency' do
-      expect(subject.lookup(:decimal_mark, currency)).to eq(',')
+    it 'returns decimal_mark as defined in currency' do
+      expect(subject.lookup(:decimal_mark, usd)).to eq('.')
+      expect(subject.lookup(:decimal_mark, nok)).to eq(',')
+    end
+
+    it 'returns format based on currency' do
+      expect(subject.lookup(:format, usd)).to eq('%u%n')
+      expect(subject.lookup(:format, nok)).to eq('%n %u')
     end
   end
 end

--- a/spec/locale_backend/i18n_spec.rb
+++ b/spec/locale_backend/i18n_spec.rb
@@ -16,7 +16,7 @@ describe Money::LocaleBackend::I18n do
       before do
         I18n.locale = :de
         I18n.backend.store_translations(:de, number: {
-          currency: { format: { delimiter: '.', separator: ',' } }
+          currency: { format: { delimiter: '.', separator: ',', format: '%u %n' } }
         })
       end
 
@@ -26,6 +26,10 @@ describe Money::LocaleBackend::I18n do
 
       it 'returns decimal_mark based on the current locale' do
         expect(subject.lookup(:decimal_mark, nil)).to eq(',')
+      end
+
+      it 'returns format based on the current locale' do
+        expect(subject.lookup(:format, nil)).to eq('%u %n')
       end
     end
 
@@ -42,6 +46,10 @@ describe Money::LocaleBackend::I18n do
       it 'returns decimal_mark based on the current locale' do
         expect(subject.lookup(:decimal_mark, nil)).to eq(',')
       end
+
+      it 'returns nil for format' do
+        expect(subject.lookup(:format, nil)).to eq(nil)
+      end
     end
 
     context 'with no translation defined' do
@@ -51,6 +59,10 @@ describe Money::LocaleBackend::I18n do
 
       it 'returns decimal_mark based on the current locale' do
         expect(subject.lookup(:decimal_mark, nil)).to eq(nil)
+      end
+
+      it 'returns nil for format' do
+        expect(subject.lookup(:format, nil)).to eq(nil)
       end
     end
   end

--- a/spec/locale_backend/r18n_spec.rb
+++ b/spec/locale_backend/r18n_spec.rb
@@ -41,6 +41,10 @@ describe Money::LocaleBackend::R18n do
       it 'returns decimal_mark based on the current locale' do
         expect(subject.lookup(:decimal_mark, nil)).to eq(',')
       end
+
+      it 'returns nil for unsupported keys' do
+        expect(subject.lookup(:format, nil)).to eq(nil)
+      end
     end
 
     context 'with unavailable locale' do
@@ -54,6 +58,10 @@ describe Money::LocaleBackend::R18n do
 
       it 'returns decimal_mark based on the current locale' do
         expect(subject.lookup(:decimal_mark, nil)).to eq('.')
+      end
+
+      it 'returns nil for unsupported keys' do
+        expect(subject.lookup(:format, nil)).to eq(nil)
       end
     end
   end

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -585,17 +585,25 @@ describe Money, "formatting" do
       describe "with i18n = true", :i18n do
         before do
           I18n.locale = :de
-          I18n.backend.store_translations(:de, number: { currency: { format: { delimiter: ".", separator: "," } } })
+          I18n.backend.store_translations(:de, number: {
+            currency: {
+              format: {
+                delimiter: '.',
+                separator: ',',
+                format: '%u %n'
+              }
+            }
+          })
         end
 
         it 'does round fractional when set to true' do
-          expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: true)).to eq "$0,12"
-          expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: true)).to eq "$0,13"
-          expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq "ب.د0,123"
-          expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq "ب.د0,124"
-          expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: true)).to eq "$1,00"
-          expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: true)).to eq "$1,10"
-          expect(Money.new(BigDecimal('1'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar0,2"
+          expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: true)).to eq "$ 0,12"
+          expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: true)).to eq "$ 0,13"
+          expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq "ب.د 0,123"
+          expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq "ب.د 0,124"
+          expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: true)).to eq "$ 1,00"
+          expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: true)).to eq "$ 1,10"
+          expect(Money.new(BigDecimal('1'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar 0,2"
         end
       end
     end


### PR DESCRIPTION
Add localisation support for `:format` option, allowing to use I18n to provide a template for formatting