### PR TITLE
Make all strings frozen with frozen_string_literal: true pragma

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,6 +49,7 @@ Ingo Wichmann
 Jacob Atzen
 James Cotterill
 James Hunt
+Jan Klimo
 Jean-Louis Giordano
 Jean-Philippe Doyle
 Jell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.0.0
+- Add `frozen_string_literal: true` pragma comment.
+
 ## 6.13.4
 - Update currency config for Zambian Kwacha (ZMW)
 - Do not modify options passed to FormattingRules

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'coveralls', '>= 0.8.17', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rake/clean"
 require "rspec/core/rake_task"

--- a/lib/money.rb
+++ b/lib/money.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bigdecimal"
 require "bigdecimal/util"
 require "set"

--- a/lib/money/bank/base.rb
+++ b/lib/money/bank/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   # Provides classes that aid in the ability of exchange one currency with
   # another.

--- a/lib/money/bank/single_currency.rb
+++ b/lib/money/bank/single_currency.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/bank/base'
 
 class Money

--- a/lib/money/bank/variable_exchange.rb
+++ b/lib/money/bank/variable_exchange.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/bank/base'
 require 'money/rates_store/memory'
 require 'json'

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 require "json"
 require "money/currency/loader"

--- a/lib/money/currency/heuristics.rb
+++ b/lib/money/currency/heuristics.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 class Money
   class Currency

--- a/lib/money/currency/loader.rb
+++ b/lib/money/currency/loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   class Currency
     module Loader

--- a/lib/money/locale_backend/base.rb
+++ b/lib/money/locale_backend/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/locale_backend/errors'
 
 class Money

--- a/lib/money/locale_backend/currency.rb
+++ b/lib/money/locale_backend/currency.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/locale_backend/base'
 
 class Money

--- a/lib/money/locale_backend/errors.rb
+++ b/lib/money/locale_backend/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   module LocaleBackend
     class NotSupported < StandardError; end

--- a/lib/money/locale_backend/i18n.rb
+++ b/lib/money/locale_backend/i18n.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/locale_backend/base'
 
 class Money

--- a/lib/money/locale_backend/legacy.rb
+++ b/lib/money/locale_backend/legacy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/locale_backend/base'
 require 'money/locale_backend/i18n'
 

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -1,4 +1,5 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 require "money/bank/variable_exchange"
 require "money/bank/single_currency"
 require "money/money/arithmetic"

--- a/lib/money/money/allocation.rb
+++ b/lib/money/money/allocation.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 class Money
   class Allocation

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   module Arithmetic
     # Wrapper for coerced numeric values to distinguish

--- a/lib/money/money/constructors.rb
+++ b/lib/money/money/constructors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   module Constructors
 

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -1,4 +1,5 @@
-# encoding: UTF-8
+# frozen_string_literal: true
+
 require 'money/money/formatting_rules'
 
 class Money

--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 
 class Money
   class FormattingRules

--- a/lib/money/money/locale_backend.rb
+++ b/lib/money/money/locale_backend.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 
 require 'money/locale_backend/errors'
 require 'money/locale_backend/legacy'

--- a/lib/money/rates_store/memory.rb
+++ b/lib/money/rates_store/memory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   module RatesStore
 
@@ -91,7 +93,7 @@ class Money
         enum = Enumerator.new do |yielder|
           index.each do |key, rate|
             iso_from, iso_to = key.split(INDEX_KEY_SEPARATOR)
-            yielder.yield iso_from, iso_to, rate                  
+            yielder.yield iso_from, iso_to, rate
           end
         end
 

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   VERSION = '6.13.4'
 end

--- a/money.gemspec
+++ b/money.gemspec
@@ -1,4 +1,5 @@
-# -*- encoding: utf-8 -*-
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "money/version"

--- a/spec/bank/base_spec.rb
+++ b/spec/bank/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::Bank::Base do
 
   describe ".instance" do

--- a/spec/bank/single_currency_spec.rb
+++ b/spec/bank/single_currency_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::Bank::SingleCurrency do
   describe "#exchange_with" do
     it "raises when called" do

--- a/spec/bank/variable_exchange_spec.rb
+++ b/spec/bank/variable_exchange_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'yaml'
 

--- a/spec/currency/heuristics_spec.rb
+++ b/spec/currency/heuristics_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 describe Money::Currency::Heuristics do
   describe "#analyze_string" do

--- a/spec/currency/loader_spec.rb
+++ b/spec/currency/loader_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 describe Money::Currency::Loader do
   it "returns a currency table hash" do

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 describe Money::Currency do
   FOO = '{ "priority": 1, "iso_code": "FOO", "iso_numeric": "840", "name": "United States Dollar", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 1000, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "smallest_denomination": 1 }'

--- a/spec/locale_backend/currency_spec.rb
+++ b/spec/locale_backend/currency_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 describe Money::LocaleBackend::Currency do
   describe '#lookup' do

--- a/spec/locale_backend/i18n_spec.rb
+++ b/spec/locale_backend/i18n_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 describe Money::LocaleBackend::I18n do
   describe '#initialize' do

--- a/spec/locale_backend/legacy_spec.rb
+++ b/spec/locale_backend/legacy_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 describe Money::LocaleBackend::Legacy do
   after { Money.use_i18n = true }

--- a/spec/money/allocation_spec.rb
+++ b/spec/money/allocation_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 describe Money::Allocation do
   describe 'given number as argument' do

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 describe Money::Arithmetic do
   describe "-@" do

--- a/spec/money/constructors_spec.rb
+++ b/spec/money/constructors_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 describe Money::Constructors do
 

--- a/spec/money/formatting_rules_spec.rb
+++ b/spec/money/formatting_rules_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 describe Money::FormattingRules do
   it 'does not modify frozen rules in place' do

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 describe Money, "formatting" do
 

--- a/spec/money/locale_backend_spec.rb
+++ b/spec/money/locale_backend_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 describe Money::LocaleBackend do
   describe '.find' do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 describe Money do
   describe '.locale_backend' do

--- a/spec/rates_store/memory_spec.rb
+++ b/spec/rates_store/memory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::RatesStore::Memory do
   let(:subject) { described_class.new }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "coveralls"
 Coveralls.wear!
 

--- a/spec/support/shared_examples/money_examples.rb
+++ b/spec/support/shared_examples/money_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples 'instance with custom bank' do |operation, value|
   let(:custom_bank) { Money::Bank::VariableExchange.new }
   let(:instance) { Money.new(1, :usd, custom_bank) }


### PR DESCRIPTION
#### Changes

1. Include `frozen_string_literal: true` magic comment on top of each file.
1. Drop comments specifying encoding. `UTF8` has been the default since Ruby 2.0. I can see the current master still supporting `1.9.3` so this should go into `v7` that seems to be dropping support for older rubies. 