### PR TITLE
Only included required files in packaged gem

### DIFF
--- a/money.gemspec
+++ b/money.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "yard", "~> 0.9.11"
   s.add_development_dependency "kramdown", "~> 1.1"
 
-  s.files         = `git ls-files`.split($/)
+  s.files         = `git ls-files -z -- config/* lib/* CHANGELOG.md LICENSE money.gemspec README.md`.split("\x0")
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]


### PR DESCRIPTION
This will ensure that all the dotfiles, specs, Gemfiles and other non-required files are not included in the packaged gem