### PR TITLE
Allow passing custom store as a string to Money::Bank::VariableExchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@ end
 Now you can use it with the default bank.
 
 ```ruby
+# For Rails 6 pass model name as a string to make it compatible with zeitwerk
+# Money.default_bank = Money::Bank::VariableExchange.new("ExchangeRate")
 Money.default_bank = Money::Bank::VariableExchange.new(ExchangeRate)
 
 # Add to the underlying store

--- a/lib/money/bank/variable_exchange.rb
+++ b/lib/money/bank/variable_exchange.rb
@@ -42,7 +42,7 @@ class Money
     #   bank.get_rate 'USD', 'CAD'
     class VariableExchange < Base
 
-      attr_reader :mutex, :store
+      attr_reader :mutex
 
       # Available formats for importing/exporting rates.
       RATE_FORMATS = [:json, :ruby, :yaml].freeze
@@ -59,6 +59,10 @@ class Money
       def initialize(st = Money::RatesStore::Memory.new, &block)
         @store = st
         super(&block)
+      end
+
+      def store
+        @store.is_a?(String) ? Object.const_get(@store) : @store
       end
 
       def marshal_dump

--- a/spec/bank/variable_exchange_spec.rb
+++ b/spec/bank/variable_exchange_spec.rb
@@ -20,10 +20,14 @@ describe Money::Bank::VariableExchange do
       describe 'custom store' do
         let(:custom_store) { Object.new }
 
-        let(:bank) { described_class.new(custom_store) }
-
         it 'sets #store to be custom store' do
+          bank = described_class.new(custom_store)
           expect(bank.store).to eql(custom_store)
+        end
+
+        it 'allows passing custom store as a string' do
+          bank = described_class.new('Object')
+          expect(bank.store).to eql(Object)
         end
       end
 


### PR DESCRIPTION
In Rails 6.0 zeitwerk is used as default class loader. It's not allowing using classes from `app` directory in initializers:
```
DEPRECATION WARNING: Initialization autoloaded the constants ExchangeRate

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ExchangeRate, for example,
the expected changes won't be reflected in that stale Class object.

These autoloaded constants have been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
```

To workaround that I added the ability to pass custom store as a string and load the actual class (like `ExchangeRate` model) only when store methods were called.