### PR TITLE
Adds a few enhancements to per instance infinite precision

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -644,8 +644,9 @@ class Money
 
   private
 
-  def dup_with_new_fractional(new_fractional)
-    self.class.new(new_fractional, currency, { bank: bank, infinite_precision: infinite_precision? })
+  def dup_with_new_fractional(new_fractional, infinite_precision = nil)
+    infinite_precision = self.infinite_precision? if infinite_precision.nil?
+    self.class.new(new_fractional, currency, { bank: bank, infinite_precision: infinite_precision })
   end
 
   def as_d(num)

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -124,6 +124,16 @@ class Money
     attr_accessor :default_bank, :default_formatting_rules,
       :use_i18n, :default_infinite_precision, :conversion_precision,
       :locale_backend
+
+    def infinite_precision
+      warn '[DEPRECATION] `Money.infinite_precision` is deprecated - use `Money.default_infinite_precision` instead'
+      self.default_infinite_precision
+    end
+
+    def infinite_precision=(value)
+      warn '[DEPRECATION] `Money.infinite_precision=` is deprecated - use `Money.default_infinite_precision= ` instead'
+      self.default_infinite_precision = value
+    end
   end
 
   # @!attribute default_currency

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -409,8 +409,7 @@ class Money
   #
   # @return [String]
   def inspect
-    "#<#{self.class.name} fractional:#{fractional} currency:#{currency}" \
-    "#{' with_infinite_precision' if infinite_precision?}>"
+    "#<#{self.class.name} fractional:#{fractional} currency:#{currency}"
   end
 
   def to_precise

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -320,6 +320,7 @@ class Money
     @bank     ||= Money.default_bank
     @infinite_precision = obj.respond_to?(:infinite_precision?) ? obj.infinite_precision? : options[:infinite_precision]
     @infinite_precision = self.class.default_infinite_precision if @infinite_precision.nil?
+    @infinite_precision = !!@infinite_precision # ensure we have a boolean
 
     # BigDecimal can be Infinity and NaN, money of that amount does not make sense
     raise ArgumentError, 'must be initialized with a finite value' unless @fractional.finite?
@@ -405,7 +406,7 @@ class Money
   end
 
   def infinite_precision?
-    !!@infinite_precision
+    @infinite_precision
   end
 
   # Common inspect function

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -114,14 +114,15 @@ class Money
     #   @return [Boolean] Use this to disable i18n even if it's used by other
     #     objects in your app.
     #
-    # @!attribute [rw] infinite_precision
-    #   @return [Boolean] Use this to enable infinite precision cents
+    # @!attribute [rw] default_infinite_precision
+    #   @return [Boolean] Use this to enable infinite precision cents as the
+    #     global default
     #
     # @!attribute [rw] conversion_precision
     #   @return [Integer] Use this to specify precision for converting Rational
     #     to BigDecimal
     attr_accessor :default_bank, :default_formatting_rules,
-      :use_i18n, :infinite_precision, :conversion_precision,
+      :use_i18n, :default_infinite_precision, :conversion_precision,
       :locale_backend
   end
 
@@ -183,7 +184,7 @@ class Money
     self.locale_backend = :legacy
 
     # Default to not using infinite precision cents
-    self.infinite_precision = false
+    self.default_infinite_precision = false
 
     # Default to bankers rounding
     self.rounding_mode = BigDecimal::ROUND_HALF_EVEN
@@ -264,6 +265,8 @@ class Money
   # @param [Numeric] amount The numerical value of the money.
   # @param [Currency, String, Symbol] currency The currency format.
   # @param [Money::Bank::*] bank The exchange bank to use.
+  # @param [Boolean] infinite_precision Whether to enable infinite precision for
+  #   the instance.
   #
   # @example
   #   Money.from_amount(23.45, "USD") # => #<Money fractional:2345 currency:USD>
