### PR TITLE
Improve documentation for the ActiveRecord store

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,17 +316,24 @@ The following example implements an `ActiveRecord` store to save exchange rates 
 ```ruby
 # rails g model exchange_rate from:string to:string rate:float
 
-# for Rails 5 replace ActiveRecord::Base with ApplicationRecord
-class ExchangeRate < ActiveRecord::Base
+class ExchangeRate < ApplicationRecord
   def self.get_rate(from_iso_code, to_iso_code)
     rate = find_by(from: from_iso_code, to: to_iso_code)
-    rate.present? ? rate.rate : nil
+    rate&.rate
   end
 
   def self.add_rate(from_iso_code, to_iso_code, rate)
     exrate = find_or_initialize_by(from: from_iso_code, to: to_iso_code)
     exrate.rate = rate
     exrate.save!
+  end
+  
+  def self.each_rate
+    return find_each unless block_given?
+
+    find_each do |rate|
+      yield rate.from, rate.to, rate.rate
+    end
   end
 end
 ```


### PR DESCRIPTION
Add the missing `each_rate` method, simplify existing methods. I also dropped the comment for `ApplicationRecord` in favor of using it directly. Rails < 5 is long gone.