### PR TITLE
Fixes to the Money class docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 - Wrap all amount parts when `:html_wrap` option is used
 - Deprecate `#currency_as_string` and `#currency_as_string=` (in favour of `#with_currency`)
 - Add `#with_currency` for swapping the currency
-- Rewrite allocate/split (fixing some penny loosing issues)
+- Rewrite allocate/split (fixing some penny losing issues)
 
 ## 6.11.3
 - Fix regression: if enabled use i18n locales in Money#to_s
@@ -76,7 +76,7 @@
 - Added new symbol for bitcoin denomination
 - Specify custom rounding precision when using `infinite_precision`
 - Allow splits with sums greater than 1
-- Prevent arithmetic methods from loosing reference to the bank
+- Prevent arithmetic methods from losing reference to the bank
 - Fix coerced zero numeric subtraction
 - Fix south asian formatting to support whole numbers
 - Refactor formatting logic

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -579,7 +579,7 @@ class Money
 
   # Creates a formatted price string according to several rules.
   #
-  # @param [Hash] See Money::Formatter for the list of formatting options
+  # @param [Hash] rules See {Money::Formatter Money::Formatter} for the list of formatting options
   #
   # @return [String]
   #

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -91,17 +91,21 @@ class Money
   class << self
 
     # @!attribute [rw] default_bank
-    #   @return [Money::Bank::Base] Each Money object is associated with a bank
-    #     object, which is responsible for currency exchange. This property
-    #     allows you to specify the default bank object. The default value for
-    #     this property is an instance of +Bank::VariableExchange.+ It allows
-    #     one to specify custom exchange rates.
+    #   Used to set a default bank for currency exchange.
+    #
+    #   Each Money object is associated with a bank
+    #   object, which is responsible for currency exchange. This property
+    #   allows you to specify the default bank object. The default value for
+    #   this property is an instance of +Bank::VariableExchange.+ It allows
+    #   one to specify custom exchange rates.
+    #
+    #   @return [Money::Bank::Base]
     #
     # @!attribute default_formatting_rules
-    #   @return [Hash] Use this to define a default hash of rules for every time
-    #     +Money#format+ is called.  Rules provided on method call will be
-    #     merged with the default ones.  To overwrite a rule, just provide the
-    #     intended value while calling +format+.
+    #   Used to define a default hash of rules for every time
+    #   +Money#format+ is called.  Rules provided on method call will be
+    #   merged with the default ones.  To overwrite a rule, just provide the
+    #   intended value while calling +format+.
     #
     #   @see Money::Formatter#initialize Money::Formatter for more details
     #
@@ -110,16 +114,22 @@ class Money
     #     Money.new(0, "USD").format                          # => "free"
     #     Money.new(0, "USD").format(display_free: false)  # => "$0.00"
     #
+    #   @return [Hash]
+    #
     # @!attribute [rw] use_i18n
-    #   @return [Boolean] Use this to disable i18n even if it's used by other
-    #     objects in your app.
+    #   Used to disable i18n even if it's used by other components of your app.
+    #
+    #   @return [Boolean]
     #
     # @!attribute [rw] infinite_precision
-    #   @return [Boolean] Use this to enable infinite precision cents
+    #   Used to enable infinite precision cents
+    #
+    #   @return [Boolean]
     #
     # @!attribute [rw] conversion_precision
-    #   @return [Integer] Use this to specify precision for converting Rational
-    #     to BigDecimal
+    #   Used to specify precision for converting Rational to BigDecimal
+    #
+    #   @return [Integer]
     attr_accessor :default_bank, :default_formatting_rules,
       :use_i18n, :infinite_precision, :conversion_precision,
       :locale_backend

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -103,7 +103,7 @@ class Money
     #     merged with the default ones.  To overwrite a rule, just provide the
     #     intended value while calling +format+.
     #
-    #   @see +Money::Formatting#format+ for more details.
+    #   @see Money::Formatter#initialize Money::Formatter for more details
     #
     #   @example
     #     Money.default_formatting_rules = { display_free: true }

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -91,7 +91,7 @@ class Money
   class << self
 
     # @!attribute [rw] default_bank
-    #   @return [Money::Bank::Base] Each Money object is associated to a bank
+    #   @return [Money::Bank::Base] Each Money object is associated with a bank
     #     object, which is responsible for currency exchange. This property
     #     allows you to specify the default bank object. The default value for
     #     this property is an instance of +Bank::VariableExchange.+ It allows