@@ -292,6 +295,8 @@ class Money
   #   = 0.
   # @param [Currency, String, Symbol] currency The currency format.
   # @param [Money::Bank::*] bank The exchange bank to use.
+  # @param [Boolean] infinite_precision Whether to enable infinite precision for
+  #   the instance.
   #
   # @return [Money]
   #
@@ -307,7 +312,7 @@ class Money
     @infinite_precision =
       if infinite_precision.nil?
         if obj.respond_to?(:infinite_precision?) then obj.infinite_precision?
-        else self.class.infinite_precision
+        else self.class.default_infinite_precision
         end
       else
         infinite_precision

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -132,7 +132,8 @@ class Money
         when Money
           other = other.exchange_to(currency)
           new_fractional = fractional.public_send(op, other.fractional)
-          dup_with_new_fractional(new_fractional)
+          infinite_precision = self.infinite_precision? || other.infinite_precision?
+          dup_with_new_fractional(new_fractional, infinite_precision )
         when CoercedNumeric
           raise TypeError, non_zero_message.call(other.value) unless other.zero?
           dup_with_new_fractional(other.value.public_send(op, fractional))
@@ -226,7 +227,8 @@ class Money
     def divmod_money(val)
       cents = val.exchange_to(currency).cents
       quotient, remainder = fractional.divmod(cents)
-      [quotient, dup_with_new_fractional(remainder)]
+      infinite_precision = self.infinite_precision? || val.infinite_precision?
+      [quotient, dup_with_new_fractional(remainder, infinite_precision)]
     end
     private :divmod_money
 

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -347,7 +347,7 @@ class Money
     end
 
     def format_decimal_part(value)
-      return nil if currency.decimal_places == 0 && !Money.infinite_precision
+      return nil if currency.decimal_places == 0 && !money.infinite_precision?
       return nil if rules[:no_cents]
       return nil if rules[:no_cents_if_whole] && value.to_i == 0
 

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -213,6 +213,18 @@ describe Money::Arithmetic do
       expect(Money.new(10_00) + 0).to eq Money.new(10_00)
     end
 
+    it "preserves the highest precision of the operands" do
+      high_precision_money = Money.new(10.7654, "USD", { infinite_precision: true })
+      low_precision_money = Money.new(10, "USD", { infinite_precision: false })
+      answer_money = Money.new(20.7654, "USD", { infinite_precision: true })
+      expect((high_precision_money + low_precision_money).infinite_precision?).to eq true
+      expect(high_precision_money + low_precision_money).to eq answer_money
+      expect((low_precision_money + high_precision_money).infinite_precision?).to eq true
+      expect(low_precision_money + high_precision_money).to eq answer_money
+      expect((low_precision_money + low_precision_money).infinite_precision?).to eq false
+      expect(low_precision_money + low_precision_money).to eq Money.new(20, "USD", { infinite_precision: false })
+    end
+
     it "preserves the class in the result when using a subclass of Money" do
       special_money_class = Class.new(Money)
       expect(special_money_class.new(10_00, "USD") + Money.new(90, "USD")).to be_a special_money_class
@@ -242,6 +254,17 @@ describe Money::Arithmetic do
 
     it "subtract Integer 0 to money and returns the same ammount" do
       expect(Money.new(10_00) - 0).to eq Money.new(10_00)
+    end
+
+    it "preserves the highest precision of the operands" do
+      high_precision_money = Money.new(10.7654, "USD", { infinite_precision: true })
+      low_precision_money = Money.new(10, "USD", { infinite_precision: false })
+      expect((high_precision_money - low_precision_money).infinite_precision?).to eq true
+      expect(high_precision_money - low_precision_money).to eq Money.new(0.7654, "USD", { infinite_precision: true })
+      expect((low_precision_money - high_precision_money).infinite_precision?).to eq true
+      expect(low_precision_money - high_precision_money).to eq Money.new(-0.7654, "USD", { infinite_precision: true })
+      expect((low_precision_money - low_precision_money).infinite_precision?).to eq false
+      expect(low_precision_money - low_precision_money).to eq Money.new(0, "USD", { infinite_precision: false })
     end
 
     it "preserves the class in the result when using a subclass of Money" do
