### PR TITLE
fix(currency): Albanian Lek subunit should be 1

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -39,14 +39,14 @@
     "disambiguate_symbol": "Lek",
     "alternate_symbols": ["Lek"],
     "subunit": "Qintar",
-    "subunit_to_unit": 100,
+    "subunit_to_unit": 1,
     "symbol_first": false,
     "format": "%n %u",
     "html_entity": "",
     "decimal_mark": ".",
     "thousands_separator": ",",
     "iso_numeric": "008",
-    "smallest_denomination": 100
+    "smallest_denomination": 1
   },
   "amd": {
     "priority": 100,


### PR DESCRIPTION
When using JavaScript Intl.NumberFormat, it shows different subunit for Albanian Lek currency. For example,

```javascript
let numFormat = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'ALL' });
let { minimumFractionDigits } = numFormat.resolvedOptions();
console.log(minimumFractionDigits);
// Result shows 0 instead of 2
```

Hence, I think it is necessary to change the Albanian Lek subunits to 1.
I believe this will be a breaking change as well.