### PR TITLE
Prevent Divide By Zero in Money#allocate

### DIFF
--- a/lib/money/money/allocation.rb
+++ b/lib/money/money/allocation.rb
@@ -24,8 +24,11 @@ class Money
         parts_sum = parts.inject(0, :+)
         part = parts.pop
 
-        current_split = remaining_amount * part / parts_sum
-        current_split = current_split.truncate if whole_amounts
+        current_split = 0
+        if parts_sum > 0
+          current_split = remaining_amount * part / parts_sum
+          current_split = current_split.truncate if whole_amounts
+        end
 
         result.unshift current_split
         remaining_amount -= current_split

--- a/spec/money/allocation_spec.rb
+++ b/spec/money/allocation_spec.rb
@@ -87,6 +87,11 @@ describe Money::Allocation do
         expect(described_class.generate(10, [1, 1, 2])).to eq([3, 2, 5])
         expect(described_class.generate(100, [1, 1, 1])).to eq([34, 33, 33])
       end
+
+      it 'handles zero arguments' do
+        expect(described_class.generate(100, [1, 1, 0])).to eq([50, 50, 0])
+        expect(described_class.generate(100, [0, 1, 1])).to eq([0, 50, 50])
+      end
     end
 
     context 'fractional amounts' do


### PR DESCRIPTION
This leads to an error when attempting to allocate a zero value, and the
zero value is the first argument in parts.

Example:

```
[1] pry(main)> Money.new(100, "USD").allocate([1, 1, 0])
=> [#<Money fractional:50 currency:USD>, #<Money fractional:50 currency:USD>, #<Money fractional:0 currency:USD>]

[2] pry(main)> Money.new(100, "USD").allocate([0, 1, 1])
ZeroDivisionError: divided by 0

[3] pry(main)> Money.new(100, "USD").allocate([1, 1, 0.0])
=> [#<Money fractional:50 currency:USD>, #<Money fractional:50 currency:USD>, #<Money fractional:0 currency:USD>]

[4] pry(main)> Money.new(100, "USD").allocate([0.0, 1, 1])
FloatDomainError: NaN
```