### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/money.gemspec
+++ b/money.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |s|
     s.metadata['changelog_uri'] = 'https://github.com/RubyMoney/money/blob/master/CHANGELOG.md'
     s.metadata['source_code_uri'] = 'https://github.com/RubyMoney/money/'
     s.metadata['bug_tracker_uri'] = 'https://github.com/RubyMoney/money/issues'
+    s.metadata['rubygems_mfa_required'] = 'true'
   end
 end


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/