### PR TITLE
Bump Ruby I18n requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Upcoming 7.0.0.alpha
 
+- Require Ruby >= 3.1 and I18n ~> 1.9
 - **Potential breaking change**: Fix USDC decimals places from 2 to 6
 - **Potential breaking change**: Fix MGA (Malagasy Ariary) to be a zero-decimal currency (changing subunit_to_unit from 5 to 1)
 - Fix typo in ILS currency

--- a/money.gemspec
+++ b/money.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.add_dependency "bigdecimal"
-  s.add_dependency 'i18n', [">= 0.6.4", '<= 2']
+  s.add_dependency 'i18n', "~> 1.9"
 
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"


### PR DESCRIPTION
Require 1.9, the first version tested against Ruby 3.1

Close #1097

Ref: https://github.com/ruby-i18n/i18n/releases?page=2