### PR TITLE
Add ability to nest `Money.with_rounding_mode` blocks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -76,6 +76,7 @@ Kenn Ejima
 Kenneth Salomon
 kirillian
 Laurynas Butkus
+Łukasz Wójcik
 Marcel Scherf
 Marco Otte-Witte
 Mateus Gomes
@@ -97,6 +98,7 @@ Nick Lozon
 Nihad Abbasov
 Olek Janiszewski
 Orien Madgwick
+Paweł Madejski
 Paul McMahon
 Paulo Diniz
 Pavan Sudarshan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Potential breaking change**: Fix USDC decimals places from 2 to 6
 - Fix typo in ILS currency
 - Add Caribbean Guilder (XCG) as replacement for Netherlands Antillean Gulden (ANG)
+- Add ability to nest `Money.with_rounding_mode` blocks
 
 ## 6.19.0
 

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -263,10 +263,11 @@ class Money
   #     Money.new(1200) * BigDecimal('0.029')
   #   end
   def self.with_rounding_mode(mode)
+    original_mode = Thread.current[:money_rounding_mode]
     Thread.current[:money_rounding_mode] = mode
     yield
   ensure
-    Thread.current[:money_rounding_mode] = nil
+    Thread.current[:money_rounding_mode] = original_mode
   end
 
   # Adds a new exchange rate to the default bank and return the rate.

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -244,6 +244,27 @@ describe Money do
         Money.from_amount(1.999).to_d
       end).to eq 1.99
     end
+
+    it 'allows blocks nesting' do
+      Money.with_rounding_mode(BigDecimal::ROUND_DOWN) do
+        expect(Money.rounding_mode).to eq(BigDecimal::ROUND_DOWN)
+
+        Money.with_rounding_mode(BigDecimal::ROUND_UP) do
+          expect(Money.rounding_mode).to eq(BigDecimal::ROUND_UP)
+          expect(Money.from_amount(2.137).to_d).to eq 2.14
+        end
+
+        expect(
+          Money.rounding_mode
+        ).to eq(BigDecimal::ROUND_DOWN), 'Outer mode should be restored after inner block'
+        expect(Money.from_amount(2.137).to_d).to eq 2.13
+      end
+
+      expect(
+        Money.rounding_mode
+      ).to eq(BigDecimal::ROUND_HALF_EVEN), 'Original mode should be restored after outer block'
+      expect(Money.from_amount(2.137).to_d).to eq 2.14
+    end
   end
 
   %w[cents pence].each do |units|

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -223,15 +223,19 @@ describe Money do
   describe '.with_rounding_mode' do
     it 'sets the .rounding_mode method deprecated' do
       allow(Money).to receive(:warn)
+      allow(Money).to receive(:with_rounding_mode).and_call_original
+
+      rounding_block = lambda do
+        Money.from_amount(1.999).to_d
+      end
 
       expect(Money.from_amount(1.999).to_d).to eq 2
-      expect(Money.rounding_mode(BigDecimal::ROUND_DOWN) do
-        Money.from_amount(1.999).to_d
-      end).to eq 1.99
+      expect(Money.rounding_mode(BigDecimal::ROUND_DOWN, &rounding_block)).to eq 1.99
       expect(Money)
         .to have_received(:warn)
         .with('[DEPRECATION] calling `rounding_mode` with a block is deprecated. ' \
               'Please use `.with_rounding_mode` instead.')
+      expect(Money).to have_received(:with_rounding_mode).with(BigDecimal::ROUND_DOWN, &rounding_block)
     end
 
     it 'rounds using with_rounding_mode' do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -209,7 +209,19 @@ describe Money do
       expect(Money.from_amount(1, "USD", bank).bank).to eq bank
     end
 
-    it 'warns about rounding_mode deprecation' do
+    context 'given a currency is provided' do
+      context 'and the currency is nil' do
+        let(:currency) { nil }
+
+        it "should have the default currency" do
+          expect(Money.from_amount(1, currency).currency).to eq Money.default_currency
+        end
+      end
+    end
+  end
+
+  describe '.with_rounding_mode' do
+    it 'sets the .rounding_mode method deprecated' do
       allow(Money).to receive(:warn)
 
       expect(Money.from_amount(1.999).to_d).to eq 2
@@ -227,16 +239,6 @@ describe Money do
       expect(Money.with_rounding_mode(BigDecimal::ROUND_DOWN) do
         Money.from_amount(1.999).to_d
       end).to eq 1.99
-    end
-
-    context 'given a currency is provided' do
-      context 'and the currency is nil' do
-        let(:currency) { nil }
-
-        it "should have the default currency" do
-          expect(Money.from_amount(1, currency).currency).to eq Money.default_currency
-        end
-      end
     end
   end
 
@@ -322,11 +324,11 @@ YAML
 
       context "with a block" do
         it "respects the rounding_mode" do
-          expect(Money.rounding_mode(BigDecimal::ROUND_DOWN) do
+          expect(Money.with_rounding_mode(BigDecimal::ROUND_DOWN) do
             Money.new(1.9).fractional
           end).to eq 1
 
-          expect(Money.rounding_mode(BigDecimal::ROUND_UP) do
+          expect(Money.with_rounding_mode(BigDecimal::ROUND_UP) do
             Money.new(1.1).fractional
           end).to eq 2
 
@@ -334,11 +336,11 @@ YAML
         end
 
         it "works for multiplication within a block" do
-          Money.rounding_mode(BigDecimal::ROUND_DOWN) do
+          Money.with_rounding_mode(BigDecimal::ROUND_DOWN) do
             expect((Money.new(1_00) * "0.019".to_d).fractional).to eq 1
           end
 
-          Money.rounding_mode(BigDecimal::ROUND_UP) do
+          Money.with_rounding_mode(BigDecimal::ROUND_UP) do
             expect((Money.new(1_00) * "0.011".to_d).fractional).to eq 2
           end
 


### PR DESCRIPTION
# WHAT

[Allow .with_rounding_mode blocks nesting](https://github.com/RubyMoney/money/commit/ed324fd8d0340ba22e5ef9d1650d812840a32dc7)

# WHY

So, that we can safely use the block and not rely on global `rounding_mode`.

Relates to the comment in PR which introduced the feature https://github.com/RubyMoney/money/pull/343#issuecomment-31320148

