### PR TITLE
Switch default rounding mode to ROUND_HALF_UP

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ To round to the nearest cent (or anything more precise), you can use the `round`
 Money.infinite_precision = true
 Money.new(2.34567).format       #=> "$0.0234567"
 Money.new(2.34567).round.format #=> "$0.02"
-Money.new(2.34567).round(BigDecimal::ROUND_HALF_UP, 2).format #=> "$0.0235"
+Money.new(2.34567).round(BigDecimal::ROUND_DOWN, 2).format #=> "$0.0234"
 ```
 
 ## Ruby on Rails

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -155,8 +155,8 @@ class Money
     # Default to not using infinite precision cents
     self.infinite_precision = false
 
-    # Default to bankers rounding
-    self.rounding_mode = BigDecimal::ROUND_HALF_EVEN
+    # Same default as BigDecimal
+    self.rounding_mode = BigDecimal::ROUND_HALF_UP
 
     # Default the conversion of Rationals precision to 16
     self.conversion_precision = 16
@@ -177,7 +177,7 @@ class Money
   # @return [BigDecimal::ROUND_MODE,Yield] rounding mode or block results
   #
   # @example
-  #   fee = Money.rounding_mode(BigDecimal::ROUND_HALF_UP) do
+  #   fee = Money.rounding_mode(BigDecimal::ROUND_HALF_DOWN) do
   #     Money.new(1200) * BigDecimal('0.029')
   #   end
   def self.rounding_mode(mode = nil)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -273,8 +273,10 @@ YAML
     end
 
     context "user changes rounding_mode" do
-      after do
-        Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN
+      around do |example|
+        previous_mode = Money.rounding_mode
+        example.run
+        Money.rounding_mode = previous_mode
       end
 
       context "with the setter" do
@@ -297,7 +299,7 @@ YAML
             Money.new(1.1).fractional
           end).to eq 2
 
-          expect(Money.rounding_mode).to eq BigDecimal::ROUND_HALF_EVEN
+          expect(Money.rounding_mode).to eq BigDecimal::ROUND_HALF_UP
         end
 
         it "works for multiplication within a block" do
@@ -309,7 +311,7 @@ YAML
             expect((Money.new(1_00) * "0.011".to_d).fractional).to eq 2
           end
 
-          expect(Money.rounding_mode).to eq BigDecimal::ROUND_HALF_EVEN
+          expect(Money.rounding_mode).to eq BigDecimal::ROUND_HALF_UP
         end
       end
     end


### PR DESCRIPTION
The current default rounding mode is `ROUND_HALF_EVEN` also known as the "Banker's Rounding". This means that 1.4, 1.5, 1.6 are rounded to 2, however 2.4, 2.5, 2.6 are also rounded to 2 (towards nearest even number).

This helps minimizing the accumulated error when performing big amounts of operations, however this is not intuitive and can cause confusion, which is not expected from a default setting.

Changing this to `ROUND_HALF_UP`, which is a common sense approach. Will add this to post-install message as a warning.