### PR TITLE
Fix MGA (Malagasy Ariary) to be a zero-decimal currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming 7.0.0.alpha
 
 - **Potential breaking change**: Fix USDC decimals places from 2 to 6
+- **Potential breaking change**: Fix MGA (Malagasy Ariary) to be a zero-decimal currency (changing subunit_to_unit from 5 to 1)
 - Fix typo in ILS currency
 - Add Caribbean Guilder (XCG) as replacement for Netherlands Antillean Gulden (ANG)
 

--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -1371,7 +1371,7 @@
     "symbol": "Ar",
     "alternate_symbols": [],
     "subunit": "Iraimbilanja",
-    "subunit_to_unit": 5,
+    "subunit_to_unit": 1,
     "symbol_first": true,
     "html_entity": "",
     "decimal_mark": ".",

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -298,8 +298,8 @@ describe Money, "formatting" do
       specify "(no_cents_if_whole: true) works as documented" do
         expect(Money.new(10000, "VUV").format(no_cents_if_whole: true, symbol: false)).to eq "10,000"
         expect(Money.new(10034, "VUV").format(no_cents_if_whole: true, symbol: false)).to eq "10,034"
-        expect(Money.new(10000, "MGA").format(no_cents_if_whole: true, symbol: false)).to eq "2,000"
-        expect(Money.new(10034, "MGA").format(no_cents_if_whole: true, symbol: false)).to eq "2,006.8"
+        expect(Money.new(10000, "MGA").format(no_cents_if_whole: true, symbol: false)).to eq "10,000"
+        expect(Money.new(10034, "MGA").format(no_cents_if_whole: true, symbol: false)).to eq "10,034"
         expect(Money.new(10000, "VND").format(no_cents_if_whole: true, symbol: false)).to eq "10.000"
         expect(Money.new(10034, "VND").format(no_cents_if_whole: true, symbol: false)).to eq "10.034"
         expect(Money.new(10000, "USD").format(no_cents_if_whole: true, symbol: false)).to eq "100"
@@ -311,8 +311,8 @@ describe Money, "formatting" do
       specify "(no_cents_if_whole: false) works as documented" do
         expect(Money.new(10000, "VUV").format(no_cents_if_whole: false, symbol: false)).to eq "10,000"
         expect(Money.new(10034, "VUV").format(no_cents_if_whole: false, symbol: false)).to eq "10,034"
-        expect(Money.new(10000, "MGA").format(no_cents_if_whole: false, symbol: false)).to eq "2,000.0"
-        expect(Money.new(10034, "MGA").format(no_cents_if_whole: false, symbol: false)).to eq "2,006.8"
+        expect(Money.new(10000, "MGA").format(no_cents_if_whole: false, symbol: false)).to eq "10,000"
+        expect(Money.new(10034, "MGA").format(no_cents_if_whole: false, symbol: false)).to eq "10,034"
         expect(Money.new(10000, "VND").format(no_cents_if_whole: false, symbol: false)).to eq "10.000"
         expect(Money.new(10034, "VND").format(no_cents_if_whole: false, symbol: false)).to eq "10.034"
         expect(Money.new(10000, "USD").format(no_cents_if_whole: false, symbol: false)).to eq "100.00"
@@ -627,7 +627,7 @@ describe Money, "formatting" do
         expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq "د.ب0.124"
         expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: true)).to eq "$1.00"
         expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: true)).to eq "$1.10"
-        expect(Money.new(BigDecimal('1.7'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar0.4"
+        expect(Money.new(BigDecimal('1.7'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar2.0"
       end
 
       it "does not round fractional when set to false" do
@@ -639,7 +639,7 @@ describe Money, "formatting" do
         expect(Money.new(BigDecimal('123.5'), "KWD").format(rounded_infinite_precision: false)).to eq "د.ك0.1235"
         expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: false)).to eq "$1.001"
         expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: false)).to eq "$1.095"
-        expect(Money.new(BigDecimal('1.7'), "MGA").format(rounded_infinite_precision: false)).to eq "Ar0.34"
+        expect(Money.new(BigDecimal('1.7'), "MGA").format(rounded_infinite_precision: false)).to eq "Ar1.7"
       end
 
       describe "with i18n = false" do
@@ -685,7 +685,7 @@ describe Money, "formatting" do
           expect(Money.new(BigDecimal('123.5'), "BHD").format(rounded_infinite_precision: true)).to eq "د.ب0,124"
           expect(Money.new(BigDecimal('100.1'), "USD").format(rounded_infinite_precision: true)).to eq "$1,00"
           expect(Money.new(BigDecimal('109.5'), "USD").format(rounded_infinite_precision: true)).to eq "$1,10"
-          expect(Money.new(BigDecimal('1'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar0,2"
+          expect(Money.new(BigDecimal('1'), "MGA").format(rounded_infinite_precision: true)).to eq "Ar1,0"
         end
       end
     end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -538,7 +538,7 @@ YAML
     end
 
     it "does not work when :subunit_to_unit == 5" do
-      expect(Money.new(10_00, "MGA").to_s).to eq "200.0"
+      expect(Money.new(10_00, "MRU").to_s).to eq "200.0"
     end
 
     it "respects :decimal_mark" do


### PR DESCRIPTION
According to Stripe's documentation (https://docs.stripe.com/currencies#zero-decimal), MGA is included in their list of zero-decimal currencies, and this change ensures the Money gem correctly formats MGA amounts without decimal places.

Also from the [Wikipedia](https://en.wikipedia.org/wiki/Malagasy_ariary) entry:

> It is notionally subdivided into 5 iraimbilanja and is one of only two non-decimal currencies currently circulating (the other is the Mauritanian ouguiya). The names ariary and iraimbilanja derive from the pre-colonial currency, with ariary (from the Spanish word "real") being the name for a silver dollar. Iraimbilanja means "one iron weight" and was the name of an old coin worth 1⁄5 of an ariary. However, as of May 2023, the unit is effectively obsolete since the iraimbilanja has practically no purchasing power, and the coins have fallen into disuse.