### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1']
 
     steps:
     - uses: actions/checkout@v2

--- a/AUTHORS
+++ b/AUTHORS
@@ -100,6 +100,7 @@ Pavel Gabriel
 pconnor
 Pedro Nascimento
 Pelle Braendgaard
+Peter Goldstein
 Peter Rhoades
 Phil Cohen
 pivotal-cloudplanner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming
 
 - Add second dobra (STN) from São Tomé and Príncipe
+- Add Ruby 3.1 to the CI matrix
 
 ## 6.17.0
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -274,13 +274,20 @@ describe Money do
     decimal_mark: ! ','
     thousands_separator: .
     iso_numeric: '978'
-    mutex: !ruby/object:Mutex {}
+    mutex: !ruby/object:Thread::Mutex {}
     last_updated: 2012-11-23 20:41:47.454438399 +02:00
 YAML
       }
 
+      let(:m) do
+        if Psych::VERSION > '4.0'
+          YAML.safe_load(serialized, permitted_classes: [Money, Money::Currency, Symbol, Thread::Mutex, Time])
+        else
+          YAML.safe_load(serialized, [Money, Money::Currency, Symbol, Thread::Mutex, Time])
+        end
+      end
+
       it "uses BigDecimal when rounding" do
-        m = YAML::load serialized
         expect(m).to be_a(Money)
         expect(m.class.default_infinite_precision).to be false
         expect(m.fractional).to eq 250 # 249.5 rounded up
@@ -288,8 +295,7 @@ YAML
       end
 
       it "is a BigDecimal when using infinite_precision", :default_infinite_precision_true do
-        money = YAML::load serialized
-        expect(money.fractional).to be_a BigDecimal
+        expect(m.fractional).to be_a BigDecimal
       end
     end
 


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.

To get this working I had to make some changes in a serialization test to support the Psych 4 safe load.  The odd part is that I couldn't find any matching code for loading `Money` objects in the actual gem.  I may have missed something.