### PR TITLE
Update currency_iso.json

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -1977,8 +1977,8 @@
     "subunit_to_unit": 100,
     "symbol_first": false,
     "html_entity": "",
-    "decimal_mark": ".",
-    "thousands_separator": ",",
+    "decimal_mark": ",",
+    "thousands_separator": ".",
     "iso_numeric": "968",
     "smallest_denomination": 1
   },


### PR DESCRIPTION
Suriname uses the locality of Netherlands, and thus a thousand seperator of . and a decimal mark of ,
This can be seen on the website of the central bank (https://www.cbvs.sr/)
The general public however uses a thousand seperator of , and a decimal mark of .