### PR TITLE
FIx doc comment error in formatter.rb

### DIFF
--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -185,7 +185,7 @@ class Money
     #  in a html <span> tag.
     #
     # @example
-    #   Money.new(10000, "USD").format(disambiguate: false)
+    #   Money.new(10000, "USD").format(html_wrap_symbol: true)
     #   #=> "<span class=\"currency_symbol\">$100.00</span>
     #
     # @option rules [Symbol] :symbol_position (:before) `:before` if the currency


### PR DESCRIPTION
The example for the documentation of the `:html_wrap_symbol` option showed the Ruby code from the previous option, `:disambiguate`, with the correct resulting string. Fixed to show the correct option being used in the example.