### PR TITLE
Infinite precision instance

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -669,6 +669,10 @@ class Money
 
   private
 
+  def highest_precision(other)
+    infinite_precision? || other.infinite_precision?
+  end
+
   def as_d(num)
     if num.respond_to?(:to_d)
       num.is_a?(Rational) ? num.to_d(self.class.conversion_precision) : num.to_d

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -137,7 +137,8 @@ class Money
         when Money
           other = other.exchange_to(currency)
           new_fractional = fractional.public_send(op, other.fractional)
-          dup_with(fractional: new_fractional)
+          infinite_precision = self.infinite_precision? || other.infinite_precision?
+          dup_with(fractional: new_fractional, infinite_precision: infinite_precision)
         when CoercedNumeric
           raise TypeError, non_zero_message.call(other.value) unless other.zero?
           dup_with(fractional: other.value.public_send(op, fractional))
@@ -231,7 +232,8 @@ class Money
     def divmod_money(val)
       cents = val.exchange_to(currency).cents
       quotient, remainder = fractional.divmod(cents)
-      [quotient, dup_with(fractional: remainder)]
+      infinite_precision = self.infinite_precision? || val.infinite_precision?
+      [quotient, dup_with(fractional: remainder, infinite_precision: infinite_precision)]
     end
     private :divmod_money
 

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -137,7 +137,7 @@ class Money
         when Money
           other = other.exchange_to(currency)
           new_fractional = fractional.public_send(op, other.fractional)
-          infinite_precision = self.infinite_precision? || other.infinite_precision?
+          infinite_precision = highest_precision(other)
           dup_with(fractional: new_fractional, infinite_precision: infinite_precision)
         when CoercedNumeric
           raise TypeError, non_zero_message.call(other.value) unless other.zero?
@@ -232,7 +232,7 @@ class Money
     def divmod_money(val)
       cents = val.exchange_to(currency).cents
       quotient, remainder = fractional.divmod(cents)
-      infinite_precision = self.infinite_precision? || val.infinite_precision?
+      infinite_precision = highest_precision(val)
       [quotient, dup_with(fractional: remainder, infinite_precision: infinite_precision)]
     end
     private :divmod_money

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -347,7 +347,7 @@ class Money
     end
 
     def format_decimal_part(value)
-      return nil if currency.decimal_places == 0 && !Money.infinite_precision
+      return nil if currency.decimal_places == 0 && !money.infinite_precision?
       return nil if rules[:no_cents]
       return nil if rules[:no_cents_if_whole] && value.to_i == 0
 

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -226,6 +226,18 @@ describe Money::Arithmetic do
       expect(Money.new(10_00) + 0).to eq Money.new(10_00)
     end
 
+    it "preserves the highest precision of the operands" do
+      high_precision_money = Money.new(10.7654, "USD", { infinite_precision: true })
+      low_precision_money = Money.new(10, "USD", { infinite_precision: false })
+      answer_money = Money.new(20.7654, "USD", { infinite_precision: true })
+      expect((high_precision_money + low_precision_money).infinite_precision?).to eq true
+      expect(high_precision_money + low_precision_money).to eq answer_money
+      expect((low_precision_money + high_precision_money).infinite_precision?).to eq true
+      expect(low_precision_money + high_precision_money).to eq answer_money
+      expect((low_precision_money + low_precision_money).infinite_precision?).to eq false
+      expect(low_precision_money + low_precision_money).to eq Money.new(20, "USD", { infinite_precision: false })
+    end
+
     it "preserves the class in the result when using a subclass of Money" do
       special_money_class = Class.new(Money)
       expect(special_money_class.new(10_00, "USD") + Money.new(90, "USD")).to be_a special_money_class
@@ -255,6 +267,17 @@ describe Money::Arithmetic do
 
     it "subtract Integer 0 to money and returns the same ammount" do
       expect(Money.new(10_00) - 0).to eq Money.new(10_00)
+    end
+
+    it "preserves the highest precision of the operands" do
+      high_precision_money = Money.new(10.7654, "USD", { infinite_precision: true })
+      low_precision_money = Money.new(10, "USD", { infinite_precision: false })
+      expect((high_precision_money - low_precision_money).infinite_precision?).to eq true
+      expect(high_precision_money - low_precision_money).to eq Money.new(0.7654, "USD", { infinite_precision: true })
+      expect((low_precision_money - high_precision_money).infinite_precision?).to eq true
+      expect(low_precision_money - high_precision_money).to eq Money.new(-0.7654, "USD", { infinite_precision: true })
+      expect((low_precision_money - low_precision_money).infinite_precision?).to eq false
+      expect(low_precision_money - low_precision_money).to eq Money.new(0, "USD", { infinite_precision: false })
     end
 
     it "preserves the class in the result when using a subclass of Money" do
