### PR TITLE
Add Caribbean Guilder (XGG)

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -2557,6 +2557,21 @@
     "iso_numeric": "951",
     "smallest_denomination": 1
   },
+  "xcg": {
+    "priority": 100,
+    "iso_code": "XCG",
+    "name": "Caribbean Guilder",
+    "symbol": "Cg",
+    "alternate_symbols": [],
+    "subunit": "Cent",
+    "subunit_to_unit": 100,
+    "symbol_first": true,
+    "html_entity": "",
+    "decimal_mark": ",",
+    "thousands_separator": ".",
+    "iso_numeric": "532",
+    "smallest_denomination": 1
+  },
   "xdr": {
     "priority": 100,
     "iso_code": "XDR",


### PR DESCRIPTION
In this PR we're adding the Caribbean Guilder currency

https://en.wikipedia.org/wiki/Caribbean_guilder#:~:text=The%20Caribbean%20guilder%20(code%3A%20XCG,slated%20for%20introduction%20in%202025.