### PR TITLE
Allow true for thousands_separator

### DIFF
--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -246,11 +246,9 @@ class Money
     def thousands_separator
       val = lookup :thousands_separator
 
-      if val == true
-        val = (Money.locale_backend && Money.locale_backend.lookup(:thousands_separator, currency)) || DEFAULTS[key]
-      end
+      return val unless val == true
 
-      val
+      lookup_default :thousands_separator
     end
 
     def decimal_mark
@@ -380,6 +378,10 @@ class Money
     def lookup(key)
       return rules[key] || DEFAULTS[key] if rules.has_key?(key)
 
+      lookup_default key
+    end
+
+    def lookup_default(key)
       (Money.locale_backend && Money.locale_backend.lookup(key, currency)) || DEFAULTS[key]
     end
 

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -124,10 +124,13 @@ class Money
     #  the currency should be delimited by the specified character or ','
     #
     # @example
-    #   # If false is specified, no thousands_separator is used.
+    #   # If a falsey value is specified, no thousands_separator is used.
     #   Money.new(100000, "USD").format(thousands_separator: false) #=> "1000.00"
     #   Money.new(100000, "USD").format(thousands_separator: nil)   #=> "1000.00"
     #   Money.new(100000, "USD").format(thousands_separator: "")    #=> "1000.00"
+    #
+    #   # If true is specified, the locale or default thousands_separator is used.
+    #   Money.new(100000, "USD").format(thousands_separator: true) #=> "1,000.00"
     #
     #   # If a string is specified, it's value is used.
     #   Money.new(100000, "USD").format(thousands_separator: ".") #=> "$1.000.00"
@@ -241,7 +244,13 @@ class Money
     end
 
     def thousands_separator
-      lookup :thousands_separator
+      val = lookup :thousands_separator
+
+      if val == true
+        val = (Money.locale_backend && Money.locale_backend.lookup(:thousands_separator, currency)) || DEFAULTS[key]
+      end
+
+      val
     end
 
     def decimal_mark

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -448,12 +448,17 @@ describe Money, "formatting" do
     describe ":thousands_separator option" do
       specify "(thousands_separator: a thousands_separator string) works as documented" do
         expect(Money.us_dollar(100000).format(thousands_separator: ".")).to eq "$1.000.00"
+        expect(Money.us_dollar(100000).format(thousands_separator: ".")).to eq "$1.000.00"
         expect(Money.us_dollar(200000).format(thousands_separator: "")).to eq "$2000.00"
       end
 
       specify "(thousands_separator: false or nil) works as documented" do
         expect(Money.us_dollar(100000).format(thousands_separator: false)).to eq "$1000.00"
         expect(Money.us_dollar(200000).format(thousands_separator: nil)).to eq "$2000.00"
+      end
+
+      specify "(thousands_separator: true) works as documented" do
+        expect(Money.us_dollar(100000).format(thousands_separator: true)).to eq "$1,000.00"
       end
 
       specify "(delimiter: a delimiter string) works as documented" do
@@ -464,6 +469,10 @@ describe Money, "formatting" do
       specify "(delimiter: false or nil) works as documented" do
         expect(Money.us_dollar(100000).format(delimiter: false)).to eq "$1000.00"
         expect(Money.us_dollar(200000).format(delimiter: nil)).to eq "$2000.00"
+      end
+
+      specify "(delimiter: true) works as documented" do
+        expect(Money.us_dollar(100000).format(delimiter: true)).to eq "$1,000.00"
       end
 
       it "defaults to ',' if currency isn't recognized" do


### PR DESCRIPTION
# Problem Statement
When configuration is set to use `thousands_separator: false`, using the locale or default separator cannot be done ambiguously.

# Solution
Allow `thousands_separator: true` to be used to use the locale or default separator.

# Risk
This will break for anyone using `true` as an actual separator.

# Testing
## Before Change
```spec
Failures:

  1) Money formatting #format :thousands_separator option (thousands_separator: true) works as documented
     Failure/Error: expect(Money.us_dollar(100000).format(thousands_separator: true)).to eq "$1,000.00"
     
       expected: "$1,000.00"
            got: "$1true000.00"
     
       (compared using ==)
     # ./spec/money/formatting_spec.rb:461:in `block (4 levels) in <top (required)>'

  2) Money formatting #format :thousands_separator option (delimiter: true) works as documented
     Failure/Error: expect(Money.us_dollar(100000).format(delimiter: true)).to eq "$1,000.00"
     
       expected: "$1,000.00"
            got: "$1true000.00"
     
       (compared using ==)
     # ./spec/money/formatting_spec.rb:475:in `block (4 levels) in <top (required)>'

Finished in 0.28673 seconds (files took 0.2447 seconds to load)
487 examples, 2 failures
```

## After Change
```spec
Finished in 0.29289 seconds (files took 0.25815 seconds to load)
487 examples, 0 failures
```