@@ -374,7 +397,7 @@ describe Money::Arithmetic do
       end
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       it "uses BigDecimal division" do
         ts = [
           {a: Money.new( 13, :USD), b: 4, c: Money.new( 3.25, :USD)},
@@ -429,7 +452,7 @@ describe Money::Arithmetic do
       end
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       it "uses BigDecimal division" do
         ts = [
           {a: Money.new( 13, :USD), b: 4, c: Money.new( 3.25, :USD)},
@@ -482,13 +505,29 @@ describe Money::Arithmetic do
       end
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       it "uses BigDecimal division" do
         ts = [
             {a: Money.new( 13, :USD), b: 4, c: [Money.new( 3, :USD), Money.new( 1, :USD)]},
             {a: Money.new( 13, :USD), b: -4, c: [Money.new(-4, :USD), Money.new(-3, :USD)]},
             {a: Money.new(-13, :USD), b: 4, c: [Money.new(-4, :USD), Money.new( 3, :USD)]},
             {a: Money.new(-13, :USD), b: -4, c: [Money.new( 3, :USD), Money.new(-1, :USD)]},
+            # {a: Money.new( 10, :USD), b: 3.1, c: [Money.new( 3, :USD), Money.new( 0.7, :USD)]},
+            # {a: Money.new( 10, :USD), b: -3.1 , c: [Money.new( -4, :USD), Money.new( -2.4, :USD)]},
+            # {a: Money.new( -10, :USD), b: 3.1 , c: [Money.new( -4, :USD), Money.new( 2.4, :USD)]},
+            # {a: Money.new( -10, :USD), b: -3.1 , c: [Money.new( 3, :USD), Money.new( -0.7, :USD)]},
+        ]
+        ts.each do |t|
+          expect(t[:a].divmod(t[:b])).to eq t[:c]
+        end
+      end
+    end
+
+    context "with mixed precision" do
+      it "it maintains infinite precision" do
+        ts = [
+          {a: Money.new( 12.99, :USD, {infinite_precision: true}), b: Money.new( 3, :USD), c: [ BigDecimal(4), Money.new( 0.99, :USD, {infinite_precision: true})]},
+          {a: Money.new( 13, :USD), b: Money.new(3.5, :USD, {infinite_precision: true}), c: [ BigDecimal(3), Money.new(2.5, :USD, {infinite_precision: true})]},
         ]
         ts.each do |t|
           expect(t[:a].divmod(t[:b])).to eq t[:c]

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -173,7 +173,7 @@ describe Money, "formatting" do
         end
 
         it "displays a decimal part when infinite_precision is true on the instance" do
-          expect(Money.new(10_00.1, "VUV", nil, true).format).to eq "Vt1,000.1"
+          expect(Money.new(10_00.1, "VUV", { infinite_precision: true }).format).to eq "Vt1,000.1"
         end
       end
 
@@ -184,7 +184,7 @@ describe Money, "formatting" do
         end
 
         it "does not display a decimal part when infinite_precision is false on the instance" do
-          expect(Money.new(10_00.1, "VUV", nil, false).format).to eq "Vt1,000"
+          expect(Money.new(10_00.1, "VUV", { infinite_precision: false }).format).to eq "Vt1,000"
         end
       end
     end

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -166,12 +166,26 @@ describe Money, "formatting" do
         expect(Money.new(10_00, "VUV").format).to eq "Vt1,000"
       end
 
-      it "does not displays a decimal part when infinite_precision is false" do
-        expect(Money.new(10_00.1, "VUV").format).to eq "Vt1,000"
+      context "when infinite_precision is not set globally",
+              :default_infinite_precision_false do
+        it "does not display a decimal part" do
+          expect(Money.new(10_00.1, "VUV").format).to eq "Vt1,000"
+        end
+
+        it "displays a decimal part when infinite_precision is true on the instance" do
+          expect(Money.new(10_00.1, "VUV", nil, true).format).to eq "Vt1,000.1"
+        end
       end
 
-      it "displays a decimal part when infinite_precision is true", :infinite_precision do
-        expect(Money.new(10_00.1, "VUV").format).to eq "Vt1,000.1"
+      context "when infinite_precision is set globally",
+              :default_infinite_precision_true do
+        it "does display a decimal part" do
+          expect(Money.new(10_00.1, "VUV").format).to eq "Vt1,000.1"
+        end
+
+        it "does not display a decimal part when infinite_precision is false on the instance" do
+          expect(Money.new(10_00.1, "VUV", nil, false).format).to eq "Vt1,000"
+        end
       end
     end
 
@@ -609,7 +623,7 @@ describe Money, "formatting" do
       end
     end
 
-    describe ":rounded_infinite_precision option", :infinite_precision do
+    describe ":rounded_infinite_precision option", :default_infinite_precision_true do
       it "does round fractional when set to true" do
         expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: true)).to eq "$0.12"
         expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: true)).to eq "$0.13"

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -118,7 +118,7 @@ describe Money do
 
     context "with infinite_precision on the instance only" do
       let(:initializing_value) { 1.50 }
