### PR TITLE
fix typo in Shekel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming 7.0.0.alpha
 
 - **Potential breaking change**: Fix USDC decimals places from 2 to 6
+- Fix typo in ILS currency
 
 ## 6.19.0
 

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -972,7 +972,7 @@
   "ils": {
     "priority": 100,
     "iso_code": "ILS",
-    "name": "Israeli New Sheqel",
+    "name": "Israeli New Shekel",
     "symbol": "₪",
     "alternate_symbols": ["ש״ח", "NIS"],
     "subunit": "Agora",


### PR DESCRIPTION
Hello! 

One of our customers reported a typo in the word "Sheqel" which should be "Shekel". A quick [Google search](https://www.google.com/search?q=ILS+currency&sca_esv=f39be0dcf9683254&sca_upv=1&ei=sWrEZtSlIPKH9u8P-6768Ag&ved=0ahUKEwiUwo2oqYOIAxXyg_0HHXuXHo4Q4dUDCA8&uact=5&oq=ILS+currency&gs_lp=Egxnd3Mtd2l6LXNlcnAiDElMUyBjdXJyZW5jeTIKEAAYgAQYQxiKBTIFEAAYgAQyBRAAGIAEMgUQABiABDIFEAAYgAQyBRAAGIAEMgUQABiABDIFEAAYgAQyBRAAGIAEMgUQABiABEiWClDnAVjRCHABeAGQAQCYAY8BoAHHB6oBAzUuNLgBA8gBAPgBAZgCCqAC4gfCAgoQABiwAxjWBBhHwgINEAAYgAQYsAMYQxiKBcICBRAuGIAEmAMAiAYBkAYKkgcDNS41oAf5Lg&sclient=gws-wiz-serp) agrees with it.

Thanks!