### PR TITLE
Prevent method redefinition warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ end
 
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.fail_on_error = false
+  t.ruby_opts = "-w"
 end
 
 task default: :spec

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -131,8 +131,9 @@ class Money
     #
     #   @return [Integer]
     attr_accessor :default_bank, :default_formatting_rules,
-      :use_i18n, :infinite_precision, :conversion_precision,
-      :locale_backend
+      :infinite_precision, :conversion_precision
+
+    attr_reader :use_i18n, :locale_backend
   end
 
   # @!attribute default_currency


### PR DESCRIPTION
Using `attr_accessor` already defines `attr=`, so now that we have
custom writers, we don't need to define them with `attr_accessor`.

Warnings:

    lib/money/money.rb:162: warning: method redefined; discarding old locale_backend=
    lib/money/money.rb:172: warning: method redefined; discarding old use_i18n=

Additionally, add `-w` to rspec's Ruby opts, so that we see such errors
earlier.