-      subject(:money) { Money.new(initializing_value, nil, nil, true) }
+      subject(:money) { Money.new(initializing_value, nil, { infinite_precision: true }) }
 
       it "should have the correct cents" do
         expect(money.cents).to eq BigDecimal('1.50')
@@ -192,10 +192,10 @@ describe Money do
 
     it  "does not round the given amount when infinite_precision is set " \
         "on the instance" do
-      expect(Money.from_amount(4.444, "USD", nil, true).amount).to eq "4.444".to_d
-      expect(Money.from_amount(5.555, "USD", nil, true).amount).to eq "5.555".to_d
-      expect(Money.from_amount(444.4, "JPY", nil, true).amount).to eq "444.4".to_d
-      expect(Money.from_amount(555.5, "JPY", nil, true).amount).to eq "555.5".to_d
+      expect(Money.from_amount(4.444, "USD", { infinite_precision: true }).amount).to eq "4.444".to_d
+      expect(Money.from_amount(5.555, "USD", { infinite_precision: true }).amount).to eq "5.555".to_d
+      expect(Money.from_amount(444.4, "JPY", { infinite_precision: true }).amount).to eq "444.4".to_d
+      expect(Money.from_amount(555.5, "JPY", { infinite_precision: true }).amount).to eq "555.5".to_d
     end
 
     it "accepts an optional currency" do
@@ -431,7 +431,7 @@ YAML
       end
 
       it "returns a BigDecimal when infinite_precision is set on instance" do
-        money = Money.new(100, "EUR", nil, true)
+        money = Money.new(100, "EUR", { infinite_precision: true })
         expect(money.round_to_nearest_cash_value).to be_a BigDecimal
       end
     end
@@ -444,7 +444,7 @@ YAML
       end
 
       it "returns an Integer when infinite_precision is set to false on instance" do
-        money = Money.new(100, "EUR", nil, false)
+        money = Money.new(100, "EUR", { infinite_precision: false })
         expect(money.round_to_nearest_cash_value).to be_a Integer
       end
     end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -813,75 +813,77 @@ YAML
   end
 
   describe "#round" do
-    it_behaves_like "rounding" do
-      subject(:rounded) { money.round }
+    let(:money) { Money.new(15.75, 'NZD') }
+    subject(:rounded) { money.round }
 
-      it 'preserves assigned bank' do
-        bank = Money::Bank::VariableExchange.new
-        rounded = Money.new(1_00, 'USD', bank).round
+    it_behaves_like "rounding"
 
