### PR TITLE
Add space to CHF format

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -452,7 +452,7 @@
     "subunit": "Rappen",
     "subunit_to_unit": 100,
     "symbol_first": true,
-    "format": "%u%n",
+    "format": "%u %n",
     "html_entity": "",
     "decimal_mark": ".",
     "thousands_separator": ",",

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -750,16 +750,16 @@ describe Money, "formatting" do
     end
   end
 
-  describe ':format to "%u%n" for currency with :symbol_first to true' do
+  describe ':format to "%u %n" for currency with :symbol_first to true' do
     context 'when rules are not passed' do
-      it "does not insert space between symbol and number" do
-        expect(Money.new(100_00, 'CHF').format).to eq "CHF100.00"
+      it "inserts a space between symbol and number" do
+        expect(Money.new(100_00, 'CHF').format).to eq "CHF 100.00"
       end
     end
 
     context 'when symbol_position is passed' do
       it "inserts currency symbol before the amount when set to :before" do
-        expect(Money.new(100_00, 'CHF').format(symbol_position: :before)).to eq "CHF100.00"
+        expect(Money.new(100_00, 'CHF').format(symbol_position: :before)).to eq "CHF 100.00"
       end
 
       it "inserts currency symbol after the amount when set to :after" do


### PR DESCRIPTION
As far as I can find anywhere, the correct formatting for CHF includes a space.
Similar PR on another project: https://github.com/invoiceninja/invoiceninja/issues/4109
