### PR TITLE
Potential fix for #897. Use monitor for recursive mutual exclusion.

### DIFF
--- a/spec/bank/variable_exchange_spec.rb
+++ b/spec/bank/variable_exchange_spec.rb
@@ -149,7 +149,7 @@ describe Money::Bank::VariableExchange do
 
     it "delegates options to store, options are a no-op" do
       expect(subject.store).to receive(:get_rate).with('USD', 'EUR')
-      subject.get_rate('USD', 'EUR', without_mutex: true)
+      subject.get_rate('USD', 'EUR')
     end
   end
 

--- a/spec/rates_store/memory_spec.rb
+++ b/spec/rates_store/memory_spec.rb
@@ -10,17 +10,8 @@ describe Money::RatesStore::Memory do
 
   describe 'add_rate' do
     it "uses a mutex by default" do
-      expect(subject.instance_variable_get(:@mutex)).to receive(:synchronize)
+      expect(subject.instance_variable_get(:@guard)).to receive(:synchronize)
       subject.add_rate('USD', 'EUR', 1.25)
-    end
-
-    context ':without_mutex' do
-      let(:subject) { Money::RatesStore::Memory.new(without_mutex: true) }
-
-      it "doesn't use mutex if requested not to" do
-        expect(subject.instance_variable_get(:@mutex)).not_to receive(:synchronize)
-        subject.add_rate('USD', 'EUR', 1.25)
-      end
     end
   end
 
@@ -44,7 +35,7 @@ describe Money::RatesStore::Memory do
   describe '#transaction' do
     context 'mutex' do
       it 'uses mutex' do
-        expect(subject.instance_variable_get('@mutex')).to receive(:synchronize)
+        expect(subject.instance_variable_get('@guard')).to receive(:synchronize)
         subject.transaction{ 1 + 1 }
       end
 
@@ -54,15 +45,6 @@ describe Money::RatesStore::Memory do
             subject.add_rate('USD', 'CAD', 1)
           end
         }.not_to raise_error
-      end
-    end
-
-    context 'no mutex' do
-      let(:subject) { Money::RatesStore::Memory.new(without_mutex: true) }
-
-      it 'does not use mutex' do
-        expect(subject.instance_variable_get('@mutex')).not_to receive(:synchronize)
-        subject.transaction{ 1 + 1 }
       end
     end
   end


### PR DESCRIPTION
Remove without_mutex option as it's now irrelevant.