-        expect(rounded.bank).to eq(bank)
+    it 'preserves assigned bank' do
+      bank = Money::Bank::VariableExchange.new
+      rounded = Money.new(1_00, 'USD', bank).round
+
+      expect(rounded.bank).to eq(bank)
+    end
+
+    context "without infinite_precision" do
+      it "returns a different money" do
+        expect(rounded).not_to be money
       end
 
-      context "without infinite_precision" do
-        it "returns a different money" do
-          expect(rounded).not_to be money
-        end
-
-        it "uses a provided rounding strategy" do
-          rounded = money.round(BigDecimal::ROUND_DOWN)
-          expect(rounded.cents).to eq 15
-        end
-
-        it "does not accumulate rounding error" do
-          money_1 = Money.new(10.9).round(BigDecimal::ROUND_DOWN)
-          money_2 = Money.new(10.9).round(BigDecimal::ROUND_DOWN)
-
-          expect(money_1 + money_2).to eq(Money.new(20))
-        end
+      it "uses a provided rounding strategy" do
+        rounded = money.round(BigDecimal::ROUND_DOWN)
+        expect(rounded.cents).to eq 15
       end
 
-      context "with infinite_precision", :infinite_precision do
-        it "uses a provided rounding strategy" do
-          rounded = money.round(BigDecimal::ROUND_DOWN)
-          expect(rounded.cents).to eq 15
-        end
+      it "does not accumulate rounding error" do
+        money_1 = Money.new(10.9).round(BigDecimal::ROUND_DOWN)
+        money_2 = Money.new(10.9).round(BigDecimal::ROUND_DOWN)
 
-        context "when using a specific rounding precision" do
-          let(:money) { Money.new(15.7526, 'NZD') }
+        expect(money_1 + money_2).to eq(Money.new(20))
+      end
+    end
 
-          it "uses the provided rounding precision" do
-            rounded = money.round(BigDecimal::ROUND_DOWN, 3)
-            expect(rounded.fractional).to eq 15.752
-          end
+    context "with infinite_precision", :infinite_precision do
+      it "uses a provided rounding strategy" do
+        rounded = money.round(BigDecimal::ROUND_DOWN)
+        expect(rounded.cents).to eq 15
+      end
+
+      context "when using a specific rounding precision" do
+        let(:money) { Money.new(15.7526, 'NZD') }
+
+        it "uses the provided rounding precision" do
+          rounded = money.round(BigDecimal::ROUND_DOWN, 3)
+          expect(rounded.fractional).to eq 15.752
         end
       end
     end
   end
 
   describe "#to_rounding" do
-    it_behaves_like "rounding" do
-      subject(:rounded) { money.to_rounding }
+    let(:money) { Money.new(15.75, 'NZD') }
+    subject(:rounded) { money.to_rounding }
 
-      context "without infinite_precision" do
-        it "returns the same money (self)" do
-          expect(rounded).to be money
-        end
+    it_behaves_like "rounding"
 
-        it 'returns "non-precise" money' do
-          expect(rounded.infinite_precision?).to be false
-        end
+    context "without infinite_precision" do
+      it "returns the same money (self)" do
+        expect(rounded).to be money
       end
 
-      context "with infinite_precision", :infinite_precision do
-        it "returns a different money" do
-          expect(rounded).not_to be money
-        end
+      it 'returns "non-precise" money' do
+        expect(rounded.infinite_precision?).to be false
+      end
+    end
 
-        it 'returns "non-precise" money' do
-          expect(money.infinite_precision?).to be true
-          expect(rounded.infinite_precision?).to be false
-        end
+    context "with infinite_precision", :infinite_precision do
+      it "returns a different money" do
+        expect(rounded).not_to be money
+      end
+
+      it 'returns "non-precise" money' do
+        expect(money.infinite_precision?).to be true
+        expect(rounded.infinite_precision?).to be false
       end
     end
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -299,7 +299,7 @@ YAML
         expect(m.fractional).to be_a(Integer)
       end
 
