### PR TITLE
Fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - rvm: rbx-3
   fast_finish: true
 before_install:
-  - gem install bundler --version 1.17.3
+  - gem install bundler --version '~> 1.17'
 script: bundle exec rspec spec
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - rvm: rbx-3
   fast_finish: true
 before_install:
-  - gem update bundler
+  - gem install bundler
 script: bundle exec rspec spec
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - rvm: rbx-3
   fast_finish: true
 before_install:
-  - gem install bundler
+  - gem install bundler --version 1.17.3
 script: bundle exec rspec spec
 notifications:
   email:

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,6 @@ elsif RUBY_VERSION =~ /^1/
   gem 'tins',           '~> 1.6.0'
   gem 'term-ansicolor', '< 1.4'
 end
+gem 'i18n', '1.2.0' if RUBY_VERSION =~ /^2\.[012]/
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,6 @@ elsif RUBY_VERSION =~ /^1/
   gem 'tins',           '~> 1.6.0'
   gem 'term-ansicolor', '< 1.4'
 end
-gem 'i18n', '1.2.0' if RUBY_VERSION =~ /^2\.[012]/
+gem 'i18n', '<= 1.2.0' if RUBY_VERSION < '2.3'
 
 gemspec

--- a/money.gemspec
+++ b/money.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'i18n', [">= 0.6.4", '<= 2']
 
-  s.add_development_dependency "bundler", "~> 1.3"
+  s.add_development_dependency "bundler"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.4"
   s.add_development_dependency "yard", "~> 0.9.11"


### PR DESCRIPTION
Since Bundler 2.0 was released, the build has failed!

In Travis CI we install the [latest version of Bundler (2.0.1)](https://travis-ci.org/RubyMoney/money/jobs/475145276#L473), but our gemspec [specifies we must use `~> 1.3`](https://travis-ci.org/RubyMoney/money/jobs/475145276#L488) which excludes Bundler v2.



To fix this:

* remove the constraint on the Bundler version from the gemspec (this allows developers to use the Bundler version they desire).
* Install Bundler 1.17.3 on TravisCI (Bundler v2 requires Ruby >= 2.3. We can bump up to Bundler v2 after we remove the legacy Ruby versions from the build matrix.)

Additionally the latest release of i18n is incompatible with legacy Rubies. For these Rubies the i18n has been pinned to the last known working version: 1.2.0.