### PR TITLE
Suppress warnings on testing

### DIFF
--- a/lib/money/locale_backend/legacy.rb
+++ b/lib/money/locale_backend/legacy.rb
@@ -9,7 +9,7 @@ class Money
       end
 
       def lookup(key, currency)
-        warn '[DEPRECATION] You are using the default localization behaviour that will change in the next major release. Find out more - https://github.com/RubyMoney/money#deprecation'
+        warn '[RUBY MONEY DEPRECATION] You are using the default localization behaviour that will change in the next major release. Find out more - https://github.com/RubyMoney/money#deprecation'
 
         if Money.use_i18n
           i18n_backend.lookup(key, nil) || currency.public_send(key)

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -142,7 +142,7 @@ class Money
   #     +Money::Currency+ instance.
   def self.default_currency
     if @using_deprecated_default_currency
-      warn '[WARNING] The default currency will change from `USD` to `nil` in the next major release. Make ' \
+      warn '[RUBY MONEY WARNING] The default currency will change from `USD` to `nil` in the next major release. Make ' \
            'sure to set it explicitly using `Money.default_currency=` to avoid potential issues'
       @using_deprecated_default_currency = false
     end
@@ -171,9 +171,9 @@ class Money
 
   def self.use_i18n=(value)
     if value
-      warn '[DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :i18n` instead for locale based formatting'
+      warn '[RUBY MONEY DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :i18n` instead for locale based formatting'
     else
-      warn '[DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :currency` instead for currency based formatting'
+      warn '[RUBY MONEY DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :currency` instead for currency based formatting'
     end
 
     @use_i18n = value
@@ -217,14 +217,14 @@ class Money
   # @return [BigDecimal::ROUND_MODE] rounding mode
   def self.rounding_mode(mode = nil)
     if mode
-      warn "[DEPRECATION] calling `rounding_mode` with a block is deprecated. Please use `.with_rounding_mode` instead."
+      warn "[RUBY MONEY DEPRECATION] calling `rounding_mode` with a block is deprecated. Please use `.with_rounding_mode` instead."
       return with_rounding_mode(mode) { yield }
     end
 
     return Thread.current[:money_rounding_mode] if Thread.current[:money_rounding_mode]
 
     if @using_deprecated_default_rounding_mode
-      warn '[WARNING] The default rounding mode will change from `ROUND_HALF_EVEN` to `ROUND_HALF_UP` in the ' \
+      warn '[RUBY MONEY WARNING] The default rounding mode will change from `ROUND_HALF_EVEN` to `ROUND_HALF_UP` in the ' \
            'next major release. Set it explicitly using `Money.rounding_mode=` to avoid potential problems.'
       @using_deprecated_default_rounding_mode = false
     end
@@ -365,7 +365,7 @@ class Money
   # @example
   #   Money.new(100, :USD).currency_as_string #=> "USD"
   def currency_as_string
-    warn "[DEPRECATION] `currency_as_string` is deprecated. Please use `.currency.to_s` instead."
+    warn "[RUBY MONEY DEPRECATION] `currency_as_string` is deprecated. Please use `.currency.to_s` instead."
     currency.to_s
   end
 
@@ -378,7 +378,7 @@ class Money
   # @example
   #   Money.new(100).currency_as_string("CAD") #=> #<Money::Currency id: cad>
   def currency_as_string=(val)
-    warn "[DEPRECATION] `currency_as_string=` is deprecated - Money instances are immutable." \
+    warn "[RUBY MONEY DEPRECATION] `currency_as_string=` is deprecated - Money instances are immutable." \
       " Please use `with_currency` instead."
     @currency = Currency.wrap(val)
   end

--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -41,7 +41,7 @@ class Money
         rules = rules.dup if rules.is_a?(Hash)
 
         if rules.is_a?(Symbol)
-          warn '[DEPRECATION] Use Hash when passing rules to Money#format.'
+          warn '[RUBY MONEY DEPRECATION] Use Hash when passing rules to Money#format.'
           rules = { rules => true }
         end
       end
