### PR TITLE
Replace deprecated method and add Ethereum (ETH) to non-ISO currencies

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,6 +30,7 @@ Dave Kroondyk
 Diego Aguir Selzlein
 Doug Droper
 Douglas Miller
+Douglas Suptitz Franca
 Ed Saunders
 Edwin Vlieg
 Eloy

--- a/config/currency_non_iso.json
+++ b/config/currency_non_iso.json
@@ -142,5 +142,20 @@
     "thousands_separator": ",",
     "iso_numeric": "",
     "smallest_denomination": 1
+  },
+  "eth": {
+    "priority": 100,
+    "iso_code": "ETH",
+    "name": "Ethereum",
+    "symbol": "Ξ",
+    "alternate_symbols": [],
+    "subunit": "Wei",
+    "subunit_to_unit": 1000000000000000000,
+    "symbol_first": true,
+    "html_entity": "&#x039E;",
+    "decimal_mark": ".",
+    "thousands_separator": ",",
+    "iso_numeric": "",
+    "smallest_denomination": 1
   }
 }

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -336,6 +336,7 @@ describe Money::Currency do
 
     it "returns false if the currency is not iso" do
       expect(described_class.new(:btc).iso?).to be false
+      expect(described_class.new(:eth).iso?).to be false
     end
   end
 

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -917,20 +917,26 @@ describe Money, "formatting" do
       specify "(drop_trailing_zeros: true) works as documented" do
         expect(Money.new(89000, "BTC").format(drop_trailing_zeros: true, symbol: false)).to eq "0.00089"
         expect(Money.new(89000, "BCH").format(drop_trailing_zeros: true, symbol: false)).to eq "0.00089"
+        expect(Money.new(890000000000000000, "ETH").format(drop_trailing_zeros: true, symbol: false)).to eq "0.89"
         expect(Money.new(100089000, "BTC").format(drop_trailing_zeros: true, symbol: false)).to eq "1.00089"
         expect(Money.new(100089000, "BCH").format(drop_trailing_zeros: true, symbol: false)).to eq "1.00089"
+        expect(Money.new(1000890000000000000, "ETH").format(drop_trailing_zeros: true, symbol: false)).to eq "1.00089"
         expect(Money.new(100000000, "BTC").format(drop_trailing_zeros: true, symbol: false)).to eq "1"
         expect(Money.new(100000000, "BCH").format(drop_trailing_zeros: true, symbol: false)).to eq "1"
+        expect(Money.new(1000000000000000000, "ETH").format(drop_trailing_zeros: true, symbol: false)).to eq "1"
         expect(Money.new(110, "AUD").format(drop_trailing_zeros: true, symbol: false)).to eq "1.1"
       end
 
       specify "(drop_trailing_zeros: false) works as documented" do
         expect(Money.new(89000, "BTC").format(drop_trailing_zeros: false, symbol: false)).to eq "0.00089000"
         expect(Money.new(89000, "BCH").format(drop_trailing_zeros: false, symbol: false)).to eq "0.00089000"
+        expect(Money.new(890000000000000000, "ETH").format(drop_trailing_zeros: false, symbol: false)).to eq "0.890000000000000000"
         expect(Money.new(100089000, "BTC").format(drop_trailing_zeros: false, symbol: false)).to eq "1.00089000"
         expect(Money.new(100089000, "BCH").format(drop_trailing_zeros: false, symbol: false)).to eq "1.00089000"
+        expect(Money.new(1000890000000000000, "ETH").format(drop_trailing_zeros: false, symbol: false)).to eq "1.000890000000000000"
         expect(Money.new(100000000, "BTC").format(drop_trailing_zeros: false, symbol: false)).to eq "1.00000000"
         expect(Money.new(100000000, "BCH").format(drop_trailing_zeros: false, symbol: false)).to eq "1.00000000"
+        expect(Money.new(1000000000000000000, "ETH").format(drop_trailing_zeros: false, symbol: false)).to eq "1.000000000000000000"
         expect(Money.new(110, "AUD").format(drop_trailing_zeros: false, symbol: false)).to eq "1.10"
       end
     end


### PR DESCRIPTION
This pull request include one change:

1. **Add Ethereum (ETH) to non-ISO currencies:** Ethereum has been added to the list of non-ISO currencies, allowing the Money library to handle transactions in Ethereum.