### PR TITLE
Deleted disambiguate_symbol for USD

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -2323,7 +2323,6 @@
     "iso_code": "USD",
     "name": "United States Dollar",
     "symbol": "$",
-    "disambiguate_symbol": "US$",
     "alternate_symbols": ["US$"],
     "subunit": "Cent",
     "subunit_to_unit": 100,


### PR DESCRIPTION
USD should not have `disambiguate_symbol` and prices in USD should always be formatted like `$10,000`, the documentation confirms this: https://github.com/RubyMoney/money/blob/main/lib/money/money/formatter.rb#L181.

Currently, `Money.new(100, 'USD').format(disambiguate: true)` prints `US$1.00`, which is wrong and confusing.