### PR TITLE
Fix deprecation warning when running specs

### DIFF
--- a/spec/bank/base_spec.rb
+++ b/spec/bank/base_spec.rb
@@ -32,25 +32,25 @@ describe Money::Bank::Base do
 
   describe "#exchange_with" do
     it "is not implemented" do
-      expect { subject.exchange_with(Money.new(100, 'USD'), 'EUR') }.to raise_exception(NotImplementedError)
+      expect { subject.exchange_with(Money.new(100, 'USD'), 'EUR') }.to raise_error(NotImplementedError)
     end
   end
 
   describe "#same_currency?" do
     it "accepts str/str" do
-      expect { subject.send(:same_currency?, 'USD', 'EUR') }.to_not raise_exception
+      expect { subject.send(:same_currency?, 'USD', 'EUR') }.to_not raise_error
     end
 
     it "accepts currency/str" do
-      expect { subject.send(:same_currency?, Money::Currency.wrap('USD'), 'EUR') }.to_not raise_exception
+      expect { subject.send(:same_currency?, Money::Currency.wrap('USD'), 'EUR') }.to_not raise_error
     end
 
     it "accepts str/currency" do
-      expect { subject.send(:same_currency?, 'USD', Money::Currency.wrap('EUR')) }.to_not raise_exception
+      expect { subject.send(:same_currency?, 'USD', Money::Currency.wrap('EUR')) }.to_not raise_error
     end
 
     it "accepts currency/currency" do
-      expect { subject.send(:same_currency?, Money::Currency.wrap('USD'), Money::Currency.wrap('EUR')) }.to_not raise_exception
+      expect { subject.send(:same_currency?, Money::Currency.wrap('USD'), Money::Currency.wrap('EUR')) }.to_not raise_error
     end
 
     it "returns true when currencies match" do
@@ -67,8 +67,8 @@ describe Money::Bank::Base do
       expect(subject.send(:same_currency?, Money::Currency.wrap('USD'), Money::Currency.wrap('EUR'))).to be false
     end
 
-    it "raises an UnknownCurrency exception when an unknown currency is passed" do
-      expect { subject.send(:same_currency?, 'AAA', 'BBB') }.to raise_exception(Money::Currency::UnknownCurrency)
+    it "raises an UnknownCurrency error when an unknown currency is passed" do
+      expect { subject.send(:same_currency?, 'AAA', 'BBB') }.to raise_error(Money::Currency::UnknownCurrency)
     end
   end
 end

--- a/spec/bank/single_currency_spec.rb
+++ b/spec/bank/single_currency_spec.rb
@@ -3,7 +3,7 @@ describe Money::Bank::SingleCurrency do
     it "raises when called" do
       expect {
         subject.exchange_with(Money.new(100, 'USD'), 'EUR')
-      }.to raise_exception(Money::Bank::DifferentCurrencyError, "No exchanging of currencies allowed: 1.00 USD to EUR")
+      }.to raise_error(Money::Bank::DifferentCurrencyError, "No exchanging of currencies allowed: 1.00 USD to EUR")
     end
   end
 end

--- a/spec/bank/variable_exchange_spec.rb
+++ b/spec/bank/variable_exchange_spec.rb
@@ -33,11 +33,11 @@ describe Money::Bank::VariableExchange do
 
       describe "#exchange_with" do
         it "accepts str" do
-          expect { bank.exchange_with(Money.new(100, 'USD'), 'EUR') }.to_not raise_exception
+          expect { bank.exchange_with(Money.new(100, 'USD'), 'EUR') }.to_not raise_error
         end
 
         it "accepts currency" do
-          expect { bank.exchange_with(Money.new(100, 'USD'), Money::Currency.wrap('EUR')) }.to_not raise_exception
+          expect { bank.exchange_with(Money.new(100, 'USD'), Money::Currency.wrap('EUR')) }.to_not raise_error
         end
 
         it "exchanges one currency to another" do
@@ -48,12 +48,12 @@ describe Money::Bank::VariableExchange do
           expect(bank.exchange_with(Money.new(10, 'USD'), 'EUR')).to eq Money.new(13, 'EUR')
         end
 
-        it "raises an UnknownCurrency exception when an unknown currency is requested" do
-          expect { bank.exchange_with(Money.new(100, 'USD'), 'BBB') }.to raise_exception(Money::Currency::UnknownCurrency)
+        it "raises an UnknownCurrency error when an unknown currency is requested" do
+          expect { bank.exchange_with(Money.new(100, 'USD'), 'BBB') }.to raise_error(Money::Currency::UnknownCurrency)
         end
 
-        it "raises an UnknownRate exception when an unknown rate is requested" do
-          expect { bank.exchange_with(Money.new(100, 'USD'), 'JPY') }.to raise_exception(Money::Bank::UnknownRate)
+        it "raises an UnknownRate error when an unknown rate is requested" do
+          expect { bank.exchange_with(Money.new(100, 'USD'), 'JPY') }.to raise_error(Money::Bank::UnknownRate)
         end
 
         #it "rounds the exchanged result down" do
@@ -136,8 +136,8 @@ describe Money::Bank::VariableExchange do
       expect(subject.store.get_rate('USD', 'EUR')).to eq 1.25
     end
 
-    it "raises an UnknownCurrency exception when an unknown currency is passed" do
-      expect { subject.set_rate('AAA', 'BBB', 1.25) }.to raise_exception(Money::Currency::UnknownCurrency)
+    it "raises an UnknownCurrency error when an unknown currency is passed" do
+      expect { subject.set_rate('AAA', 'BBB', 1.25) }.to raise_error(Money::Currency::UnknownCurrency)
     end
   end
 
