### PR TITLE
Raise warning on using `Money.default_currency`

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -125,22 +125,31 @@ class Money
       :locale_backend
 
     # @attr_writer rounding_mode Use this to specify the rounding mode
-    #
-    # @!attribute default_currency
-    #   @return [Money::Currency] The default currency, which is used when
-    #     +Money.new+ is called without an explicit currency argument. The
-    #     default value is Currency.new("USD"). The value must be a valid
-    #     +Money::Currency+ instance.
-    attr_writer :rounding_mode, :default_currency
+    attr_writer :rounding_mode
 
   end
 
+  # @!attribute default_currency
+  #   @return [Money::Currency] The default currency, which is used when
+  #     +Money.new+ is called without an explicit currency argument. The
+  #     default value is Currency.new("USD"). The value must be a valid
+  #     +Money::Currency+ instance.
   def self.default_currency
+    if @using_deprecated_default_currency
+      warn '[WARNING] The default currency will change to `nil` in the next major release. Make ' \
+           'sure to set it explicitly using `Money.default_currency=` to avoid potential issues'
+    end
+
     if @default_currency.respond_to?(:call)
       Money::Currency.new(@default_currency.call)
     else
       Money::Currency.new(@default_currency)
     end
+  end
+
+  def self.default_currency=(currency)
+    @using_deprecated_default_currency = false
+    @default_currency = currency
   end
 
   def self.locale_backend=(value)
@@ -163,6 +172,7 @@ class Money
 
     # Set the default currency for creating new +Money+ object.
     self.default_currency = Currency.new("USD")
+    @using_deprecated_default_currency = true
 
     # Default to using i18n
     @use_i18n = true

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -194,11 +194,16 @@ describe Money do
     end
 
     it 'warns about rounding_mode deprecation' do
-      expect(Money).to receive(:warn)
+      allow(Money).to receive(:warn)
+
       expect(Money.from_amount(1.999).to_d).to eq 2
       expect(Money.rounding_mode(BigDecimal::ROUND_DOWN) do
         Money.from_amount(1.999).to_d
       end).to eq 1.99
+      expect(Money)
+        .to have_received(:warn)
+        .with('[DEPRECATION] calling `rounding_mode` with a block is deprecated. ' \
+              'Please use `.with_rounding_mode` instead.')
     end
 
     it 'rounds using with_rounding_mode' do
@@ -881,13 +886,7 @@ YAML
   end
 
   describe ".default_currency" do
-    before do
-      @default_currency = Money.default_currency
-    end
-
-    after do
-      Money.default_currency = @default_currency
-    end
+    after { Money.setup_defaults }
 
     it "accepts a lambda" do
       Money.default_currency = lambda { :eur }
@@ -897,6 +896,22 @@ YAML
     it "accepts a symbol" do
       Money.default_currency = :eur
       expect(Money.default_currency).to eq Money::Currency.new(:eur)
+    end
+
+    it 'warns about changing default_currency value' do
+      expect(Money)
+        .to receive(:warn)
+        .with('[WARNING] The default currency will change to `nil` in the next major release. Make ' \
+              'sure to set it explicitly using `Money.default_currency=` to avoid potential issues')
+
+      Money.default_currency
+    end
+
+    it 'does not warn if the default_currency has been changed' do
+      Money.default_currency = Money::Currency.new(:usd)
+
+      expect(Money).not_to receive(:warn)
+      Money.default_currency
     end
   end
 end


### PR DESCRIPTION
`Money.default_currency` will change to `nil` in v7. Raising a warning to inform everyone ahead of time and prevent potential issues