### PR TITLE
Reverts HUF subunits back to ISO 4217

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -945,7 +945,7 @@
     "symbol": "Ft",
     "alternate_symbols": [],
     "subunit": "",
-    "subunit_to_unit": 1,
+    "subunit_to_unit": 100,
     "symbol_first": false,
     "format": "%n %u",
     "html_entity": "",


### PR DESCRIPTION
Subunits of Hungarian forint are no longer in circulation and were eliminated in #679.
However, ISO continues to treat HUF as a two decimal place currency.
This can be confirmed against the standard here: https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml

To align Money with the ISO 4217 standard, this change restores original behavior of considering HUF a 2 decimal point currency.
