### PR TITLE
Remove redundant encoding

### DIFF
--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "json"
 require "money/currency/loader"
 require "money/currency/heuristics"

--- a/lib/money/currency/heuristics.rb
+++ b/lib/money/currency/heuristics.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Money
   class Currency
     module Heuristics

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "money/bank/variable_exchange"
 require "money/bank/single_currency"
 require "money/money/arithmetic"

--- a/lib/money/money/allocation.rb
+++ b/lib/money/money/allocation.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class Money
   class Allocation
     # Splits a given amount in parts. The allocation is based on the parts' proportions

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 require 'money/money/formatting_rules'
 
 class Money

--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 class Money
   class FormattingRules
     def initialize(currency, *raw_rules)

--- a/lib/money/money/locale_backend.rb
+++ b/lib/money/money/locale_backend.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'money/locale_backend/errors'
 require 'money/locale_backend/legacy'
 require 'money/locale_backend/i18n'

--- a/money.gemspec
+++ b/money.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "money/version"

--- a/spec/currency/heuristics_spec.rb
+++ b/spec/currency/heuristics_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Money::Currency::Heuristics do
   describe "#analyze_string" do
     let(:it) { Money::Currency }

--- a/spec/currency/loader_spec.rb
+++ b/spec/currency/loader_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Money::Currency::Loader do
   it "returns a currency table hash" do
     expect(subject.load_currencies).to be_a Hash

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Money::Currency do
   FOO = '{ "priority": 1, "iso_code": "FOO", "iso_numeric": "840", "name": "United States Dollar", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 1000, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "smallest_denomination": 1 }'
 

--- a/spec/locale_backend/currency_spec.rb
+++ b/spec/locale_backend/currency_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Money::LocaleBackend::Currency do
   describe '#lookup' do
     let(:currency) { Money::Currency.new('EUR') }

--- a/spec/locale_backend/i18n_spec.rb
+++ b/spec/locale_backend/i18n_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Money::LocaleBackend::I18n do
   describe '#initialize' do
     it 'raises an error when I18n is not defined' do

--- a/spec/locale_backend/legacy_spec.rb
+++ b/spec/locale_backend/legacy_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Money::LocaleBackend::Legacy do
   after { Money.use_i18n = true }
 

--- a/spec/money/allocation_spec.rb
+++ b/spec/money/allocation_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Money::Allocation do
    describe 'given number as argument' do
      it 'raises an error when invalid argument is given' do

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Money::Arithmetic do
   describe "-@" do
     it "changes the sign of a number" do

--- a/spec/money/constructors_spec.rb
+++ b/spec/money/constructors_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Money::Constructors do
 
   describe "::empty" do

--- a/spec/money/formatting_rules_spec.rb
+++ b/spec/money/formatting_rules_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Money::FormattingRules do
   it 'does not modify frozen rules in place' do
     expect {

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Money, "formatting" do
 
   BAR = '{ "priority": 1, "iso_code": "BAR", "iso_numeric": "840", "name": "Dollar with 4 decimal places", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 10000, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "smallest_denomination": 1 }'

--- a/spec/money/locale_backend_spec.rb
+++ b/spec/money/locale_backend_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Money::LocaleBackend do
   describe '.find' do
     it 'returns an initialized backend' do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 describe Money do
   describe '.locale_backend' do
     after { Money.locale_backend = :legacy }


### PR DESCRIPTION
This magic comment is not needed anymore because the default encoding of source code files assumed by Ruby 2 is utf-8, and the minimum required Ruby version is 3.1

Autofixed with:
```
rubocop -a --only Style/Encoding
```