-      it "it respects the object's infinite_precision setting" do
+      it "respects the object's infinite_precision setting" do
         money = YAML::load serialized.sub(
           'infinite_precision: false', 'infinite_precision: true'
         )

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -106,13 +106,22 @@ describe Money do
       end
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       context 'given the initializing value is 1.50' do
         let(:initializing_value) { 1.50 }
 
         it "should have the correct cents" do
           expect(money.cents).to eq BigDecimal('1.50')
         end
+      end
+    end
+
+    context "with infinite_precision on the instance only" do
+      let(:initializing_value) { 1.50 }
+      subject(:money) { Money.new(initializing_value, nil, nil, true) }
+
+      it "should have the correct cents" do
+        expect(money.cents).to eq BigDecimal('1.50')
       end
     end
   end
@@ -173,11 +182,20 @@ describe Money do
       expect(Money.from_amount(555.5, "JPY").amount).to eq "556".to_d
     end
 
-    it "does not round the given amount when infinite_precision is set", :infinite_precision do
+    it  "does not round the given amount when infinite_precision is set",
+        :default_infinite_precision_true do
       expect(Money.from_amount(4.444, "USD").amount).to eq "4.444".to_d
       expect(Money.from_amount(5.555, "USD").amount).to eq "5.555".to_d
       expect(Money.from_amount(444.4, "JPY").amount).to eq "444.4".to_d
       expect(Money.from_amount(555.5, "JPY").amount).to eq "555.5".to_d
+    end
+
+    it  "does not round the given amount when infinite_precision is set " \
+        "on the instance" do
+      expect(Money.from_amount(4.444, "USD", nil, true).amount).to eq "4.444".to_d
+      expect(Money.from_amount(5.555, "USD", nil, true).amount).to eq "5.555".to_d
+      expect(Money.from_amount(444.4, "JPY", nil, true).amount).to eq "444.4".to_d
+      expect(Money.from_amount(555.5, "JPY", nil, true).amount).to eq "555.5".to_d
     end
 
     it "accepts an optional currency" do
@@ -275,15 +293,17 @@ YAML
       it "uses BigDecimal when rounding" do
         m = YAML::load serialized
         expect(m).to be_a(Money)
-        expect(m.class.infinite_precision).to be false
+        expect(m.class.default_infinite_precision).to be false
+        expect(m.infinite_precision?).to be false
         expect(m.fractional).to eq 250 # 249.5 rounded up
         expect(m.fractional).to be_a(Integer)
       end
 
-      it "is a BigDecimal when using infinite_precision", :infinite_precision do
+      it "it respects the object's infinite_precision setting" do
         money = YAML::load serialized.sub(
           'infinite_precision: false', 'infinite_precision: true'
         )
+        expect(money.infinite_precision?).to be true
         expect(money.fractional).to be_a BigDecimal
       end
     end
@@ -328,7 +348,7 @@ YAML
       end
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       it "returns the amount in fractional unit" do
         expect(Money.new(1_00).fractional).to eq BigDecimal("100")
       end
@@ -403,14 +423,30 @@ YAML
       expect {money.round_to_nearest_cash_value}.to raise_error(Money::UndefinedSmallestDenomination)
     end
 
-    it "returns a Integer when infinite_precision is not set" do
-      money = Money.new(100, "USD")
-      expect(money.round_to_nearest_cash_value).to be_a Integer
+    context "when infinite_precision is not set globally",
+            :default_infinite_precision_false do
+      it "returns an Integer" do
+        money = Money.new(100, "USD")
+        expect(money.round_to_nearest_cash_value).to be_a Integer
+      end
+
+      it "returns a BigDecimal when infinite_precision is set on instance" do
+        money = Money.new(100, "EUR", nil, true)
+        expect(money.round_to_nearest_cash_value).to be_a BigDecimal
+      end
     end
 
