### PR TITLE
Fix Round-Robin Distribution Logic in Money Allocation

### DIFF
--- a/lib/money/money/allocation.rb
+++ b/lib/money/money/allocation.rb
@@ -42,9 +42,9 @@ class Money
 
       ## round-robin allocation of any remaining pennies
       if result.size > 0
-        while remaining_amount != 0
-          index = 0
+        index = 0
 
+        while remaining_amount != 0
           amount_to_distribute = [1, remaining_amount.abs].min
 
           if remaining_amount > 0


### PR DESCRIPTION
This pull request addresses a flaw in the round-robin distribution logic within the money allocation functionality. Previously, the `index` variable was reset to 0 at the beginning of each iteration of the while loop, causing all operations for distributing the `amount_to_distribute` to be applied exclusively to the first element of the `result` array (`result[0]`). This prevented the correct round-robin distribution across all elements of the array.

The fix involves initializing the `index` variable **outside the while loop**, allowing it to retain its value across iterations. This change ensures that the `amount_to_distribute` is correctly applied to each element in the `result` array in a round-robin fashion.

The fact was probably not noticed, as the `remaining_amount` never seems to be above 1 due to the previous distribution (at least I have not succeeded in constructing a corresponding test case). In this respect, no erroneous results were produced. Nevertheless, I am of the opinion that it should be corrected.


