### PR TITLE
Fix yard warnings

### DIFF
--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -46,7 +46,7 @@ class Money
     # Compares two Money objects. If money objects have a different currency it
     # will attempt to convert the currency.
     #
-    # @param [Money] other_money Value to compare with.
+    # @param [Money] other Value to compare with.
     #
     # @return [Integer]
     #
@@ -103,7 +103,7 @@ class Money
     # values. If +other_money+ has a different currency then its monetary value
     # is automatically exchanged to this object's currency using +exchange_to+.
     #
-    # @param [Money] other_money Other +Money+ object to add.
+    # @param [Money] other Other +Money+ object to add.
     #
     # @return [Money]
     #
@@ -116,7 +116,7 @@ class Money
     # its monetary value is automatically exchanged to this object's currency
     # using +exchange_to+.
     #
-    # @param [Money] other_money Other +Money+ object to subtract.
+    # @param [Money] other Other +Money+ object to subtract.
     #
     # @return [Money]
     #

--- a/lib/money/rates_store/memory.rb
+++ b/lib/money/rates_store/memory.rb
@@ -19,7 +19,7 @@ class Money
       #
       # @param [Hash] opts Optional store options.
       # @option opts [Boolean] :without_mutex disables the usage of a mutex
-      # @param [Hash] rt Optional initial exchange rate data.
+      # @param [Hash] rates Optional initial exchange rate data.
       def initialize(opts = {}, rates = {})
         @rates = rates
         @options = opts


### PR DESCRIPTION
Some warnings are remain because it is defined by using `Module#define_method`.

## Before

```console
~/ghq/github.com/taki/money %be rake yard                                                                                                           master
[warn]: @param tag has unknown parameter name: other_money
    in file `lib/money/money/arithmetic.rb' near line 55
[warn]: @param tag has unknown parameter name: other_money
    in file `lib/money/money/arithmetic.rb' near line 125
[warn]: @param tag has unknown parameter name: other_money
    in file `lib/money/money/arithmetic.rb' near line 125
[warn]: @param tag has unknown parameter name: other_money
    in file `lib/money/money/arithmetic.rb' near line 125
[warn]: @param tag has unknown parameter name: other_money
    in file `lib/money/money/arithmetic.rb' near line 125
[warn]: @param tag has unknown parameter name: rt
    in file `lib/money/rates_store/memory.rb' near line 23
Files:          20
Modules:         7 (    6 undocumented)
Classes:        23 (    9 undocumented)
Constants:       9 (    8 undocumented)
Attributes:     26 (    0 undocumented)
Methods:       129 (   22 undocumented)
 76.80% documented
```

## After

```console
~/ghq/github.com/taki/money %be rake yard                                                                                                           master
[warn]: @param tag has duplicate parameter name: other
    in file `lib/money/money/arithmetic.rb' near line 125
[warn]: @param tag has duplicate parameter name: other
    in file `lib/money/money/arithmetic.rb' near line 125
Files:          20
Modules:         7 (    6 undocumented)
Classes:        23 (    9 undocumented)
Constants:       9 (    8 undocumented)
Attributes:     26 (    0 undocumented)
Methods:       129 (   22 undocumented)
 76.80% documented
```
