### PR TITLE
Require Ruby 3.1 and fix bigdecimal requirement

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v4

--- a/money.gemspec
+++ b/money.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "yard", "~> 0.9.11"
   s.add_development_dependency "kramdown", "~> 2.3"
 
+  s.required_ruby_version = '>= 3.1'
+
   s.files         = `git ls-files -z -- config/* lib/* CHANGELOG.md LICENSE money.gemspec README.md`.split("\x0")
   s.require_paths = ["lib"]
 

--- a/money.gemspec
+++ b/money.gemspec
@@ -14,8 +14,7 @@ Gem::Specification.new do |s|
   s.description = "A Ruby Library for dealing with money and currency conversion."
   s.license     = "MIT"
 
-
-  s.add_dependency "bigdecimal", "~> 3.1" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('6.19.0')
+  s.add_dependency "bigdecimal"
   s.add_dependency 'i18n', [">= 0.6.4", '<= 2']
 
   s.add_development_dependency "bundler"


### PR DESCRIPTION
Set minimum Ruby version to 3.1

Drop all EOL Ruby versions

Close #1086

---

Remove conditional on bigdecimal

- bigdecimal installs and works fine on all supported ruby versions
- The condition was checking for ruby version to be greater than 6.19,
  which will not happen soon
- The condition is also evaluated on `rubygems`, and it is not correct

Close #1085