### PR TITLE
Rounding Documentation Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Money.new(2.34567).round.format #=> "$0.02"
 Money.new(2.34567).round(BigDecimal::ROUND_HALF_UP, 2).format #=> "$0.0235"
 ```
 
-You can set the default rounding method by passing one the `BigDecimal` mode enumerables like so:
+You can set the default rounding mode by passing one of the `BigDecimal` mode enumerables like so:
 ```ruby
 Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN
 ```

--- a/README.md
+++ b/README.md
@@ -423,6 +423,13 @@ Money.new(2.34567).round.format #=> "$0.02"
 Money.new(2.34567).round(BigDecimal::ROUND_HALF_UP, 2).format #=> "$0.0235"
 ```
 
+You can set the default rounding method by passing one the `BigDecimal` mode enumerables like so:
+```ruby
+Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN
+```
+See [BigDecimal::ROUND_MODE](https://ruby-doc.org/stdlib-2.5.1/libdoc/bigdecimal/rdoc/BigDecimal.html#ROUND_MODE) for more information
+
+
 ## Ruby on Rails
 
 To integrate money in a Rails application use [money-rails](https://github.com/RubyMoney/money-rails).


### PR DESCRIPTION
### Why
Based on the recently introduced warning about the default rounding method changing I endeavoured to provide this value in my initializer. Doing so proved a little confusing as there was no mention of what values were expected and I had to dig through the initial PR (https://github.com/RubyMoney/money/pull/883) to figure it out.

### What
I've added a short snippet to the documentation about how to set the round_mode and what values are expected. This includes a link to the `BigDecimal` documentation that outlines the possible values.
