### PR TITLE
Fixes ruby deprecation warning regarding `bigdecimal` will be moved out from stdlib soon

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -139,3 +139,4 @@ Yuusuke Takizawa
 Zubin Henner
 Бродяной Александр
 Nicolay Hvidsten
+Simon Neutert

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming
 
 - Change Peruvian Sol (PEN) decimal mark and thousands separator.
+- Fix deprecation warning for BigDecimal being moved out from stdlib.
 
 ## 6.18.0
 

--- a/money.gemspec
+++ b/money.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
   s.description = "A Ruby Library for dealing with money and currency conversion."
   s.license     = "MIT"
 
-  s.add_dependency "bigdecimal", "~> 3.1"
+
+  s.add_dependency "bigdecimal", "~> 3.1" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('6.19.0')
   s.add_dependency 'i18n', [">= 0.6.4", '<= 2']
 
   s.add_development_dependency "bundler"

--- a/money.gemspec
+++ b/money.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.description = "A Ruby Library for dealing with money and currency conversion."
   s.license     = "MIT"
 
+  s.add_dependency "bigdecimal", "~> 3.1"
   s.add_dependency 'i18n', [">= 0.6.4", '<= 2']
 
   s.add_development_dependency "bundler"

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -759,7 +759,7 @@ describe Money, "formatting" do
 
     context 'when symbol_position is passed' do
       it "inserts currency symbol before the amount when set to :before" do
-        expect(Money.new(100_00, 'CHF').format(symbol_position: :before)).to eq "CHF 100.00"
+        expect(Money.new(100_00, 'CHF').format(symbol_position: :before)).to eq "CHF100.00"
       end
 
       it "inserts currency symbol after the amount when set to :after" do


### PR DESCRIPTION
### What/Why

When using this gem in a project a warning is thrown.

```sh
/usr/local/bundle/gems/money-6.16.0/lib/money.rb:1: 
  warning: 
    bigdecimal was loaded from the standard library,  
    but will no longer be part of the default gems since  
    Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec.  
    Also contact author of money-6.16.0 to add bigdecimal  
    into its gemspec.
```

Shopify has a related issue to the topic, see their issue [#1772](https://github.com/Shopify/liquid/issues/1772).

### What was done

- [x] fixed the specs, as one was erroring out. This could potentially break how CHF (Swiss Franks) were supposed to work. Please see https://github.com/RubyMoney/money/pull/1055 and provide some feedback 🙏
- [x] add `bigdecimal` gem to gemspec file with a condition for the used version of the gem
- [x] entry in CHANGELOG.md and AUTHORS 