### PR TITLE
[Proposal]  Public API to initialize currency class variable @@instances and instance variable @table

### DIFF
--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -206,6 +206,10 @@ class Money
         all.each { |c| yield(c) }
       end
 
+      def initialize!
+        @@instances = {}
+        @table = Loader.load_currencies
+      end
 
       private
 

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -206,7 +206,7 @@ class Money
         all.each { |c| yield(c) }
       end
 
-      def initialize!
+      def reset!
         @@instances = {}
         @table = Loader.load_currencies
       end

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -395,4 +395,28 @@ describe Money::Currency do
       unregister_foo
     end
   end
+
+  describe '#initialize!' do
+    let(:modified_mark) { '&&' }
+
+    before do
+      cad = described_class.find(:cad)
+
+      described_class.register(
+        :priority            => 100,
+        :iso_code            => cad.iso_code,
+        :name                => cad.name,
+        :subunit             => cad.subunit,
+        :subunit_to_unit     => cad.subunit_to_unit,
+        :thousands_separator => cad.thousands_separator,
+        :decimal_mark        => modified_mark
+      )
+    end
+
+    it "initializes modified currency" do
+      expect(described_class.find(:cad).decimal_mark).to eq modified_mark
+      described_class.initialize!
+      expect(described_class.find(:cad).decimal_mark).not_to eq modified_mark
+    end
+  end
 end

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -396,7 +396,7 @@ describe Money::Currency do
     end
   end
 
-  describe '#initialize!' do
+  describe '#reset!' do
     let(:modified_mark) { '&&' }
 
     before do
@@ -413,9 +413,9 @@ describe Money::Currency do
       )
     end
 
-    it "initializes modified currency" do
+    it "resets modified currency" do
       expect(described_class.find(:cad).decimal_mark).to eq modified_mark
-      described_class.initialize!
+      described_class.reset!
       expect(described_class.find(:cad).decimal_mark).not_to eq modified_mark
     end
   end


### PR DESCRIPTION
Provide public API to initialize Money::Currency.

Money::Currency provides registered currency within the ruby process if the currency is once registered.
It became a problem for me on the test context.
Once the currency was overwritten by using `register`, there is no way to initialize the currency table within the ruby process.
I could solve that by using instance_variable_set, and class_variable_set like below.

```ruby
Money::Currency.class_variable_set('@@instances', {})
Money::Currency.instance_variable_set('@table', Money::Currency::Loader.load_currencies)
```

But I suppose it might be good to provide `initialize` API as a library.