### PR TITLE
Fix the issue where japanese formatting is no longer possible.

### DIFF
--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -72,7 +72,7 @@ class Money
     end
 
     def localize_formatting_rules(rules)
-      if currency.iso_code == "JPY" && I18n.locale == :ja
+      if currency.iso_code == "JPY" && I18n.locale == :ja && rules[:format] == nil
         rules[:symbol] = "円" unless rules[:symbol] == false
         rules[:format] = '%n%u'
       end

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -147,6 +147,7 @@ describe Money, "formatting" do
         money = Money.new(1000, "JPY")
         expect(money.format).to eq "1,000円"
         expect(money.format(symbol: false)).to eq "1,000"
+        expect(money.format(format: "%u%n")).to eq "¥1,000"
       end
 
       after  { I18n.locale = @_locale }


### PR DESCRIPTION
I am using the money gem in a Japanese locale, but there seems to be an issue with the Money#format method, as indicated in the following link:

https://github.com/RubyMoney/money/blob/main/lib/money/money.rb#L627

I would like to make various changes as follows:

```
irb(main):001:0> Money.new(1000, "JPY").format(format: "%u %n foo bar")
=> "¥ 1,000 foo bar"
```
However, in reality, the format does not change:

```
irb(main):001:0> Money.new(1000, "JPY").format(format: "%u %n foo bar")
=> "1,000円"
```

Removing localize_formatting_rules Formatting would be the correct fix, but it has been rejected. I am waiting for the 7.0 release, but I cannot wait until then.

https://github.com/RubyMoney/money/pull/650
https://github.com/RubyMoney/money/pull/101

Without removing localize_formatting_rulesFormatting, I have made adjustments so that the format is applied correctly.