### PR TITLE
Added Caribbean Guilder (XCG) currency

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -2557,6 +2557,22 @@
     "iso_numeric": "951",
     "smallest_denomination": 1
   },
+  "xcg": {
+    "priority": 100,
+    "iso_code": "XCG",
+    "name": "Caribbean Guilder",
+    "symbol": "Cg",
+    "alternate_symbols": ["ƒ"],
+    "subunit": "Cent",
+    "subunit_to_unit": 100,
+    "symbol_first": false,
+    "format": "%n %u",
+    "html_entity": "&#x0192;",
+    "decimal_mark": ".",
+    "thousands_separator": ",",
+    "iso_numeric": "532",
+    "smallest_denomination": 1
+  },
   "xdr": {
     "priority": 100,
     "iso_code": "XDR",


### PR DESCRIPTION
This currency is officially introduced on the 31th of March 2025. 

See here: https://en.wikipedia.org/wiki/Caribbean_guilder