### PR TITLE
Add R18n locale backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,9 @@ For deprecated methods of integrating with Rails, check [the wiki](https://githu
 
 ## Localization
 
-In order to localize formatting you can use `I18n` gem:
+In order to localize formatting you can use different gems:
+
+### I18n
 
 ```ruby
 Money.locale_backend = :i18n
@@ -456,6 +458,21 @@ For this example `Money.new(123456789, "SEK").format` will return `1,234,567.89
 kr` which otherwise would have returned `1 234 567,89 kr`.
 
 This will work seamlessly with [rails-i18n](https://github.com/svenfuchs/rails-i18n) gem that already has a lot of locales defined.
+
+### R18n
+
+```ruby
+Money.locale_backend = :r18n
+```
+
+With this enabled a thousands seperator and a decimal mark will get looked up in locales, including bundled.
+
+For example `Money.new(123456789, "SEK").format` in English will return
+`1,234,567.89 kr` which otherwise would have returned `1 234 567,89 kr`.
+
+This will work seamlessly with [different R18n adapters](https://github.com/r18n/r18n) that already have a lot of locales defined.
+
+### Disable
 
 If you wish to disable this feature and use defaults instead:
 

--- a/lib/money/locale_backend/r18n.rb
+++ b/lib/money/locale_backend/r18n.rb
@@ -1,0 +1,20 @@
+require 'money/locale_backend/base'
+
+class Money
+  module LocaleBackend
+    class R18n < Base
+      KEY_MAP = {
+        thousands_separator: :number_group,
+        decimal_mark: :number_decimal
+      }.freeze
+
+      def initialize
+        raise NotSupported, 'R18n not found' unless defined?(::R18n)
+      end
+
+      def lookup(key, _)
+        ::R18n.get.locale.public_send KEY_MAP[key]
+      end
+    end
+  end
+end

--- a/lib/money/money/locale_backend.rb
+++ b/lib/money/money/locale_backend.rb
@@ -3,6 +3,7 @@
 require 'money/locale_backend/errors'
 require 'money/locale_backend/legacy'
 require 'money/locale_backend/i18n'
+require 'money/locale_backend/r18n'
 require 'money/locale_backend/currency'
 
 class Money
@@ -10,6 +11,7 @@ class Money
     BACKENDS = {
       legacy: Money::LocaleBackend::Legacy,
       i18n: Money::LocaleBackend::I18n,
+      r18n: Money::LocaleBackend::R18n,
       currency: Money::LocaleBackend::Currency
     }.freeze
 

--- a/money.gemspec
+++ b/money.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'i18n', [">= 0.6.4", '<= 2']
 
   s.add_development_dependency "bundler", "~> 1.3"
+  s.add_development_dependency "r18n-core", "~> 3.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.4"
   s.add_development_dependency "yard", "~> 0.9.11"

--- a/spec/locale_backend/r18n_spec.rb
+++ b/spec/locale_backend/r18n_spec.rb
@@ -1,0 +1,60 @@
+# encoding: utf-8
+
+describe Money::LocaleBackend::R18n do
+  describe '#initialize' do
+    it 'raises an error when R18n is not defined' do
+      hide_const('R18n')
+
+      expect { described_class.new }.to raise_error(Money::LocaleBackend::NotSupported)
+    end
+  end
+
+  describe '#lookup' do
+    before do
+      R18n.default_loader = Class.new do
+        def available
+          %i[de].map { |locale| R18n.locale locale }
+        end
+
+        def load(_locale)
+          {}
+        end
+      end
+    end
+
+    after do
+      R18n.reset!
+      R18n.set :en
+    end
+
+    subject { described_class.new }
+
+    context 'with available locale' do
+      before do
+        R18n.set :de
+      end
+
+      it 'returns thousands_separator based on the current locale' do
+        expect(subject.lookup(:thousands_separator, nil)).to eq('.')
+      end
+
+      it 'returns decimal_mark based on the current locale' do
+        expect(subject.lookup(:decimal_mark, nil)).to eq(',')
+      end
+    end
+
+    context 'with unavailable locale' do
+      before do
+        R18n.set :unavailable
+      end
+
+      it 'returns thousands_separator based on the current locale' do
+        expect(subject.lookup(:thousands_separator, nil)).to eq(',')
+      end
+
+      it 'returns decimal_mark based on the current locale' do
+        expect(subject.lookup(:decimal_mark, nil)).to eq('.')
+      end
+    end
+  end
+end

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -135,6 +135,70 @@ describe Money, "formatting" do
     end
   end
 
+  context "with r18n" do
+    before :each do
+      Money.locale_backend = :r18n
+       R18n.reset!
+       R18n.default_loader = Class.new do
+        def available
+          %i[de].map { |locale| R18n.locale locale }
+        end
+
+        def load(_locale)
+          {}
+        end
+      end
+    end
+
+    after :each do
+      R18n.reset!
+      R18n.set :en
+      Money.locale_backend = :legacy
+    end
+
+    context "with available locale" do
+      before :each do
+        R18n.set :de
+      end
+
+      subject(:money) { Money.empty("USD") }
+
+      it "should use '.' as the thousands separator" do
+        expect(money.thousands_separator).to eq '.'
+      end
+
+      it "should use ',' as the decimal mark" do
+        expect(money.decimal_mark).to eq ','
+      end
+    end
+
+    context "with unavailable locale" do
+      before :each do
+        R18n.set :unavailable
+      end
+
+      subject(:money) { Money.empty("USD") }
+
+      it "should use ',' as the thousands separator" do
+        expect(money.thousands_separator).to eq ','
+      end
+
+      it "should use '.' as the decimal mark" do
+        expect(money.decimal_mark).to eq '.'
+      end
+    end
+
+    context "with overridden r18n settings" do
+      it "should respect explicit overriding of thousands_separator/delimiter when decimal_mark/separator collide and there’s no decimal component for currencies that have no subunit" do
+        expect(Money.new(300_000, 'ISK').format(thousands_separator: ".", decimal_mark: ',')).to eq "kr300.000"
+      end
+
+      it "should respect explicit overriding of thousands_separator/delimiter when decimal_mark/separator collide and there’s no decimal component for currencies with subunits that drop_trailing_zeros" do
+        expect(Money.new(300_000, 'USD').format(thousands_separator: ".", decimal_mark: ',', drop_trailing_zeros: true)).to eq "$3.000"
+      end
+    end
+  end
+
   describe "#format" do
     it 'supports the old formatting options' do
       expect(Money.zero.format(:display_free)).to eq('free')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ $LOAD_PATH.unshift File.dirname(__FILE__)
 require "rspec"
 require "money"
 
+require "r18n-core"
+
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
 I18n.enforce_available_locales = false


### PR DESCRIPTION
https://github.com/r18n/r18n

---

We have many deprecations now, and our project uses R18n instead of I18n.