### PR TITLE
Do not modify passed-in options in FormattingRules

### DIFF
--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -38,6 +38,7 @@ class Money
         rules = {}
       elsif rules.size == 1
         rules = rules.pop
+        rules = rules.dup if rules.is_a?(Hash)
 
         if rules.is_a?(Symbol)
           warn '[DEPRECATION] Use Hash when passing rules to Money#format.'

--- a/spec/money/formatting_rules_spec.rb
+++ b/spec/money/formatting_rules_spec.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+describe Money::FormattingRules do
+  it 'does not modify frozen rules in place' do
+    expect {
+      Money::FormattingRules.new(Money::Currency.new('USD'), { separator: '.' }.freeze)
+    }.not_to raise_error
+  end
+
+  it 'does not modify rules in place' do
+    rules = { separator: '.' }
+    new_rules = Money::FormattingRules.new(Money::Currency.new('USD'), rules)
+
+    expect(rules).to eq(separator: '.')
+    expect(rules).not_to eq(new_rules)
+  end
+end


### PR DESCRIPTION
This behaviour is confusing and can be potentially harmful as the hash that was
passed in gets modified