### PR TITLE
Fix Bahraini dinar symbol

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -224,7 +224,7 @@
     "priority": 100,
     "iso_code": "BHD",
     "name": "Bahraini Dinar",
-    "symbol": ".د.ب",
+    "symbol": "د.ب.",
     "alternate_symbols": ["BD"],
     "subunit": "Fils",
     "subunit_to_unit": 1000,

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -224,7 +224,7 @@
     "priority": 100,
     "iso_code": "BHD",
     "name": "Bahraini Dinar",
-    "symbol": "ب.د",
+    "symbol": ".د.ب",
     "alternate_symbols": ["BD"],
     "subunit": "Fils",
     "subunit_to_unit": 1000,

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -224,7 +224,7 @@
     "priority": 100,
     "iso_code": "BHD",
     "name": "Bahraini Dinar",
-    "symbol": "د.ب.",
+    "symbol": "د.ب",
     "alternate_symbols": ["BD"],
     "subunit": "Fils",
     "subunit_to_unit": 1000,

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -158,7 +158,7 @@ describe Money, "formatting" do
     end
 
     it "respects :subunit_to_unit currency property" do
-      expect(Money.new(10_00, "BHD").format).to eq "د.ب.1.000"
+      expect(Money.new(10_00, "BHD").format).to eq "د.ب1.000"
     end
 
     context "when :subunit_to_unit is 1" do
@@ -271,7 +271,7 @@ describe Money, "formatting" do
       end
 
       it "respects :subunit_to_unit currency property" do
-        expect(Money.new(10_00, "BHD").format(no_cents: true)).to eq "د.ب.1"
+        expect(Money.new(10_00, "BHD").format(no_cents: true)).to eq "د.ب1"
       end
 
       it "inserts thousand separators if symbol contains decimal mark and no_cents is true" do
@@ -613,8 +613,8 @@ describe Money, "formatting" do
       it "does round fractional when set to true" do
         expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: true)).to eq "$0.12"
         expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: true)).to eq "$0.13"
-        expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq "د.ب.0.123"
-        expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq "د.ب.0.124"
+        expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq "د.ب0.123"
+        expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq "د.ب0.124"
         expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: true)).to eq "$1.00"
         expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: true)).to eq "$1.10"
         expect(Money.new(BigDecimal('1.7'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar0.4"
@@ -623,8 +623,8 @@ describe Money, "formatting" do
       it "does not round fractional when set to false" do
         expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: false)).to eq "$0.121"
         expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: false)).to eq "$0.125"
-        expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: false)).to eq "د.ب.0.1231"
-        expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: false)).to eq "د.ب.0.1235"
+        expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: false)).to eq "د.ب0.1231"
+        expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: false)).to eq "د.ب0.1235"
         expect(Money.new(BigDecimal('123.1'), "KWD").format(rounded_infinite_precision: false)).to eq "د.ك0.1231"
         expect(Money.new(BigDecimal('123.5'), "KWD").format(rounded_infinite_precision: false)).to eq "د.ك0.1235"
         expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: false)).to eq "$1.001"
@@ -671,8 +671,8 @@ describe Money, "formatting" do
         it 'does round fractional when set to true' do
           expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: true)).to eq "$0,12"
           expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: true)).to eq "$0,13"
-          expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq "د.ب.0,123"
-          expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq "د.ب.0,124"
+          expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq "د.ب0,123"
+          expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq "د.ب0,124"
           expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: true)).to eq "$1,00"
           expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: true)).to eq "$1,10"
           expect(Money.new(BigDecimal('1'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar0,2"

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -158,7 +158,7 @@ describe Money, "formatting" do
     end
 
     it "respects :subunit_to_unit currency property" do
-      expect(Money.new(10_00, "BHD").format).to eq "ب.د1.000"
+      expect(Money.new(10_00, "BHD").format).to eq ".د.ب1.000"
     end
 
     context "when :subunit_to_unit is 1" do
@@ -271,7 +271,7 @@ describe Money, "formatting" do
       end
 
       it "respects :subunit_to_unit currency property" do
-        expect(Money.new(10_00, "BHD").format(no_cents: true)).to eq "ب.د1"
+        expect(Money.new(10_00, "BHD").format(no_cents: true)).to eq ".د.ب1"
       end
 
       it "inserts thousand separators if symbol contains decimal mark and no_cents is true" do
@@ -613,8 +613,8 @@ describe Money, "formatting" do
       it "does round fractional when set to true" do
         expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: true)).to eq "$0.12"
         expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: true)).to eq "$0.13"
-        expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq "ب.د0.123"
-        expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq "ب.د0.124"
+        expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq ".د.ب0.123"
+        expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq ".د.ب0.124"
         expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: true)).to eq "$1.00"
         expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: true)).to eq "$1.10"
         expect(Money.new(BigDecimal('1.7'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar0.4"
@@ -623,8 +623,8 @@ describe Money, "formatting" do
       it "does not round fractional when set to false" do
         expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: false)).to eq "$0.121"
         expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: false)).to eq "$0.125"
