### PR TITLE
Allow specifying a delimiter pattern

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,6 +33,7 @@ Edwin Vlieg
 Eloy
 Evan Alter
 Exoth
+Ferran Pelayo Monfort
 Filipe Goncalves
 Francisco Trindade
 François Beausoleil

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.14.2
+## 6.15.0
 
 - Add :delimiter_pattern option to the Formatter
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.14.2
+
+- Add :delimiter_pattern option to the Formatter
+
 ## 6.14.1
 
 - Fix CHF format regression introduced in v6.14.0

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -330,7 +330,9 @@ class Money
 
     def format_whole_part(value)
       # Apply thousands_separator
-      value.gsub regexp_format, "\\1#{thousands_separator}"
+      value.gsub(rules[:delimiter_pattern]) do |digit_to_delimit|
+        "#{digit_to_delimit}#{thousands_separator}"
+      end
     end
 
     def extract_whole_and_decimal_parts
@@ -364,15 +366,6 @@ class Money
       return rules[key] || DEFAULTS[key] if rules.has_key?(key)
 
       (Money.locale_backend && Money.locale_backend.lookup(key, currency)) || DEFAULTS[key]
-    end
-
-    def regexp_format
-      if rules[:south_asian_number_formatting]
-        # from http://blog.revathskumar.com/2014/11/regex-comma-seperated-indian-currency-format.html
-        /(\d+?)(?=(\d\d)+(\d)(?!\d))(\.\d+)?/
-      else
-        /(\d)(?=(?:\d{3})+(?:[^\d]{1}|$))/
-      end
     end
 
     def symbol_value_from(rules)

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -211,6 +211,12 @@ class Money
     #   Money.new(89000, :btc).format(drop_trailing_zeros: true) #=> B⃦0.00089
     #   Money.new(110, :usd).format(drop_trailing_zeros: true)   #=> $1.1
     #
+    # @option rules [Boolean] :delimiter_pattern (/(\d)(?=(?:\d{3})+(?:[^\d]{1}|$))/) Regular expression to set the placement
+    #   for the thousands delimiter
+    #
+    # @example
+    #   Money.new(89000, :btc).format(delimiter_pattern: /(\d)(?=\d)/) #=> B⃦8,9,0.00
+    #
     # @option rules [String] :format (nil) Provide a template for formatting. `%u` will be replaced
     # with the symbol (if present) and `%n` will be replaced with the number.
     #

--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -12,6 +12,7 @@ class Money
       @rules = localize_formatting_rules(@rules)
       @rules = translate_formatting_rules(@rules) if @rules[:translate]
       @rules[:format] ||= determine_format_from_formatting_rules(@rules)
+      @rules[:delimiter_pattern] ||= delimiter_pattern_rule(@rules)
 
       warn_about_deprecated_rules(@rules)
     end
@@ -87,6 +88,15 @@ class Money
         rules.fetch(:symbol_before_without_space, true) ? '%u%n' : '%u %n'
       else
         rules[:symbol_after_without_space] ? '%n%u' : '%n %u'
+      end
+    end
+
+    def delimiter_pattern_rule(rules)
+      if rules[:south_asian_number_formatting]
+        # from http://blog.revathskumar.com/2014/11/regex-comma-seperated-indian-currency-format.html
+        /(\d+?)(?=(\d\d)+(\d)(?!\d))(\.\d+)?/
+      else
+        I18n.t('number.currency.format.delimiter_pattern', default: nil) || /(\d)(?=(?:\d{3})+(?:[^\d]{1}|$))/
       end
     end
 

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,3 +1,3 @@
 class Money
-  VERSION = '6.14.2'
+  VERSION = '6.15.0'
 end

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,3 +1,3 @@
 class Money
-  VERSION = '6.14.1'
+  VERSION = '6.14.2'
 end

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -92,7 +92,7 @@ describe Money, "formatting" do
         I18n.locale = :de
         I18n.backend.store_translations(
             :de,
-            number: { currency: { format: { delimiter: ".", separator: "," } } }
+            number: { currency: { format: { delimiter: ".", separator: ",", delimiter_pattern: /(\d)(?=\d)/ } } }
         )
       end
 
@@ -104,6 +104,10 @@ describe Money, "formatting" do
 
       it "should use ',' as the decimal mark" do
         expect(money.decimal_mark).to eq ','
+      end
+
+      it "should use delimiter pattern" do
+        expect(Money.new(1_456_00, "EUR").format).to eq "€1.4.5.6,00"
       end
     end
 


### PR DESCRIPTION
To add an option to put the thousands separators according to a regex.
Use the ones previously defined in `Formatter#regexp_format` if not specified
Move the logic to fetch this regex to `FormatterRules`

Both the name and the path for the option are taken from [activesupport](https://api.rubyonrails.org/classes/ActiveSupport/NumberHelper.html#method-i-number_to_delimited)

