### PR TITLE
Drop `number.currency.format.delimiter_pattern` option parsing

### DIFF
--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -96,7 +96,7 @@ class Money
         # from http://blog.revathskumar.com/2014/11/regex-comma-seperated-indian-currency-format.html
         /(\d+?)(?=(\d\d)+(\d)(?!\d))(\.\d+)?/
       else
-        I18n.t('number.currency.format.delimiter_pattern', default: nil) || /(\d)(?=(?:\d{3})+(?:[^\d]{1}|$))/
+        /(\d)(?=(?:\d{3})+(?:[^\d]{1}|$))/
       end
     end
 

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -92,7 +92,7 @@ describe Money, "formatting" do
         I18n.locale = :de
         I18n.backend.store_translations(
             :de,
-            number: { currency: { format: { delimiter: ".", separator: ",", delimiter_pattern: /(\d)(?=\d)/ } } }
+            number: { currency: { format: { delimiter: ".", separator: "," } } }
         )
       end
 
@@ -104,10 +104,6 @@ describe Money, "formatting" do
 
       it "should use ',' as the decimal mark" do
         expect(money.decimal_mark).to eq ','
-      end
-
-      it "should use delimiter pattern" do
-        expect(Money.new(1_456_00, "EUR").format).to eq "€1.4.5.6,00"
       end
     end
 
@@ -717,6 +713,12 @@ describe Money, "formatting" do
         expect(money.format(format: '%n%u', sign_before_symbol: false)).to eq('-99.99$')
         expect(money.format(format: '%u%n', sign_before_symbol: false)).to eq('$-99.99')
         expect(money.format(format: '%u%n', sign_before_symbol: true)).to eq('-$99.99')
+      end
+    end
+
+    describe ':delimiter_pattern option' do
+      it "should use delimiter pattern" do
+        expect(Money.new(1_456_00, "EUR").format(delimiter_pattern: /(\d)(?=\d)/)).to eq "€1.4.5.6,00"
       end
     end
 


### PR DESCRIPTION
As suggested in this comment https://github.com/RubyMoney/money/pull/981#discussion_r600023628, looking for `I18n.t('number.currency.format.delimiter_pattern', default: nil)` is quite expensive.
This PR drops support for that and enforces to pass this option when calling the `#format` method