-        expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: false)).to eq "ب.د0.1231"
-        expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: false)).to eq "ب.د0.1235"
+        expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: false)).to eq ".د.ب0.1231"
+        expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: false)).to eq ".د.ب0.1235"
         expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: false)).to eq "$1.001"
         expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: false)).to eq "$1.095"
         expect(Money.new(BigDecimal('1.7'), "MGA").format(rounded_infinite_precision: false)).to eq "Ar0.34"
@@ -669,8 +669,8 @@ describe Money, "formatting" do
         it 'does round fractional when set to true' do
           expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: true)).to eq "$0,12"
           expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: true)).to eq "$0,13"
-          expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq "ب.د0,123"
-          expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq "ب.د0,124"
+          expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq ".د.ب0,123"
+          expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq ".د.ب0,124"
           expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: true)).to eq "$1,00"
           expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: true)).to eq "$1,10"
           expect(Money.new(BigDecimal('1'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar0,2"

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -158,7 +158,7 @@ describe Money, "formatting" do
     end
 
     it "respects :subunit_to_unit currency property" do
-      expect(Money.new(10_00, "BHD").format).to eq ".د.ب1.000"
+      expect(Money.new(10_00, "BHD").format).to eq "د.ب.1.000"
     end
 
     context "when :subunit_to_unit is 1" do
@@ -271,7 +271,7 @@ describe Money, "formatting" do
       end
 
       it "respects :subunit_to_unit currency property" do
-        expect(Money.new(10_00, "BHD").format(no_cents: true)).to eq ".د.ب1"
+        expect(Money.new(10_00, "BHD").format(no_cents: true)).to eq "د.ب.1"
       end
 
       it "inserts thousand separators if symbol contains decimal mark and no_cents is true" do
@@ -613,8 +613,8 @@ describe Money, "formatting" do
       it "does round fractional when set to true" do
         expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: true)).to eq "$0.12"
         expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: true)).to eq "$0.13"
-        expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq ".د.ب0.123"
-        expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq ".د.ب0.124"
+        expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq "د.ب.0.123"
+        expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq "د.ب.0.124"
         expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: true)).to eq "$1.00"
         expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: true)).to eq "$1.10"
         expect(Money.new(BigDecimal('1.7'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar0.4"
@@ -623,8 +623,10 @@ describe Money, "formatting" do
       it "does not round fractional when set to false" do
         expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: false)).to eq "$0.121"
         expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: false)).to eq "$0.125"
-        expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: false)).to eq ".د.ب0.1231"
-        expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: false)).to eq ".د.ب0.1235"
+        expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: false)).to eq "د.ب.0.1231"
+        expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: false)).to eq "د.ب.0.1235"
+        expect(Money.new(BigDecimal('123.1'), "KWD").format(rounded_infinite_precision: false)).to eq "د.ك0.1231"
+        expect(Money.new(BigDecimal('123.5'), "KWD").format(rounded_infinite_precision: false)).to eq "د.ك0.1235"
         expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: false)).to eq "$1.001"
         expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: false)).to eq "$1.095"
         expect(Money.new(BigDecimal('1.7'), "MGA").format(rounded_infinite_precision: false)).to eq "Ar0.34"
@@ -669,8 +671,8 @@ describe Money, "formatting" do
         it 'does round fractional when set to true' do
           expect(Money.new(BigDecimal('12.1'), "USD").format(rounded_infinite_precision: true)).to eq "$0,12"
           expect(Money.new(BigDecimal('12.5'), "USD").format(rounded_infinite_precision: true)).to eq "$0,13"
-          expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq ".د.ب0,123"
-          expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq ".د.ب0,124"
+          expect(Money.new(BigDecimal('123.1'), "BHD").format(rounded_infinite_precision: true)).to eq "د.ب.0,123"
+          expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq "د.ب.0,124"
           expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: true)).to eq "$1,00"
           expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: true)).to eq "$1,10"
           expect(Money.new(BigDecimal('1'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar0,2"


### PR DESCRIPTION
Issue #957 - According to the [ISO-4217](https://en.wikipedia.org/wiki/Currency_symbol) and [Bahraini dinar Wiki](https://en.wikipedia.org/wiki/Bahraini_dinar) and [Bahraini dinar Ar Wiki](https://ar.wikipedia.org/wiki/%D8%AF%D9%8A%D9%86%D8%A7%D8%B1_%D8%A8%D8%AD%D8%B1%D9%8A%D9%86%D9%8A) the correct currency symbol for this Bahraini Dinar should be د.ب instead of ب.د
