### PR TITLE
Test against Ruby 3.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Ruby 3.3 is the stable Ruby version at the moment.

Also updates the checkout action to the latest available to prevent a deprecation warning related to Node 16 based actions.

> [!IMPORTANT]  
> Requires a change in Settings by a repository admin (see below comment)