### PR TITLE
Updates currency config for ZMW

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,6 @@
 Abhay Kumar
 Adrian Longley
+Alexander Donkin
 Alexander Ross
 Alex Speller
 Andreas Loupasakis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+- Update currency config for Zambian Kwacha (ZMW)
 
 ## 6.13.3
 - Remove specs from the packaged gem

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -2604,6 +2604,6 @@
     "decimal_mark": ".",
     "thousands_separator": ",",
     "iso_numeric": "967",
-    "smallest_denomination": 2
+    "smallest_denomination": 5
   }
 }

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -2594,16 +2594,16 @@
     "priority": 100,
     "iso_code": "ZMW",
     "name": "Zambian Kwacha",
-    "symbol": "ZK",
+    "symbol": "K",
     "disambiguate_symbol": "ZMW",
     "alternate_symbols": [],
     "subunit": "Ngwee",
     "subunit_to_unit": 100,
-    "symbol_first": false,
+    "symbol_first": true,
     "html_entity": "",
     "decimal_mark": ".",
     "thousands_separator": ",",
     "iso_numeric": "967",
-    "smallest_denomination": 5
+    "smallest_denomination": 2
   }
 }


### PR DESCRIPTION
Updates various currency configuration for the Zambian Kwacha. Used the [Bank Of Zambia](http://www.boz.zm/currency-family.htm) as a resource to confirm the updates.