### PR TITLE
Allow double conversion using same bank

### DIFF
--- a/lib/money/bank/variable_exchange.rb
+++ b/lib/money/bank/variable_exchange.rb
@@ -114,7 +114,7 @@ class Money
           if rate = get_rate(from.currency, to_currency)
             fractional = calculate_fractional(from, to_currency)
             from.class.new(
-              exchange(fractional, rate, &block), to_currency
+              exchange(fractional, rate, &block), to_currency, self
             )
           else
             raise UnknownRate, "No conversion rate known for '#{from.currency.iso_code}' -> '#{to_currency}'"

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -641,6 +641,14 @@ YAML
       expect(money.exchange_to("EUR")).to eq Money.new(200_00, "EUR")
     end
 
+    it "allows double conversion using same bank" do
+      bank = Money::Bank::VariableExchange.new
+      bank.add_rate('EUR', 'USD', 2)
+      bank.add_rate('USD', 'EUR', 0.5)
+      money = Money.new(100_00, "USD", bank)
+      expect(money.exchange_to("EUR").exchange_to("USD")).to eq money
+    end
+
     it 'uses the block given as rounding method' do
       money = Money.new(100_00, 'USD')
       expect(money.bank).to receive(:exchange_with).and_yield(300_00)


### PR DESCRIPTION
Right now double conversion raises if `Money.default_bank` doesn't have require rate.

It's even more complicated if original bank uses historical rates from OXR *of specific date*,
but second conversion uses default bank *of today*