### PR TITLE
update Georgian Lari symbol

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,6 +65,7 @@ Jose C. Rivera
 Josh Delsman
 Josh Hepworth
 Joshua Clayton
+Julia López
 Julien Boyer
 Kaleem Ullah
 Kenichi Kamiya

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming
 
 - Add second dobra (STN) from São Tomé and Príncipe
+- Update Georgian Lari symbol
 
 ## 6.17.0
 

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -782,7 +782,7 @@
     "priority": 100,
     "iso_code": "GEL",
     "name": "Georgian Lari",
-    "symbol": "ლ",
+    "symbol": "₾",
     "alternate_symbols": ["lari"],
     "subunit": "Tetri",
     "subunit_to_unit": 100,


### PR DESCRIPTION
Hello! 

One of our customers made us notice that the Georgian Lari symbol was changed back in 2014 and we should update it here too! 

More about it in the Wikipedia page: https://en.wikipedia.org/wiki/Georgian_lari