### PR TITLE
Change Peruvian Sol (PEN) decimal mark and thousands separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming
 
+- Change Peruvian Sol (PEN) decimal mark and thousands separator.
+
+## 6.18.0
+
 - Add second dobra (STN) from São Tomé and Príncipe
 - Correct South African Rand (ZAR) to use comma decimal mark, and space thousands separator
 - Use euro symbol as html_entity for euro currency

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -1690,8 +1690,8 @@
     "subunit_to_unit": 100,
     "symbol_first": true,
     "html_entity": "S/",
-    "decimal_mark": ".",
-    "thousands_separator": ",",
+    "decimal_mark": ",",
+    "thousands_separator": ".",
     "iso_numeric": "604",
     "smallest_denomination": 1
   },

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,3 +1,3 @@
 class Money
-  VERSION = '6.18.0'
+  VERSION = '6.19.0'
 end


### PR DESCRIPTION
I looked the format used across [Mercado Libre](https://www.mercadolibre.com/) LATAM properties like https://www.mercadolibre.com.pe/

I also asked about it to a Peruvian colleague. He informed me that they use `,` for decimal mark and `.` for thousands separator.

Because of that I'm changing it here.