### PR TITLE
Add ZWG

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -2716,5 +2716,20 @@
     "thousands_separator": ",",
     "iso_numeric": "967",
     "smallest_denomination": 5
+  },
+  "zwg": {
+    "priority": 100,
+    "iso_code": "ZWG",
+    "name": "Zimbabwe Gold",
+    "symbol": "ZiG",
+    "alternate_symbols": [],
+    "subunit": "cent",
+    "subunit_to_unit": 100,
+    "symbol_first": false,
+    "html_entity": "",
+    "decimal_mark": ".",
+    "thousands_separator": ",",
+    "iso_numeric": "924",
+    "smallest_denomination": 1
   }
 }


### PR DESCRIPTION
Zimbabwe Gold is the official currency of Zimbabwe as of April 8 2024. This PR adds support for the new currency https://en.wikipedia.org/wiki/Zimbabwean_ZiG