-    it "returns a BigDecimal when infinite_precision is set", :infinite_precision do
-      money = Money.new(100, "EUR")
-      expect(money.round_to_nearest_cash_value).to be_a BigDecimal
+    context "when infinite_precision is set globally",
+            :default_infinite_precision_true do
+      it "returns a BigDecimal"do
+        money = Money.new(100, "EUR")
+        expect(money.round_to_nearest_cash_value).to be_a BigDecimal
+      end
+
+      it "returns an Integer when infinite_precision is set to false on instance" do
+        money = Money.new(100, "EUR", nil, false)
+        expect(money.round_to_nearest_cash_value).to be_a Integer
+      end
     end
   end
 
@@ -544,7 +580,7 @@ YAML
       end
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       it "shows fractional cents" do
         expect(Money.new(1.05, "USD").to_s).to eq "0.0105"
       end
@@ -729,7 +765,7 @@ YAML
       expect(special_money_class.new(005).allocate([1]).first).to be_a special_money_class
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       it "allows for fractional cents allocation" do
         moneys = Money.new(100).allocate([1, 1, 1])
         expect(moneys.inject(0, :+)).to eq(Money.new(100))
@@ -767,7 +803,7 @@ YAML
       expect(special_money_class.new(10_00).split(1).first).to be_a special_money_class
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       it "allows for splitting by fractional cents" do
         moneys = Money.new(100).split(3)
         expect(moneys.inject(0, :+)).to eq(Money.new(100))
@@ -788,7 +824,7 @@ YAML
       end
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       it "returns a different money" do
         expect(rounded).not_to be money
       end
@@ -843,7 +879,7 @@ YAML
       end
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       it "uses a provided rounding strategy" do
         rounded = money.round(BigDecimal::ROUND_DOWN)
         expect(rounded.cents).to eq 15
@@ -876,7 +912,7 @@ YAML
       end
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       it "returns a different money" do
         expect(rounded).not_to be money
       end
@@ -919,7 +955,7 @@ YAML
       end
     end
 
-    context "with infinite_precision", :infinite_precision do
+    context "with infinite_precision", :default_infinite_precision_true do
       it "returns the same money (self)" do
         expect(converted).to be money
       end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -943,18 +943,6 @@ YAML
       Subclass = Class.new(Money)
       expect(Subclass.new(1).inspect).to start_with '#<Subclass'
     end
-
-    context "without infinite_precision" do
-      it "does not mention precision" do
-        expect(Money.new(1).inspect).not_to include "precision"
-      end
-    end
-
-    context "with infinite_precision", :infinite_precision do
-      it "reports `with_infinite_precision`" do
-        expect(Money.new(1).inspect).to end_with "with_infinite_precision>"
-      end
-    end
   end
 
   describe "#as_*" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,12 +19,26 @@ def reset_i18n
   I18n.backend = I18n::Backend::Simple.new
 end
 
-RSpec.shared_context "with infinite precision", :infinite_precision do
+RSpec.shared_context  "with infinite precision set as default",
+                      :default_infinite_precision_true do
   before do
-    Money.infinite_precision = true
+    @previous_infinite_precision = Money.default_infinite_precision
+    Money.default_infinite_precision = true
   end
 
   after do
-    Money.infinite_precision = false
+    Money.default_infinite_precision = @previous_infinite_precision
+  end
+end
+
+RSpec.shared_context  "with infinite precision not set as default",
+                      :default_infinite_precision_false do
+  before do
+    @previous_infinite_precision = Money.default_infinite_precision
+    Money.default_infinite_precision = false
+  end
+
+  after do
+    Money.default_infinite_precision = @previous_infinite_precision
   end
 end


### PR DESCRIPTION
This PR should address the following:
* Updates Money constructor to accept an options hash
* Adds `Money.infinite_precision` accessor aliases for backwards compatibility
* When arithmetic is performed between two Money objects preserves the highest precision

**Note**: It is probably easiest to review this PR commit by commit.

Let me know if I anything needs cleanup or if I missed anything.