### PR TITLE
Updates symbol for Central African Franc

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -2336,7 +2336,7 @@
     "priority": 100,
     "iso_code": "XAF",
     "name": "Central African Cfa Franc",
-    "symbol": "Fr",
+    "symbol": "CFA",
     "disambiguate_symbol": "FCFA",
     "alternate_symbols": ["FCFA"],
     "subunit": "Centime",


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/West_African_CFA_franc, symbol is `CFA` rather than `FR`