### PR TITLE
Allow nil to be used as a default_currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Update thousands_separator for CHF
 - Add Caribbean Guilder (XCG) as replacement for Netherlands Antillean Gulden (ANG)
 - Add `Currency#cents_based?` to check if currency is cents-based
+- Allow `nil` to be used as a default_currency
 
 ## 6.19.0
 

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -31,6 +31,9 @@ class Money
     # Thrown when an unknown currency is requested.
     class UnknownCurrency < ArgumentError; end
 
+    # Thrown when currency is not provided.
+    class NoCurrency < ArgumentError; end
+
     class << self
       def new(id)
         id = id.to_s.downcase

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -155,7 +155,9 @@ class Money
       @using_deprecated_default_currency = false
     end
 
-    if @default_currency.respond_to?(:call)
+    if @default_currency.nil?
+      nil
+    elsif @default_currency.respond_to?(:call)
       Money::Currency.new(@default_currency.call)
     else
       Money::Currency.new(@default_currency)
@@ -307,6 +309,8 @@ class Money
     raise ArgumentError, "'amount' must be numeric" unless Numeric === amount
 
     currency = Currency.wrap(currency) || Money.default_currency
+    raise Currency::NoCurrency, 'must provide a currency' if currency.nil?
+
     value = amount.to_d * currency.subunit_to_unit
     new(value, currency, options)
   end
@@ -337,7 +341,7 @@ class Money
   #   Money.new(100, "USD") #=> #<Money @fractional=100 @currency="USD">
   #   Money.new(100, "EUR") #=> #<Money @fractional=100 @currency="EUR">
   #
-  def initialize( obj, currency = Money.default_currency, options = {})
+  def initialize(obj, currency = Money.default_currency, options = {})
     # For backwards compatibility, if options is not a Hash, treat it as a bank parameter
     unless options.is_a?(Hash)
       options = { bank: options }
@@ -351,6 +355,7 @@ class Money
 
     # BigDecimal can be Infinity and NaN, money of that amount does not make sense
     raise ArgumentError, 'must be initialized with a finite value' unless @fractional.finite?
+    raise Currency::NoCurrency, 'must provide a currency' if @currency.nil?
   end
 
   # Assuming using a currency using dollars:

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -19,6 +19,12 @@ describe Money::Currency do
     end
   end
 
+  describe "NoCurrency" do
+    it "is a subclass of ArgumentError" do
+      expect(described_class::NoCurrency < ArgumentError).to be true
+    end
+  end
+
   describe ".find" do
     before { register_foo }
     after  { unregister_foo }

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -68,6 +68,21 @@ describe Money do
       it "should have the default currency" do
         expect(money.currency).to eq Money.default_currency
       end
+
+      context 'without a default' do
+        around do |example|
+          default_currency = Money.default_currency
+          Money.default_currency = nil
+
+          example.run
+
+          Money.default_currency = default_currency
+        end
+
+        it 'should throw an NoCurrency Error' do
+          expect { money }.to raise_error(Money::Currency::NoCurrency)
+        end
+      end
     end
 
     context 'given a currency is provided' do


### PR DESCRIPTION
This is a part of fixing the https://github.com/RubyMoney/money-rails/issues/697