### PR TITLE
Allow specifying default_bank as a lambda

### DIFF
--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -129,10 +129,9 @@ class Money
     #   Used to specify precision for converting Rational to BigDecimal
     #
     #   @return [Integer]
-    attr_accessor :default_bank, :default_formatting_rules,
-      :default_infinite_precision, :conversion_precision
-
+    attr_accessor :default_formatting_rules, :default_infinite_precision, :conversion_precision
     attr_reader :use_i18n, :locale_backend
+    attr_writer :default_bank
 
     def infinite_precision
       warn '[DEPRECATION] `Money.infinite_precision` is deprecated - use `Money.default_infinite_precision` instead'
@@ -167,6 +166,14 @@ class Money
   def self.default_currency=(currency)
     @using_deprecated_default_currency = false
     @default_currency = currency
+  end
+
+  def self.default_bank
+    if @default_bank.respond_to?(:call)
+      @default_bank.call
+    else
+      @default_bank
+    end
   end
 
   def self.locale_backend=(value)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -942,4 +942,18 @@ YAML
       Money.rounding_mode
     end
   end
+
+  describe '.default_bank' do
+    after { Money.setup_defaults }
+
+    it 'accepts a bank instance' do
+      Money.default_bank = Money::Bank::SingleCurrency.instance
+      expect(Money.default_bank).to be_instance_of(Money::Bank::SingleCurrency)
+    end
+
+    it 'accepts a lambda' do
+      Money.default_bank = lambda { Money::Bank::SingleCurrency.instance }
+      expect(Money.default_bank).to be_instance_of(Money::Bank::SingleCurrency)
+    end
+  end
 end


### PR DESCRIPTION
Similar to `Money.default_currency` this will allow resolving the default bank dynamically when called