### PR TITLE
Revert CHF format changes introduced in v6.14

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -452,7 +452,7 @@
     "subunit": "Rappen",
     "subunit_to_unit": 100,
     "symbol_first": true,
-    "format": "%u %n",
+    "format": "%u%n",
     "html_entity": "",
     "decimal_mark": ".",
     "thousands_separator": ",",

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -735,10 +735,10 @@ describe Money, "formatting" do
     end
   end
 
-  describe ':format to "%u %n" for currency with :symbol_first to true' do
+  describe ':format to "%u%n" for currency with :symbol_first to true' do
     context 'when rules are not passed' do
-      it "insert space between symbol and number" do
-        expect(Money.new(100_00, 'CHF').format).to eq "CHF 100.00"
+      it "does not insert space between symbol and number" do
+        expect(Money.new(100_00, 'CHF').format).to eq "CHF100.00"
       end
     end
 

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -742,12 +742,6 @@ describe Money, "formatting" do
       end
     end
 
-    context 'when format: "%u%n" rule is passed' do
-      it "ignores :symbol_with_space in favour of format" do
-        expect(Money.new(100_00, 'CHF').format(format: '%u%n')).to eq "CHF100.00"
-      end
-    end
-
     context 'when symbol_position is passed' do
       it "inserts currency symbol before the amount when set to :before" do
         expect(Money.new(100_00, 'CHF').format(symbol_position: :before)).to eq "CHF100.00"
@@ -773,12 +767,6 @@ describe Money, "formatting" do
     context 'when rules are not passed' do
       it "insert space between symbol and number" do
         expect(Money.new(100_00, 'AED').format).to eq "100.00 د.إ"
-      end
-    end
-
-    context 'when format: "%u%n" rule is passed' do
-      it "ignores :symbol_with_space in favour of format" do
-        expect(Money.new(100_00, 'AED').format(format: '%u%n')).to eq "د.إ100.00"
       end
     end
 


### PR DESCRIPTION
As described in #966, we noticed that the default format for the `CHF` currency changed with the last version released. This PR restores the previous format and, I think, needs to be part a patch release to ensure backward compatibility.

If accepted, I can send another PR to update the CHANGELOG including this in the next patch level (or making the change in this PR directly if #968 will be merged before). 