### PR TITLE
Fix ActiveRecord custom exchange rate docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,10 @@ class ExchangeRate < ApplicationRecord
       yield rate.from, rate.to, rate.rate
     end
   end
+
+  def self.marshal_dump
+    [self]
+  end
 end
 ```
 


### PR DESCRIPTION
Without this method, calling save! throws an error that causes test suites to bomb.

Example stacktrace:

```
/opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/dynamic_matchers.rb:22:in `method_missing': undefined method `marshal_dump' for MyExchangeRateARClass:Class (NoMethodError)
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/attr_encrypted-3.1.0/lib/attr_encrypted.rb:306:in `method_missing'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/attr_encrypted-3.1.0/lib/attr_encrypted/adapters/active_record.rb:131:in `method_missing_with_attr_encrypted'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/money-6.13.8/lib/money/bank/variable_exchange.rb:69:in `marshal_dump'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest/test.rb:205:in `dump'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest/test.rb:205:in `sanitize_exception'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest/test.rb:201:in `rescue in capture_exceptions'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest/test.rb:194:in `capture_exceptions'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest/test.rb:95:in `block (2 levels) in run'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:281:in `time_it'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest/test.rb:94:in `block in run'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:376:in `on_signal'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest/test.rb:221:in `with_info_handler'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest/test.rb:93:in `run'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/bundler/gems/minitest-reporters-0996340031d4/lib/minitest/reporters.rb:48:in `run_with_hooks'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:1042:in `run_one_method'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:350:in `run_one_method'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:337:in `block (2 levels) in run'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:336:in `each'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:336:in `block in run'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:376:in `on_signal'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:363:in `with_info_handler'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:335:in `run'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/railties-6.1.5.1/lib/rails/test_unit/line_filtering.rb:10:in `run'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:169:in `block in __run'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:169:in `map'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:169:in `__run'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:146:in `run'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/minitest-5.15.0/lib/minitest.rb:73:in `block in autorun'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/activesupport-6.1.5.1/lib/active_support/fork_tracker.rb:8:in `fork'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/activesupport-6.1.5.1/lib/active_support/fork_tracker.rb:8:in `fork'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/activesupport-6.1.5.1/lib/active_support/fork_tracker.rb:27:in `fork'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/activesupport-6.1.5.1/lib/active_support/fork_tracker.rb:8:in `fork'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/activesupport-6.1.5.1/lib/active_support/fork_tracker.rb:27:in `fork'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/spring-2.1.1/lib/spring/application.rb:180:in `serve'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/spring-2.1.1/lib/spring/application.rb:145:in `block in run'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/spring-2.1.1/lib/spring/application.rb:139:in `loop'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/spring-2.1.1/lib/spring/application.rb:139:in `run'
	from /opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/spring-2.1.1/lib/spring/application/boot.rb:19:in `<top (required)>'
	from <internal:/opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from -e:1:in `<main>'
/opt/hostedtoolcache/Ruby/3.0.2/x64/lib/ruby/gems/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/validations.rb:80:in `raise_validation_error': Validation failed: "my custom validation message". (ActiveRecord::RecordInvalid)
```