### PR TITLE
Remove special handling for Japanese language only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Potential breaking change**: Fix RSD (Serbian Dinar) formatting to be like `12.345,42 RSD`
 - **Potential breaking change**: Fix USDC decimals places from 2 to 6
 - **Potential breaking change**: Fix MGA (Malagasy Ariary) to be a zero-decimal currency (changing subunit_to_unit from 5 to 1)
+- **Potential breaking change**: Remove special handling for Japanese language only
 - Updated Armenian Dram sign and HTML entity
 - Updated the Turkmen Manat symbol and HTML entity and added disambiguation symbol for TMM
 - Expose Money::VERSION

--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -9,7 +9,6 @@ class Money
       @rules = normalize_formatting_rules(raw_rules)
 
       @rules = default_formatting_rules.merge(@rules) unless @rules[:ignore_defaults]
-      @rules = localize_formatting_rules(@rules)
       @rules = translate_formatting_rules(@rules) if @rules[:translate]
       @rules[:format] ||= determine_format_from_formatting_rules(@rules)
       @rules[:delimiter_pattern] ||= delimiter_pattern_rule(@rules)
@@ -67,14 +66,6 @@ class Money
         rules[:symbol] = I18n.t currency.iso_code, scope: "number.currency.symbol", raise: true
       rescue I18n::MissingTranslationData
         # Do nothing
-      end
-      rules
-    end
-
-    def localize_formatting_rules(rules)
-      if currency.iso_code == "JPY" && I18n.locale == :ja && rules[:format] == nil
-        rules[:symbol] = "円" unless rules[:symbol] == false
-        rules[:format] = '%n%u'
       end
       rules
     end

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -145,7 +145,8 @@ RSpec.describe Money, "formatting" do
 
       it "formats Japanese currency in Japanese properly" do
         money = Money.new(1000, "JPY")
-        expect(money.format).to eq "1,000円"
+        expect(money.format).to eq "¥1,000"
+        expect(money.format(format: "%n%u", symbol: "円")).to eq "1,000円"
         expect(money.format(symbol: false)).to eq "1,000"
         expect(money.format(format: "%u%n")).to eq "¥1,000"
       end


### PR DESCRIPTION
I am the one who submitted https://github.com/RubyMoney/money/pull/1067.

Since money 7.0.0 is being developed, I have made modifications to remove special handling for the Japanese language only.

By removing `Money::FormattingRules#localize_formatting_rules`, this will be a breaking change but will ensure consistent behavior across all languages.

This is the correct behavior as pointed out here:
https://github.com/RubyMoney/money/pull/650