@@ -502,6 +525,18 @@ describe Money::Arithmetic do
             {a: Money.new( 13, :USD), b: -4, c: [Money.new(-4, :USD), Money.new(-3, :USD)]},
             {a: Money.new(-13, :USD), b: 4, c: [Money.new(-4, :USD), Money.new( 3, :USD)]},
             {a: Money.new(-13, :USD), b: -4, c: [Money.new( 3, :USD), Money.new(-1, :USD)]},
+        ]
+        ts.each do |t|
+          expect(t[:a].divmod(t[:b])).to eq t[:c]
+        end
+      end
+    end
+
+    context "with mixed precision" do
+      it "it maintains infinite precision" do
+        ts = [
+          {a: Money.new( 12.99, :USD, {infinite_precision: true}), b: Money.new( 3, :USD), c: [ BigDecimal(4), Money.new( 0.99, :USD, {infinite_precision: true})]},
+          {a: Money.new( 13, :USD), b: Money.new(3.5, :USD, {infinite_precision: true}), c: [ BigDecimal(3), Money.new(2.5, :USD, {infinite_precision: true})]},
         ]
         ts.each do |t|
           expect(t[:a].divmod(t[:b])).to eq t[:c]

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -166,12 +166,24 @@ describe Money, "formatting" do
         expect(Money.new(10_00, "VUV").format).to eq "Vt1,000"
       end
 
-      it "does not displays a decimal part when infinite_precision is false" do
-        expect(Money.new(10_00.1, "VUV").format).to eq "Vt1,000"
+      context "when infinite_precision is not set globally", :default_infinite_precision_false do
+        it "does not display a decimal part" do
+          expect(Money.new(10_00.1, "VUV").format).to eq "Vt1,000"
+        end
+
+        it "displays a decimal part when infinite_precision is true on the instance" do
+          expect(Money.new(10_00.1, "VUV", { infinite_precision: true }).format).to eq "Vt1,000.1"
+        end
       end
 
-      it "displays a decimal part when infinite_precision is true", :default_infinite_precision_true do
-        expect(Money.new(10_00.1, "VUV").format).to eq "Vt1,000.1"
+      context "when infinite_precision is set globally", :default_infinite_precision_true do
+        it "does display a decimal part" do
+          expect(Money.new(10_00.1, "VUV").format).to eq "Vt1,000.1"
+        end
+
+        it "does not display a decimal part when infinite_precision is false on the instance" do
+          expect(Money.new(10_00.1, "VUV", { infinite_precision: false }).format).to eq "Vt1,000"
+        end
       end
     end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -115,6 +115,15 @@ describe Money do
         end
       end
     end
+
+    context "with infinite_precision on the instance only" do
+      let(:initializing_value) { 1.50 }
+      subject(:money) { Money.new(initializing_value, nil, { infinite_precision: true }) }
+
+      it "should have the correct cents" do
+        expect(money.cents).to eq BigDecimal('1.50')
+      end
+    end
   end
 
   describe ".add_rate" do
@@ -173,11 +182,18 @@ describe Money do
       expect(Money.from_amount(555.5, "JPY").amount).to eq "556".to_d
     end
 
-    it "does not round the given amount when infinite_precision is set", :default_infinite_precision_true do
+    it  "does not round the given amount when infinite_precision is set", :default_infinite_precision_true do
       expect(Money.from_amount(4.444, "USD").amount).to eq "4.444".to_d
       expect(Money.from_amount(5.555, "USD").amount).to eq "5.555".to_d
       expect(Money.from_amount(444.4, "JPY").amount).to eq "444.4".to_d
       expect(Money.from_amount(555.5, "JPY").amount).to eq "555.5".to_d
