### PR TITLE
Allow :symbol lookup in LocaleBackend::I18n

### DIFF
--- a/lib/money/locale_backend/i18n.rb
+++ b/lib/money/locale_backend/i18n.rb
@@ -5,7 +5,8 @@ class Money
     class I18n < Base
       KEY_MAP = {
         thousands_separator: :delimiter,
-        decimal_mark: :separator
+        decimal_mark: :separator,
+        symbol: :unit
       }.freeze
 
       def initialize

--- a/spec/locale_backend/i18n_spec.rb
+++ b/spec/locale_backend/i18n_spec.rb
@@ -21,7 +21,7 @@ describe Money::LocaleBackend::I18n do
       before do
         I18n.locale = :de
         I18n.backend.store_translations(:de, number: {
-          currency: { format: { delimiter: '.', separator: ',' } }
+          currency: { format: { delimiter: '.', separator: ',', unit: '$' } }
         })
       end
 
@@ -31,6 +31,10 @@ describe Money::LocaleBackend::I18n do
 
       it 'returns decimal_mark based on the current locale' do
         expect(subject.lookup(:decimal_mark, nil)).to eq(',')
+      end
+
+      it 'returns symbol based on the current locale' do
+        expect(subject.lookup(:symbol, nil)).to eq('$')
       end
     end
 
@@ -56,6 +60,10 @@ describe Money::LocaleBackend::I18n do
 
       it 'returns decimal_mark based on the current locale' do
         expect(subject.lookup(:decimal_mark, nil)).to eq(nil)
+      end
+
+      it 'returns symbol based on the current locale' do
+        expect(subject.lookup(:symbol, nil)).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
This will allow for smoother transition of money-rails to support LocaleBackend. This behaviour is not used directly by the Money gem and probably never will be because we have a much better symbol database compared to rails-i18n.