### PR TITLE
Disallow initializing Money with non-finite amounts

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -280,6 +280,9 @@ class Money
     @currency   = obj.respond_to?(:currency) ? obj.currency : Currency.wrap(currency)
     @currency ||= Money.default_currency
     @bank       = obj.respond_to?(:bank) ? obj.bank : bank
+
+    # BigDecimal can be Infinity and NaN, money of that amount does not make sense
+    raise ArgumentError, 'must be initialized with a finite value' unless @fractional.finite?
   end
 
   # Assuming using a currency using dollars:

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -276,7 +276,7 @@ class Money
   #   Money.new(100, "EUR") #=> #<Money @fractional=100 @currency="EUR">
   #
   def initialize(obj, currency = Money.default_currency, bank = Money.default_bank)
-    @fractional = obj.respond_to?(:fractional) ? obj.fractional : as_d(obj)
+    @fractional = as_d(obj.respond_to?(:fractional) ? obj.fractional : obj)
     @currency   = obj.respond_to?(:currency) ? obj.currency : Currency.wrap(currency)
     @currency ||= Money.default_currency
     @bank       = obj.respond_to?(:bank) ? obj.bank : bank

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -92,6 +92,20 @@ describe Money do
       end
     end
 
+    context 'non-finite value is given' do
+      let(:error) { 'must be initialized with a finite value' }
+
+      it 'raises an error when trying to initialize with Infinity' do
+        expect { Money.new('Infinity') }.to raise_error(ArgumentError, error)
+        expect { Money.new(BigDecimal('Infinity')) }.to raise_error(ArgumentError, error)
+      end
+
+      it 'raises an error when trying to initialize with NaN' do
+        expect { Money.new('NaN') }.to raise_error(ArgumentError, error)
+        expect { Money.new(BigDecimal('NaN')) }.to raise_error(ArgumentError, error)
+      end
+    end
+
     context "with infinite_precision", :infinite_precision do
       context 'given the initializing value is 1.50' do
         let(:initializing_value) { 1.50 }


### PR DESCRIPTION
TIL: both `BigDecimal('NaN')` and `BigDecimal('Infinity')`are valid.

However these should not be allowed, because they make no sense as Money amounts and will cause problems down the line

Fixes #831 