@@ -533,13 +533,15 @@ class Money
     exchange_to("EUR")
   end
 
-  # Splits a given amount in parts without loosing pennies. The left-over pennies will be
-  # distributed round-robin amongst the parties. This means that parties listed first will likely
-  # receive more pennies than ones that are listed later.
+  # Splits a given amount in parts without losing pennies. The left-over pennies will be
+  # distributed round-robin amongst the parties. This means that parts listed first will likely
+  # receive more pennies than ones listed later.
   #
-  # @param [Array<Numeric>, Numeric] pass [2, 1, 1] to give twice as much to party1 as party2 or
-  # party3 which results in 50% of the cash to party1, 25% to party2, and 25% to party3. Passing a
-  # number instead of an array will split the amount evenly (without loosing pennies when rounding).
+  # Pass [2, 1, 1] as input to give twice as much to part1 as part2 or
+  # part3 which results in 50% of the cash to party1, 25% to part2, and 25% to part3. Passing a
+  # number instead of an array will split the amount evenly (without losing pennies when rounding).
+  #
+  # @param [Array<Numeric>, Numeric] parts how amount should be distributed to parts
   #
   # @return [Array<Money>]
   #

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -232,12 +232,14 @@ class Money
     @rounding_mode
   end
 
-  # This method temporarily changes the rounding mode. It will then return the
-  # results of the block instead.
+  # Temporarily changes the rounding mode in a given block.
   #
   # @param [BigDecimal::ROUND_MODE] mode
   #
-  # @return [BigDecimal::ROUND_MODE,Yield] block results
+  # @yield The block within which rounding mode will be changed. Its return
+  #   value will also be the return value of the whole method.
+  #
+  # @return [Object] block results
   #
   # @example
   #   fee = Money.with_rounding_mode(BigDecimal::ROUND_HALF_UP) do

--- a/lib/money/money/allocation.rb
+++ b/lib/money/money/allocation.rb
@@ -2,9 +2,9 @@
 
 class Money
   class Allocation
-    # Splits a given amount in parts without loosing pennies.
-    # The left-over pennies will be distributed round-robin amongst the parties. This means that
-    # parties listed first will likely receive more pennies than ones that are listed later.
+    # Splits a given amount in parts without losing pennies.
+    # The left-over pennies will be distributed round-robin amongst the parts. This means that
+    # parts listed first will likely receive more pennies than the ones listed later.
     #
     # The results should always add up to the original amount.
     #

--- a/spec/bank/variable_exchange_spec.rb
+++ b/spec/bank/variable_exchange_spec.rb
@@ -78,7 +78,7 @@ describe Money::Bank::VariableExchange do
           expect(bank.exchange_with(special_money_class.new(100, 'USD'), 'EUR')).to be_a special_money_class
         end
 
-        it "doesn't loose precision when handling larger amounts" do
+        it "doesn't lose precision when handling larger amounts" do
           expect(bank.exchange_with(Money.new(100_000_000_000_000_01, 'USD'), 'EUR')).to eq Money.new(133_000_000_000_000_01, 'EUR')
         end
       end

--- a/spec/money/allocation_spec.rb
+++ b/spec/money/allocation_spec.rb
@@ -18,7 +18,7 @@ describe Money::Allocation do
         expect(described_class.generate(100, 5)).to eq([20, 20, 20, 20, 20])
       end
 
-      it 'does not loose pennies' do
+      it 'does not lose pennies' do
         expect(described_class.generate(5, 2)).to eq([3, 2])
         expect(described_class.generate(2, 3)).to eq([1, 1, 0])
         expect(described_class.generate(100, 3)).to eq([34, 33, 33])
@@ -83,7 +83,7 @@ describe Money::Allocation do
         expect(described_class.generate(10, [0.1, 0.2, 0.1])).to eq([3, 5, 2])
       end
 
-      it 'does not loose pennies' do
+      it 'does not lose pennies' do
         expect(described_class.generate(10, [1, 1, 2])).to eq([3, 2, 5])
         expect(described_class.generate(100, [1, 1, 1])).to eq([34, 33, 33])
       end


### PR DESCRIPTION
I've been going throug the docs and I noticed few issue with them (wrong YARD formatting, wording, typos). Here is a PR with some fixes, mostly for methods I did look up.