### PR TITLE
explicit declaration of i18n locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ The development version (hosted on Github) can be installed with:
 ``` ruby
 require 'money'
 
+# explicitly define locales
+I18n.config.available_locales = :en
+Money.locale_backend = :i18n
+
 # 10.00 USD
 money = Money.from_cents(1000, "USD")
 money.cents     #=> 1000


### PR DESCRIPTION
`.format` requires i18n locales explicit declaration
```ruby
[6] pry(main)> Money.from_cents(123).format
[DEPRECATION] You are using the default localization behaviour that will change in the next major release. Find out more - https://github.com/RubyMoney/money#deprecation
I18n::InvalidLocale: :en is not a valid locale
from /Users/friendlyantz/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/i18n-1.12.0/lib/i18n.rb:351:in `enforce_available_locales!'
[7] pry(main)> I18n.config.available_locales = :en
=> :en
[8] pry(main)> Money.from_cents(123).format
[DEPRECATION] You are using the default localization behaviour that will change in the next major release. Find out more - https://github.com/RubyMoney/money#deprecation
=> "$1.23"
[9] pry(main)> Money.locale_backend = :i18n
=> :i18n
[10] pry(main)> Money.from_cents(123).format
=> "$1.23"
```