### PR TITLE
Add USDC stablecoin

### DIFF
--- a/config/currency_non_iso.json
+++ b/config/currency_non_iso.json
@@ -126,5 +126,21 @@
     "thousands_separator": ",",
     "iso_numeric": "",
     "smallest_denomination": 1
+  },
+  "usdc": {
+    "priority": 100,
+    "so_code": "USDC",
+    "name": "USD Coin",
+    "symbol": "USDC",
+    "disambiguate_symbol": "USDC",
+    "alternate_symbols": [],
+    "subunit": "Cent",
+    "subunit_to_unit": 100,
+    "symbol_first": false,
+    "html_entity": "$",
+    "decimal_mark": ".",
+    "thousands_separator": ",",
+    "iso_numeric": "",
+    "smallest_denomination": 1
   }
 }

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -857,6 +857,7 @@ describe Money, "formatting" do
       expect(Money.new(1999_98, "NOK").format).to eq("1.999,98 kr")
       expect(Money.new(1999_98, "SEK").format).to eq("1 999,98 kr")
       expect(Money.new(1999_98, "BCH").format).to eq("0.00199998 ₿")
+      expect(Money.new(1999_98, "USDC").format).to eq("1,999.98 USDC")
     end
 
     it "returns ambiguous signs when disambiguate is false" do
@@ -866,6 +867,7 @@ describe Money, "formatting" do
       expect(Money.new(1999_98, "NOK").format(disambiguate: false)).to eq("1.999,98 kr")
       expect(Money.new(1999_98, "SEK").format(disambiguate: false)).to eq("1 999,98 kr")
       expect(Money.new(1999_98, "BCH").format(disambiguate: false)).to eq("0.00199998 ₿")
+      expect(Money.new(1999_98, "USDC").format(disambiguate: false)).to eq("1,999.98 USDC")
     end
 
     it "returns disambiguate signs when disambiguate: true" do
@@ -875,6 +877,7 @@ describe Money, "formatting" do
       expect(Money.new(1999_98, "NOK").format(disambiguate: true)).to eq("1.999,98 NOK")
       expect(Money.new(1999_98, "SEK").format(disambiguate: true)).to eq("1 999,98 SEK")
       expect(Money.new(1999_98, "BCH").format(disambiguate: true)).to eq("0.00199998 ₿CH")
+      expect(Money.new(1999_98, "USDC").format(disambiguate: true)).to eq("1,999.98 USDC")
     end
 
     it "returns disambiguate signs when disambiguate: true and symbol: true" do
@@ -884,6 +887,7 @@ describe Money, "formatting" do
       expect(Money.new(1999_98, "NOK").format(disambiguate: true, symbol: true)).to eq("1.999,98 NOK")
       expect(Money.new(1999_98, "SEK").format(disambiguate: true, symbol: true)).to eq("1 999,98 SEK")
       expect(Money.new(1999_98, "BCH").format(disambiguate: true, symbol: true)).to eq("0.00199998 ₿CH")
+      expect(Money.new(1999_98, "USDC").format(disambiguate: true, symbol: true)).to eq("1,999.98 USDC")
     end
 
     it "returns no signs when disambiguate: true and symbol: false" do
@@ -893,6 +897,7 @@ describe Money, "formatting" do
       expect(Money.new(1999_98, "NOK").format(disambiguate: true, symbol: false)).to eq("1.999,98")
       expect(Money.new(1999_98, "SEK").format(disambiguate: true, symbol: false)).to eq("1 999,98")
       expect(Money.new(1999_98, "BCH").format(disambiguate: true, symbol: false)).to eq("0.00199998")
+      expect(Money.new(1999_98, "USDC").format(disambiguate: true, symbol: false)).to eq("1,999.98")
     end
 
     it "should never return an ambiguous format with disambiguate: true" do


### PR DESCRIPTION
## Context

This adds [USDC ](https://www.circle.com/en/usdc) which a cryptocurrency stablecoin pinned to the US dollar.

Not sure if this is the place for introducing cryptocurrencies but opened this anyway since I have a use case in my app and would help others as well.