@@ -107,23 +107,23 @@ class Money
         position = rules[:symbol_position]
         template = position == :before ? '%u %n' : '%n %u'
 
-        warn "[DEPRECATION] `symbol_position: :#{position}` is deprecated - you can replace it with `format: #{template}`"
+        warn "[RUBY MONEY DEPRECATION] `symbol_position: :#{position}` is deprecated - you can replace it with `format: #{template}`"
       end
 
       if rules.has_key?(:symbol_before_without_space)
-        warn "[DEPRECATION] `symbol_before_without_space:` option is deprecated - you can replace it with `format: '%u%n'`"
+        warn "[RUBY MONEY DEPRECATION] `symbol_before_without_space:` option is deprecated - you can replace it with `format: '%u%n'`"
       end
 
       if rules.has_key?(:symbol_after_without_space)
-        warn "[DEPRECATION] `symbol_after_without_space:` option is deprecated - you can replace it with `format: '%n%u'`"
+        warn "[RUBY MONEY DEPRECATION] `symbol_after_without_space:` option is deprecated - you can replace it with `format: '%n%u'`"
       end
 
       if rules.has_key?(:html)
-        warn "[DEPRECATION] `html` is deprecated - use `html_wrap` instead. Please note that `html_wrap` will wrap all parts of currency and if you use `with_currency` option, currency element class changes from `currency` to `money-currency`."
+        warn "[RUBY MONEY DEPRECATION] `html` is deprecated - use `html_wrap` instead. Please note that `html_wrap` will wrap all parts of currency and if you use `with_currency` option, currency element class changes from `currency` to `money-currency`."
       end
 
       if rules.has_key?(:html_wrap_symbol)
-        warn "[DEPRECATION] `html_wrap_symbol` is deprecated - use `html_wrap` instead. Please note that `html_wrap` will wrap all parts of currency."
+        warn "[RUBY MONEY DEPRECATION] `html_wrap_symbol` is deprecated - use `html_wrap` instead. Please note that `html_wrap` will wrap all parts of currency."
       end
     end
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -202,7 +202,7 @@ describe Money do
       end).to eq 1.99
       expect(Money)
         .to have_received(:warn)
-        .with('[DEPRECATION] calling `rounding_mode` with a block is deprecated. ' \
+        .with('[RUBY MONEY DEPRECATION] calling `rounding_mode` with a block is deprecated. ' \
               'Please use `.with_rounding_mode` instead.')
     end
 
@@ -908,7 +908,7 @@ YAML
     it 'warns about changing default_currency value' do
       expect(Money)
         .to receive(:warn)
-        .with('[WARNING] The default currency will change from `USD` to `nil` in the next major release. ' \
+        .with('[RUBY MONEY WARNING] The default currency will change from `USD` to `nil` in the next major release. ' \
               'Make sure to set it explicitly using `Money.default_currency=` to avoid potential issues')
 
       Money.default_currency
@@ -929,7 +929,7 @@ YAML
     it 'warns about changing default rounding_mode value' do
       expect(Money)
         .to receive(:warn)
-        .with('[WARNING] The default rounding mode will change from `ROUND_HALF_EVEN` to `ROUND_HALF_UP` in ' \
+        .with('[RUBY MONEY WARNING] The default rounding mode will change from `ROUND_HALF_EVEN` to `ROUND_HALF_UP` in ' \
               'the next major release. Set it explicitly using `Money.rounding_mode=` to avoid potential problems.')
 
       Money.rounding_mode

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,3 +28,13 @@ RSpec.shared_context "with infinite precision", :infinite_precision do
     Money.infinite_precision = false
   end
 end
+
+if RUBY_VERSION >= '2.4.0'
+  module Warning
+    def self.warn(message)
+      return if message.match?('RUBY MONEY')
+
+      super
+    end
+  end
+end


### PR DESCRIPTION
Currently, there are many warnings when you see https://travis-ci.org/RubyMoney/money/jobs/658222812.
I suppress warning use [module Warning](https://docs.ruby-lang.org/en/2.7.0/Warning.html#method-c-warn).