### PR TITLE
Change USDC decimal places from 2 to 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming
 
--
+- **Potential breaking change**: Fix USDC decimals places from 2 to 6
 
 ## 6.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Upcoming
+## Upcoming 7.0.0.alpha
 
 - **Potential breaking change**: Fix USDC decimals places from 2 to 6
 

--- a/config/currency_non_iso.json
+++ b/config/currency_non_iso.json
@@ -135,7 +135,7 @@
     "disambiguate_symbol": "USDC",
     "alternate_symbols": [],
     "subunit": "Cent",
-    "subunit_to_unit": 100,
+    "subunit_to_unit": 1000000,
     "symbol_first": false,
     "html_entity": "$",
     "decimal_mark": ".",

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -858,7 +858,7 @@ describe Money, "formatting" do
       expect(Money.new(1999_98, "NOK").format).to eq("1.999,98 kr")
       expect(Money.new(1999_98, "SEK").format).to eq("1 999,98 kr")
       expect(Money.new(1999_98, "BCH").format).to eq("0.00199998 ₿")
-      expect(Money.new(1999_98, "USDC").format).to eq("1,999.98 USDC")
+      expect(Money.new(1999_98, "USDC").format).to eq("0.199998 USDC")
     end
 
     it "returns ambiguous signs when disambiguate is false" do
@@ -868,7 +868,7 @@ describe Money, "formatting" do
       expect(Money.new(1999_98, "NOK").format(disambiguate: false)).to eq("1.999,98 kr")
       expect(Money.new(1999_98, "SEK").format(disambiguate: false)).to eq("1 999,98 kr")
       expect(Money.new(1999_98, "BCH").format(disambiguate: false)).to eq("0.00199998 ₿")
-      expect(Money.new(1999_98, "USDC").format(disambiguate: false)).to eq("1,999.98 USDC")
+      expect(Money.new(1999_98, "USDC").format(disambiguate: false)).to eq("0.199998 USDC")
     end
 
     it "returns disambiguate signs when disambiguate: true" do
@@ -878,7 +878,7 @@ describe Money, "formatting" do
       expect(Money.new(1999_98, "NOK").format(disambiguate: true)).to eq("1.999,98 NOK")
       expect(Money.new(1999_98, "SEK").format(disambiguate: true)).to eq("1 999,98 SEK")
       expect(Money.new(1999_98, "BCH").format(disambiguate: true)).to eq("0.00199998 ₿CH")
-      expect(Money.new(1999_98, "USDC").format(disambiguate: true)).to eq("1,999.98 USDC")
+      expect(Money.new(1999_98, "USDC").format(disambiguate: true)).to eq("0.199998 USDC")
     end
 
     it "returns disambiguate signs when disambiguate: true and symbol: true" do
@@ -888,7 +888,7 @@ describe Money, "formatting" do
       expect(Money.new(1999_98, "NOK").format(disambiguate: true, symbol: true)).to eq("1.999,98 NOK")
       expect(Money.new(1999_98, "SEK").format(disambiguate: true, symbol: true)).to eq("1 999,98 SEK")
       expect(Money.new(1999_98, "BCH").format(disambiguate: true, symbol: true)).to eq("0.00199998 ₿CH")
-      expect(Money.new(1999_98, "USDC").format(disambiguate: true, symbol: true)).to eq("1,999.98 USDC")
+      expect(Money.new(1999_98, "USDC").format(disambiguate: true, symbol: true)).to eq("0.199998 USDC")
     end
 
     it "returns no signs when disambiguate: true and symbol: false" do
@@ -898,7 +898,7 @@ describe Money, "formatting" do
       expect(Money.new(1999_98, "NOK").format(disambiguate: true, symbol: false)).to eq("1.999,98")
       expect(Money.new(1999_98, "SEK").format(disambiguate: true, symbol: false)).to eq("1 999,98")
       expect(Money.new(1999_98, "BCH").format(disambiguate: true, symbol: false)).to eq("0.00199998")
-      expect(Money.new(1999_98, "USDC").format(disambiguate: true, symbol: false)).to eq("1,999.98")
+      expect(Money.new(1999_98, "USDC").format(disambiguate: true, symbol: false)).to eq("0.199998")
     end
 
     it "should never return an ambiguous format with disambiguate: true" do


### PR DESCRIPTION
> [!WARNING]  
> This fix can introduce a breaking change

Before:
```
Money.new(100, "USDC").to_s
 => "1.00"
```


After:
```
Money.new(100, "USDC").to_s
 => "0.000100" 
```

Close #1081
