### PR TITLE
Update deprecation message to suggest correct formatting.

### DIFF
--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -117,7 +117,7 @@ class Money
     def warn_about_deprecated_rules(rules)
       if rules.has_key?(:symbol_position)
         position = rules[:symbol_position]
-        template = position == :before ? '%u %n' : '%n %u'
+        template = position == :before ? '%u%n' : '%n%u'
 
         warn "[DEPRECATION] `symbol_position: :#{position}` is deprecated - you can replace it with `format: #{template}`"
       end

--- a/spec/money/formatting_rules_spec.rb
+++ b/spec/money/formatting_rules_spec.rb
@@ -14,4 +14,22 @@ describe Money::FormattingRules do
     expect(rules).to eq(separator: '.')
     expect(rules).not_to eq(new_rules)
   end
+
+  context 'when the position is :before' do
+    it 'warns about deprecated :symbol_position' do
+      expect_any_instance_of(Money::FormattingRules).to receive(:warn)
+        .with('[DEPRECATION] `symbol_position: :before` is deprecated - you can replace it with `format: %u%n`')
+
+      Money::FormattingRules.new(Money::Currency.new('USD'), symbol_position: :before)
+    end
+  end
+
+  context "when the position is :after" do
+    it 'warns about deprecated :symbol_position' do
+      expect_any_instance_of(Money::FormattingRules).to receive(:warn)
+        .with('[DEPRECATION] `symbol_position: :after` is deprecated - you can replace it with `format: %n%u`')
+
+      Money::FormattingRules.new(Money::Currency.new('USD'), symbol_position: :after)
+    end
+  end
 end


### PR DESCRIPTION
The current deprecation message for the before or after symbol suggests using a format string that includes spaces.  This is a small change so that the deprecation warning is more useful.

```
[12] pry(main)> money.format(symbol_position: :before, symbol: true)
[ruby-deprecation] [DEPRECATION] `symbol_position: :before` is deprecated - you can replace it with `format: %u %n`

=> "$23.45"
[13] pry(main)> money.format(format: "%u %n", symbol: true)
=> "$ 23.45"
[14] pry(main)> money.format(format: "%u%n", symbol: true)
=> "$23.45"
```

Co-authored-by: Alec Clarke <alec.clarke.dev@gmail.com>