### PR TITLE
Support systems in which subunit_to_unit ratio is always 100

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -34,6 +34,41 @@ class Money
     fractional
   end
 
+  # Convenience method for fractional part of the amount
+  # designed for use cases in which subunit to unit ratio
+  # is assumed to be 100 for all currencies.
+  #
+  # @return [Integer] when infinite_precision is false
+  # @return [BigDecimal] when infinite_precision is true
+  #
+  # @see infinite_precision
+  #
+  # @example Behavior when subunit to unit ratio is 100
+  #   Money.new(100, 'EUR').currency.subunit_to_unit
+  #   => 100
+  #   Money.new(100, 'EUR').format
+  #   => "€1,00"
+  #   Money.new(100, 'EUR').cents
+  #   => 100
+  #   Money.new(100, 'EUR').hundredth_parts
+  #   => 100
+  #
+  # @example Behavior when subunit to unit ratio is 1
+  #   Money.new(100, 'JPY').currency.subunit_to_unit
+  #   => 1
+  #   Money.new(100, 'JPY').format
+  #   => "¥100"
+  #   Money.new(100, 'JPY').cents
+  #   => 100
+  #   Money.new(100, 'JPY').hundredth_parts
+  #   => 10000
+  #
+  def hundredth_parts
+    return cents if currency.subunit_to_unit == 100
+
+    (self * 100 / currency.subunit_to_unit).cents
+  end
+
   # The value of the monetary amount represented in the fractional or subunit
   # of the currency.
   #

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -236,6 +236,26 @@ describe Money do
     end
   end
 
+  describe "#hundredth_parts" do
+    context "when subunit_to_unit ratio is 100" do
+      it "returns the same value as #cents" do
+        expect(Money.new(100, "EUR").hundredth_parts).to be 100
+      end
+    end
+
+    context "when subunit_to_unit ratio is 1000" do
+      it "returns a tenth of the value of #cents" do
+        expect(Money.new(100, "BHD").hundredth_parts).to be 10
+      end
+    end
+
+    context "when subunit_to_unit ratio is 1" do
+      it "returns 100 times the value of #cents" do
+        expect(Money.new(100, "JPY").hundredth_parts).to be 10_000
+      end
+    end
+  end
+
   describe "#fractional" do
     it "returns the amount in fractional unit" do
       expect(Money.new(1_00).fractional).to eq 1_00


### PR DESCRIPTION
Some systems are set up in a way where the assume that #cents
will always return 100 times the value displayed by #format.
This is only the case for currencies with subunit_to_unit ratio 100.

In order to cater to the needs of those systems without altering
the behavior of the gem we introduce a convience method which
anihilates the effect of subunit_to_unit ratio.