### PR TITLE
Add new SLE currency

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -1999,11 +1999,28 @@
     "iso_numeric": "703",
     "smallest_denomination": 50
   },
+  "sle": {
+    "priority": 100,
+    "iso_code": "SLE",
+    "name": "New Leone",
+    "symbol": "Le",
+    "alternate_symbols": [],
+    "subunit": "Cent",
+    "subunit_to_unit": 100,
+    "symbol_first": false,
+    "format": "%n %u",
+    "html_entity": "",
+    "decimal_mark": ".",
+    "thousands_separator": ",",
+    "iso_numeric": "925",
+    "smallest_denomination": 1000
+  },
   "sll": {
     "priority": 100,
     "iso_code": "SLL",
     "name": "Sierra Leonean Leone",
     "symbol": "Le",
+    "disambiguate_symbol": "SLL",
     "alternate_symbols": [],
     "subunit": "Cent",
     "subunit_to_unit": 100,


### PR DESCRIPTION
This is the "New Leone" introduced to Sierra Leone in July 2022.  The
previous currency (SLL) will remain valid until October 2022.

See:
* https://www.reuters.com/article/leone-currency-idAFL8N2YI2E9
* https://en.wikipedia.org/w/index.php?title=ISO_4217&diff=1095269772&oldid=1095247155