### PR TITLE
Print warning when using unsafe serializer for rate import

### DIFF
--- a/lib/money/bank/variable_exchange.rb
+++ b/lib/money/bank/variable_exchange.rb
@@ -217,8 +217,7 @@ class Money
       #   s = bank.export_rates(:json)
       #   s #=> "{\"USD_TO_CAD\":1.24515,\"CAD_TO_USD\":0.803115}"
       def export_rates(format, file = nil, opts = {})
-        raise Money::Bank::UnknownRateFormat unless
-          RATE_FORMATS.include? format
+        raise Money::Bank::UnknownRateFormat unless RATE_FORMATS.include?(format)
 
         store.transaction do
           s = FORMAT_SERIALIZERS[format].dump(rates)
@@ -258,8 +257,13 @@ class Money
       #   bank.get_rate("USD", "CAD") #=> 1.24515
       #   bank.get_rate("CAD", "USD") #=> 0.803115
       def import_rates(format, s, opts = {})
-        raise Money::Bank::UnknownRateFormat unless
-          RATE_FORMATS.include? format
+        raise Money::Bank::UnknownRateFormat unless RATE_FORMATS.include?(format)
+
+        if format == :ruby
+          warn '[WARNING] Using :ruby format when importing rates is potentially unsafe and ' \
+            'might lead to remote code execution via Marshal.load deserializer. Consider using ' \
+            'safe alternatives such as :json and :yaml.'
+        end
 
         store.transaction do
           data = FORMAT_SERIALIZERS[format].load(s)

--- a/spec/bank/variable_exchange_spec.rb
+++ b/spec/bank/variable_exchange_spec.rb
@@ -219,11 +219,23 @@ describe Money::Bank::VariableExchange do
     end
 
     context "with format == :ruby" do
+      let(:dump) { Marshal.dump({ "USD_TO_EUR" => 1.25, "USD_TO_JPY" => 2.55 }) }
+
       it "loads the rates provided" do
-        s = Marshal.dump({"USD_TO_EUR"=>1.25,"USD_TO_JPY"=>2.55})
-        subject.import_rates(:ruby, s)
+        subject.import_rates(:ruby, dump)
+
         expect(subject.get_rate('USD', 'EUR')).to eq 1.25
         expect(subject.get_rate('USD', 'JPY')).to eq 2.55
+      end
+
+      it "prints a warning" do
+        allow(subject).to receive(:warn)
+
+        subject.import_rates(:ruby, dump)
+
+        expect(subject)
+          .to have_received(:warn)
+          .with(include('[WARNING] Using :ruby format when importing rates is potentially unsafe'))
       end
     end
 


### PR DESCRIPTION
Using `Marshal.load` with a crafted payload can lead to remote code execution

Fixes #928 