### PR TITLE
[6.14.0] Avoid warning messages when calling `#format_decimal_part`: Money.infinite_precision -> Money.default_infinite_precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Money.from_amount(2.34567).format #=> "$2.35"
 To retain the additional precision, you will also need to set `infinite_precision` to `true`.
 
 ```ruby
-Money.infinite_precision = true
+Money.default_infinite_precision = true
 Money.from_amount(2.34567).format #=> "$2.34567"
 ```
 
@@ -423,7 +423,7 @@ To round to the nearest cent (or anything more precise), you can use the `round`
 2.34567.round(2)  #=> 2.35
 
 # Money
-Money.infinite_precision = true
+Money.default_infinite_precision = true
 Money.new(2.34567).format       #=> "$0.0234567"
 Money.new(2.34567).round.format #=> "$0.02"
 Money.new(2.34567).round(BigDecimal::ROUND_HALF_UP, 2).format #=> "$0.0235"

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -347,7 +347,7 @@ class Money
     end
 
     def format_decimal_part(value)
-      return nil if currency.decimal_places == 0 && !Money.infinite_precision
+      return nil if currency.decimal_places == 0 && !Money.default_infinite_precision
       return nil if rules[:no_cents]
       return nil if rules[:no_cents_if_whole] && value.to_i == 0
 


### PR DESCRIPTION
* Avoid warning messages when calling `#format_decimal_part`

like this:

```
[DEPRECATION] `Money.infinite_precision` is deprecated - use `Money.default_infinite_precision` instead
```

* Tweaks to README.