@@ -147,8 +147,8 @@ describe Money::Bank::VariableExchange do
       expect(subject.get_rate('USD', 'EUR')).to eq 1.25
     end
 
-    it "raises an UnknownCurrency exception when an unknown currency is passed" do
-      expect { subject.get_rate('AAA', 'BBB') }.to raise_exception(Money::Currency::UnknownCurrency)
+    it "raises an UnknownCurrency error when an unknown currency is passed" do
+      expect { subject.get_rate('AAA', 'BBB') }.to raise_error(Money::Currency::UnknownCurrency)
     end
 
     it "delegates options to store, options are a no-op" do

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -367,7 +367,7 @@ describe Money::Currency do
     end
 
     it "doesn't create new symbols indefinitely" do
-      expect { described_class.new("bogus") }.to raise_exception(described_class::UnknownCurrency)
+      expect { described_class.new("bogus") }.to raise_error(described_class::UnknownCurrency)
       expect(Symbol.all_symbols.map{|s| s.to_s}).not_to include("bogus")
     end
   end

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -755,7 +755,6 @@ describe Money::Arithmetic do
 
   %w(+ - / divmod remainder).each do |op|
     describe "##{op}" do
-      subject { ->(other = self.other) { instance.send(op, other) } }
       let(:instance) { Money.usd(1) }
 
       context 'when conversions disallowed' do
@@ -771,12 +770,18 @@ describe Money::Arithmetic do
 
         context 'and other is money with different currency' do
           let(:other) { Money.gbp(1) }
-          it { should raise_error Money::Bank::DifferentCurrencyError }
+
+          it 'raises Money::Bank::DifferentCurrencyError' do
+            expect { instance.send(op, other) }.to raise_error Money::Bank::DifferentCurrencyError
+          end
 
           context 'even for zero' do
             let(:instance) { Money.usd(0) }
             let(:other) { Money.gbp(0) }
-            it { should raise_error Money::Bank::DifferentCurrencyError }
+
+            it 'raises Money::Bank::DifferentCurrencyError' do
+              expect { instance.send(op, other) }.to raise_error Money::Bank::DifferentCurrencyError
+            end
           end
         end
       end

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -673,19 +673,19 @@ describe Money::Arithmetic do
     it "raises TypeError dividing by a Money (unless other is a Money)" do
       expect {
         2 / Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_error(TypeError)
     end
 
     it "raises TypeError subtracting by a Money (unless other is a Money)" do
       expect {
         2 - Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_error(TypeError)
     end
 
     it "raises TypeError adding by a Money (unless other is a Money)" do
       expect {
         2 + Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_error(TypeError)
     end
 
     it "allows subtraction from numeric zero" do
@@ -701,7 +701,7 @@ describe Money::Arithmetic do
     it "treats multiplication as commutative" do
       expect {
         2 * Money.new(2, 'USD')
-      }.to_not raise_exception
+      }.to_not raise_error
       result = 2 * Money.new(2, 'USD')
       expect(result).to eq(Money.new(4, 'USD'))
     end
@@ -709,25 +709,25 @@ describe Money::Arithmetic do
     it "doesn't work with non-numerics" do
       expect {
         "2" * Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_error(TypeError)
     end
 
     it "correctly handles <=>" do
       expect {
         2 < Money.new(2, 'USD')
-      }.to raise_exception(ArgumentError)
+      }.to raise_error(ArgumentError)
 
       expect {
         2 > Money.new(2, 'USD')
-      }.to raise_exception(ArgumentError)
+      }.to raise_error(ArgumentError)
 
       expect {
         2 <= Money.new(2, 'USD')
-      }.to raise_exception(ArgumentError)
+      }.to raise_error(ArgumentError)
 
       expect {
         2 >= Money.new(2, 'USD')
-      }.to raise_exception(ArgumentError)
+      }.to raise_error(ArgumentError)
 
       expect(2 <=> Money.new(2, 'USD')).to be_nil
     end
@@ -738,18 +738,18 @@ describe Money::Arithmetic do
       expect(0.0 >= Money.usd(0)).to eq true
     end
 
-    it "raises exceptions for all numeric types, not just Integer" do
+    it "raises errors for all numeric types, not just Integer" do
       expect {
         2.0 / Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_error(TypeError)
 
       expect {
         Rational(2,3) / Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_error(TypeError)
 
       expect {
         BigDecimal(2) / Money.new(2, 'USD')
-      }.to raise_exception(TypeError)
+      }.to raise_error(TypeError)
     end
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -160,7 +160,7 @@ describe Money do
 
     it "disallows conversions when doing money arithmetic" do
       Money.disallow_currency_conversion!
-      expect { Money.new(100, "USD") + Money.new(100, "EUR") }.to raise_exception(Money::Bank::DifferentCurrencyError)
+      expect { Money.new(100, "USD") + Money.new(100, "EUR") }.to raise_error(Money::Bank::DifferentCurrencyError)
     end
   end
 
@@ -417,7 +417,7 @@ YAML
       expect(money.round_to_nearest_cash_value).to eq(-301)
     end
 
-    it "raises an exception if smallest denomination is not defined" do
+    it "raises an error if smallest denomination is not defined" do
       money = Money.new(100, "XAG")
       expect {money.round_to_nearest_cash_value}.to raise_error(Money::UndefinedSmallestDenomination)
     end


### PR DESCRIPTION
Also, `raise_error` better clarifies what is expected from specs and is also
shorter

- `ArgumentError` and `TypeError` are errors
- `DifferentCurrencyError`, `UndefinedSmallestDenomination`, and
  `UnknownRate` inherit from `Error`
- `UnknownCurrency` inherits from `ArgumentError`

Close #1076

---

Requires #1078 to pass CI