### PR TITLE
Only warn once if defaults are not explicitly set

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -134,6 +134,7 @@ class Money
     if @using_deprecated_default_currency
       warn '[WARNING] The default currency will change to `nil` in the next major release. Make ' \
            'sure to set it explicitly using `Money.default_currency=` to avoid potential issues'
+      @using_deprecated_default_currency = false
     end
 
     if @default_currency.respond_to?(:call)
@@ -215,6 +216,7 @@ class Money
     if @using_deprecated_default_rounding_mode
       warn '[WARNING] The default rounding mode will change to `ROUND_HALF_UP` in the next major ' \
            'release. Set it explicitly using `Money.rounding_mode=` to avoid potential problems.'
+      @using_deprecated_default_rounding_mode = false
     end
 
     @rounding_mode

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -884,6 +884,7 @@ YAML
   end
 
   describe ".default_currency" do
+    before { Money.setup_defaults }
     after { Money.setup_defaults }
 
     it "accepts a lambda" do
@@ -914,6 +915,7 @@ YAML
   end
 
   describe ".rounding_mode" do
+    before { Money.setup_defaults }
     after { Money.setup_defaults }
 
     it 'warns about changing default rounding_mode value' do


### PR DESCRIPTION
👋 Hi, so hear me out -- these warnings are useful, but not at the frequency that #882 and #883 ended up causing.

For an application that makes sufficient usage of `Money`, these changes essentially cause a flood of `[WARNING]` logs (like, potentially in the millions, because they log on _each getter call_) which could cause all sorts of problems -- filling disks, flooding sockets, taking entire systems down, and potentially costing a lot of real world $$$ to the myriad of gem consumers.

I did a little digging and I understand how, when `set_defaults` gets triggered, there is no way to know for sure whether the consumer will eventually configure these on their own. But my thought is that by the time the getters are being called, the consumers should've manually configured, and so outputting the `[WARNING]` once feels okay. At the very least, without some kind of throttling mechanism, it's definitely a lot less of a surprise to spring on consumers of this gem.

Does that make sense?