### PR TITLE
Add support for filtering historical currencies

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Abhay Kumar
+Adrian Hooper
 Adrian Longley
 Alexander Donkin
 Alexander Ross

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -5,7 +5,6 @@ require "money/currency/loader"
 require "money/currency/heuristics"
 
 class Money
-
   # Represents a specific currency unit.
   #
   # @see https://en.wikipedia.org/wiki/Currency
@@ -80,7 +79,8 @@ class Money
       def find_by_iso_numeric(num)
         num = num.to_s.rjust(3, '0')
         return if num.empty?
-        id, _ = self.table.find { |key, currency| currency[:iso_numeric] == num }
+
+        id, = table.find { |_key, currency| currency[:iso_numeric] == num }
         new(id)
       rescue UnknownCurrency
         nil
@@ -136,8 +136,13 @@ class Money
           if c.priority.nil?
             raise MissingAttributeError.new(:all, c.id, :priority)
           end
+
           c
         end.sort_by(&:priority)
+      end
+
+      def supported_currencies
+        all.select(&:supported)
       end
 
       # We need a string-based validator before creating an unbounded number of
@@ -206,7 +211,6 @@ class Money
         all.each { |c| yield(c) }
       end
 
-
       private
 
       def stringify_keys
@@ -253,7 +257,7 @@ class Money
 
     attr_reader :id, :priority, :iso_code, :iso_numeric, :name, :symbol,
       :disambiguate_symbol, :html_entity, :subunit, :subunit_to_unit, :decimal_mark,
-      :thousands_separator, :symbol_first, :smallest_denomination
+      :thousands_separator, :symbol_first, :smallest_denomination, :supported
 
     alias_method :separator, :decimal_mark
     alias_method :delimiter, :thousands_separator
@@ -434,6 +438,7 @@ class Money
       @iso_code              = data[:iso_code]
       @iso_numeric           = data[:iso_numeric]
       @name                  = data[:name]
+      @supported             = data[:supported]
       @priority              = data[:priority]
       @smallest_denomination = data[:smallest_denomination]
       @subunit               = data[:subunit]

--- a/lib/money/currency/loader.rb
+++ b/lib/money/currency/loader.rb
@@ -8,17 +8,19 @@ class Money
         #
         # @return [Hash]
         def load_currencies
-          currencies = parse_currency_file("currency_iso.json")
-          currencies.merge! parse_currency_file("currency_non_iso.json")
-          currencies.merge! parse_currency_file("currency_backwards_compatible.json")
+          currencies = parse_currency_file("currency_iso.json", supported: true)
+          currencies.merge! parse_currency_file("currency_non_iso.json", supported: true)
+          currencies.merge! parse_currency_file("currency_backwards_compatible.json", supported: false)
         end
 
         private
 
-        def parse_currency_file(filename)
+        def parse_currency_file(filename, opts)
           json = File.read("#{DATA_PATH}/#{filename}")
           json.force_encoding(::Encoding::UTF_8) if defined?(::Encoding)
-          JSON.parse(json, symbolize_names: true)
+          JSON.parse(json, symbolize_names: true).each do |_key, curr|
+            curr[:supported] = opts[:supported]
+          end
         end
       end
     end

--- a/spec/currency/loader_spec.rb
+++ b/spec/currency/loader_spec.rb
@@ -10,4 +10,9 @@ describe Money::Currency::Loader do
 
     subject.load_currencies
   end
+
+  it "sets if the currency is supported" do
+    currencies = subject.load_currencies
+    expect(currencies.values.first).to have_key(:supported)
+  end
 end

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 describe Money::Currency do
-  FOO = '{ "priority": 1, "iso_code": "FOO", "iso_numeric": "840", "name": "United States Dollar", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 1000, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "smallest_denomination": 1 }'
+  FOO = '{ "priority": 1, "iso_code": "FOO", "iso_numeric": "840", "name": "United States Dollar", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 1000, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "smallest_denomination": 1, "supported": false }'
 
   def register_foo(opts={})
     foo_attrs = JSON.parse(FOO, symbolize_names: true)
@@ -90,6 +90,18 @@ describe Money::Currency do
 
       expect{described_class.all}.to \
         raise_error(described_class::MissingAttributeError, /foo.*priority/)
+      unregister_foo
+    end
+  end
+
+  describe ".supported_currencies" do
+    it "returns an array of currencies" do
+      expect(described_class.supported_currencies).to include described_class.new(:usd)
+    end
+
+    it "doesn't return unsupported currencies" do
+      register_foo
+      expect(described_class.supported_currencies).not_to include described_class.new(:foo)
       unregister_foo
     end
   end


### PR DESCRIPTION
Introuces a new method `.supported_currencies` to get a list of all currencies
not loaded from the backwards compatible json file. Also introduces a new
property on the currency instance `#supported`

Resolves #881 by providing the ability to not only directly retrieve the supported
currencies, but also determine if a currency is supported or not.