### PR TITLE
change(data): remove HRK (Croatian Kuna)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Update Georgian Lari symbol
 - Add Ruby 3.1 and 3.2 to the CI matrix
 - Add `Money.from_dollars` alias as a more explicit initializer, it's the same as `Money.from_amount`
+- Mark Croatian Kuna (HRK) as obsolete by moving its definition to the backwards compatibility data source
 
 ## 6.17.0
 

--- a/config/currency_backwards_compatible.json
+++ b/config/currency_backwards_compatible.json
@@ -31,6 +31,22 @@
     "iso_numeric": "288",
     "smallest_denomination": 1
   },
+  "hrk": {
+    "priority": 100,
+    "iso_code": "HRK",
+    "name": "Croatian Kuna",
+    "symbol": "kn",
+    "alternate_symbols": [],
+    "subunit": "Lipa",
+    "subunit_to_unit": 100,
+    "symbol_first": false,
+    "format": "%n %u",
+    "html_entity": "",
+    "decimal_mark": ",",
+    "thousands_separator": ".",
+    "iso_numeric": "191",
+    "smallest_denomination": 1
+  },
   "ltl": {
     "priority": 100,
     "iso_code": "LTL",

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -922,22 +922,6 @@
     "iso_numeric": "340",
     "smallest_denomination": 5
   },
-  "hrk": {
-    "priority": 100,
-    "iso_code": "HRK",
-    "name": "Croatian Kuna",
-    "symbol": "kn",
-    "alternate_symbols": [],
-    "subunit": "Lipa",
-    "subunit_to_unit": 100,
-    "symbol_first": false,
-    "format": "%n %u",
-    "html_entity": "",
-    "decimal_mark": ",",
-    "thousands_separator": ".",
-    "iso_numeric": "191",
-    "smallest_denomination": 1
-  },
   "htg": {
     "priority": 100,
     "iso_code": "HTG",


### PR DESCRIPTION
On 2023-01-01, Croatia adopted the Euro and the HRK became obsolete.

https://economy-finance.ec.europa.eu/euro/eu-countries-and-euro/croatia-and-euro_en

This PR moves the definition of `HRK` to the backwards compatibility source file, consistent with other obsolete currencies.