+    end
+
+    it  "does not round the given amount when infinite_precision is set on the instance" do
+      expect(Money.from_amount(4.444, "USD", { infinite_precision: true }).amount).to eq "4.444".to_d
+      expect(Money.from_amount(5.555, "USD", { infinite_precision: true }).amount).to eq "5.555".to_d
+      expect(Money.from_amount(444.4, "JPY", { infinite_precision: true }).amount).to eq "444.4".to_d
+      expect(Money.from_amount(555.5, "JPY", { infinite_precision: true }).amount).to eq "555.5".to_d
     end
 
     it "accepts an optional currency" do
@@ -252,6 +268,7 @@ describe Money do
       let(:serialized) { <<YAML
 !ruby/object:Money
   fractional: 249.5
+  infinite_precision: false
   currency: !ruby/object:Money::Currency
     id: :eur
     priority: 2
@@ -275,12 +292,14 @@ YAML
         m = YAML::load serialized
         expect(m).to be_a(Money)
         expect(m.class.default_infinite_precision).to be false
+        expect(m.infinite_precision?).to be false
         expect(m.fractional).to eq 250 # 249.5 rounded up
         expect(m.fractional).to be_a(Integer)
       end
 
-      it "is a BigDecimal when using infinite_precision", :default_infinite_precision_true do
-        money = YAML::load serialized
+      it "respects the object's infinite_precision setting" do
+        money = YAML::load serialized.sub('infinite_precision: false', 'infinite_precision: true')
+        expect(money.infinite_precision?).to be true
         expect(money.fractional).to be_a BigDecimal
       end
     end
@@ -400,14 +419,28 @@ YAML
       expect {money.round_to_nearest_cash_value}.to raise_error(Money::UndefinedSmallestDenomination)
     end
 
-    it "returns a Integer when infinite_precision is not set" do
-      money = Money.new(100, "USD")
-      expect(money.round_to_nearest_cash_value).to be_a Integer
+    context "when infinite_precision is not set globally", :default_infinite_precision_false do
+      it "returns an Integer" do
+        money = Money.new(100, "USD")
+        expect(money.round_to_nearest_cash_value).to be_a Integer
+      end
+
+      it "returns a BigDecimal when infinite_precision is set on instance" do
+        money = Money.new(100, "EUR", { infinite_precision: true })
+        expect(money.round_to_nearest_cash_value).to be_a BigDecimal
+      end
     end
 
-    it "returns a BigDecimal when infinite_precision is set", :default_infinite_precision_true do
-      money = Money.new(100, "EUR")
-      expect(money.round_to_nearest_cash_value).to be_a BigDecimal
+    context "when infinite_precision is set globally", :default_infinite_precision_true do
+      it "returns a BigDecimal"do
+        money = Money.new(100, "EUR")
+        expect(money.round_to_nearest_cash_value).to be_a BigDecimal
+      end
+
+      it "returns an Integer when infinite_precision is set to false on instance" do
+        money = Money.new(100, "EUR", { infinite_precision: false })
+        expect(money.round_to_nearest_cash_value).to be_a Integer
+      end
     end
   end
 
@@ -780,11 +813,21 @@ YAML
     end
   end
 
-  describe "#round" do
+  shared_examples "rounding" do
     let(:money) { Money.new(15.75, 'NZD') }
     subject(:rounded) { money.round }
 
     context "without infinite_precision" do
+      it "rounds the cents" do
+        expect(rounded.cents).to eq 16
+      end
+
+      it "maintains the currency" do
+        expect(rounded.currency).to eq Money::Currency.new('NZD')
+      end
+    end
+
+    context "with infinite_precision", :default_infinite_precision_true do
       it "returns a different money" do
         expect(rounded).not_to be money
       end
@@ -795,6 +838,35 @@ YAML
 
       it "maintains the currency" do
         expect(rounded.currency).to eq Money::Currency.new('NZD')
+      end
+    end
+
+    context "when using a subclass of Money" do
+    let(:special_money_class) { Class.new(Money) }
+    let(:money) { special_money_class.new(15.75, 'NZD') }
+
+    it "preserves the class in the result" do
+      expect(rounded).to be_a special_money_class
+      end
+    end
+  end
+
+  describe "#round" do
+    let(:money) { Money.new(15.75, 'NZD') }
+    subject(:rounded) { money.round }
+
+    it_behaves_like "rounding"
+
+    it 'preserves assigned bank' do
+      bank = Money::Bank::VariableExchange.new
+      rounded = Money.new(1_00, 'USD', bank).round
+
+      expect(rounded.bank).to eq(bank)
+    end
+
+    context "without infinite_precision" do
+      it "returns a different money" do
+        expect(rounded).not_to be money
       end
 
       it "uses a provided rounding strategy" do
@@ -811,18 +883,6 @@ YAML
     end
 
     context "with infinite_precision", :default_infinite_precision_true do
-      it "returns a different money" do
-        expect(rounded).not_to be money
-      end
-
-      it "rounds the cents" do
-        expect(rounded.cents).to eq 16
-      end
-
-      it "maintains the currency" do
-        expect(rounded.currency).to eq Money::Currency.new('NZD')
-      end
-
       it "uses a provided rounding strategy" do
         rounded = money.round(BigDecimal::ROUND_DOWN)
         expect(rounded.cents).to eq 15
@@ -837,20 +897,83 @@ YAML
         end
       end
     end
+  end
 
-    it 'preserves assigned bank' do
-      bank = Money::Bank::VariableExchange.new
-      rounded = Money.new(1_00, 'USD', bank).round
+  describe "#to_rounding" do
+    let(:money) { Money.new(15.75, 'NZD') }
+    subject(:rounded) { money.to_rounding }
 
-      expect(rounded.bank).to eq(bank)
+    it_behaves_like "rounding"
+
+    context "without infinite_precision" do
+      it "returns the same money (self)" do
+        expect(rounded).to be money
+      end
+
+      it 'returns "non-precise" money' do
+        expect(rounded.infinite_precision?).to be false
+      end
     end
 
-    context "when using a subclass of Money" do
-      let(:special_money_class) { Class.new(Money) }
-      let(:money) { special_money_class.new(15.75, 'NZD') }
+    context "with infinite_precision", :default_infinite_precision_true do
+      it "returns a different money" do
+        expect(rounded).not_to be money
+      end
 
-      it "preserves the class in the result" do
-        expect(rounded).to be_a special_money_class
+      it 'returns "non-precise" money' do
+        expect(money.infinite_precision?).to be true
+        expect(rounded.infinite_precision?).to be false
+      end
+    end
+  end
+
+  describe "#to_precise" do
+    subject(:converted) { money.to_precise }
+    let(:money) { Money.new(15.75, 'NZD') }
+
+    it "allows to avoid rounding loss errors" do
+      expect(Money.new(100, 'NZD') / 3 * 100).to eq(Money.new(3300, 'NZD'))
+
+      result = (Money.new(100, 'NZD').to_precise / 3 * 100).to_rounding
+      expect(result).to eq(Money.new(3333, 'NZD'))
+    end
+
+    context "without infinite_precision" do
+      it "returns a different money" do
+        expect(converted).not_to be money
+      end
+
+      it "keeps the cents rounded" do
+        expect(converted.cents).to eq 16
+        expect(converted.cents).to be_a(BigDecimal)
+      end
+
+      it 'returns "precise" money' do
+        expect(money.infinite_precision?).to be false
+        expect(converted.infinite_precision?).to be true
+      end
+
+      it "maintains the currency" do
+        expect(converted.currency).to eq Money::Currency.new('NZD')
+      end
+    end
+
+    context "with infinite_precision", :default_infinite_precision_true do
+      it "returns the same money (self)" do
+        expect(converted).to be money
+      end
+
+      it "keeps the cents non-rounded" do
+        expect(converted.cents).to eq 15.75
+        expect(converted.cents).to be_a(BigDecimal)
+      end
+
+      it 'returns "precise" money' do
+        expect(converted.infinite_precision?).to be true
+      end
+
+      it "maintains the currency" do
+        expect(converted.currency).to eq Money::Currency.new('NZD')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,11 +21,23 @@ end
 
 RSpec.shared_context "with infinite precision", :default_infinite_precision_true do
   before do
+    @previous_infinite_precision = Money.default_infinite_precision
     Money.default_infinite_precision = true
   end
 
   after do
+    Money.default_infinite_precision = @previous_infinite_precision
+  end
+end
+
+RSpec.shared_context "with infinite precision not set as default", :default_infinite_precision_false do
+  before do
+    @previous_infinite_precision = Money.default_infinite_precision
     Money.default_infinite_precision = false
+  end
+
+  after do
+    Money.default_infinite_precision = @previous_infinite_precision
   end
 end
 


### PR DESCRIPTION
Continuation of https://github.com/RubyMoney/money/pull/914. Allows each Money instance to hold its own infinite_precision setting