### PR TITLE
update README with customising currency symbol example

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,12 @@ m = Money.from_cents('123', :gbp) # => #<Money fractional:123 currency:GBP>
 m.format(symbol: m.currency.to_s + ' ') # => "GBP 1.23"
 ```
 
+If you would like to customise currency symbols (e.g to avoid ambiguous between currencies), you can set custom symbol for specific currency as following
+
+```ruby
+  Money::Currency.table[hkd][:symbol] = 'HK$'
+```
+
 ## Rounding
 
 By default, `Money` objects are rounded to the nearest cent and the additional precision is not preserved:


### PR DESCRIPTION
## Context
Sometimes, there are currencies which have multiple symbols (e.g Hong Kong Dollar can be represented with `$` or `HK$`. When an application supports multiple currencies, this produces ambiguous interpretation which currency is displayed (.e.g USD or HKD). This PR adds an example to the README how to do it (e.g can be placed in the gem initialiser in rails app).


## Changes
 - Update ReadMe with more currency formatting instruction.

## Tests
 - [x] Tests passed