### PR TITLE
Fix allocate for array of all zeros

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Jim Kingdon
 John Duff
 John Gakos
 Jonathon M. Abbott
+Jose C. Rivera
 Josh Delsman
 Josh Hepworth
 Joshua Clayton

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.13.9
+- Fix edgecase for Money#allocate when applying to array of all zero values
+
 ## 6.13.8
 - Update symbol for XOF
 - Update UYU currency symbol

--- a/lib/money/money/allocation.rb
+++ b/lib/money/money/allocation.rb
@@ -13,7 +13,13 @@ class Money
     #   Array<Numeric> — allocates the amounts proportionally to the given array
     #
     def self.generate(amount, parts, whole_amounts = true)
-      parts = parts.is_a?(Numeric) ? Array.new(parts, 1) : parts.dup
+      parts = if parts.is_a?(Numeric)
+        Array.new(parts, 1)
+      elsif parts.all?(&:zero?)
+        Array.new(parts.count, 1)
+      else
+        parts.dup
+      end
 
       raise ArgumentError, 'need at least one party' if parts.empty?
 

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,3 +1,3 @@
 class Money
-  VERSION = '6.13.8'
+  VERSION = '6.13.9'
 end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -729,6 +729,16 @@ YAML
       end
     end
 
+    context "with all zeros" do
+      subject { Money.us_dollar(100).allocate(arry).map(&:fractional) }
+
+      let(:arry) { [0, 0] }
+
+      it "allocates evenly" do
+         expect(subject).to eq [50, 50]
+      end
+    end
+
     it "keeps subclasses intact" do
       special_money_class = Class.new(Money)
       expect(special_money_class.new(005).allocate([1]).first).to be_a special_money_class


### PR DESCRIPTION
Money#allocate was failing to round-robin remaining pennies in the case of an array of all zeros. This change treats the case of an Array of size N of all zero values, the same as for passing in a Numeric of value N for even distribution.