### PR TITLE
Enable Frozen string literals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'pry', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rake/clean"
 require "rspec/core/rake_task"

--- a/lib/money.rb
+++ b/lib/money.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bigdecimal"
 require "bigdecimal/util"
 require "set"

--- a/lib/money/bank/base.rb
+++ b/lib/money/bank/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   # Provides classes that aid in the ability of exchange one currency with
   # another.

--- a/lib/money/bank/single_currency.rb
+++ b/lib/money/bank/single_currency.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/bank/base'
 
 class Money

--- a/lib/money/bank/variable_exchange.rb
+++ b/lib/money/bank/variable_exchange.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/bank/base'
 require 'money/rates_store/memory'
 require 'json'

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "json"
 require "money/currency/loader"
 require "money/currency/heuristics"

--- a/lib/money/currency/heuristics.rb
+++ b/lib/money/currency/heuristics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   class Currency
     module Heuristics

--- a/lib/money/currency/loader.rb
+++ b/lib/money/currency/loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   class Currency
     module Loader

--- a/lib/money/locale_backend/base.rb
+++ b/lib/money/locale_backend/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/locale_backend/errors'
 
 class Money

--- a/lib/money/locale_backend/currency.rb
+++ b/lib/money/locale_backend/currency.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/locale_backend/base'
 
 class Money

--- a/lib/money/locale_backend/errors.rb
+++ b/lib/money/locale_backend/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   module LocaleBackend
     class NotSupported < StandardError; end

--- a/lib/money/locale_backend/i18n.rb
+++ b/lib/money/locale_backend/i18n.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/locale_backend/base'
 
 class Money

--- a/lib/money/locale_backend/legacy.rb
+++ b/lib/money/locale_backend/legacy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/locale_backend/base'
 require 'money/locale_backend/i18n'
 

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "money/bank/variable_exchange"
 require "money/bank/single_currency"
 require "money/money/arithmetic"

--- a/lib/money/money/allocation.rb
+++ b/lib/money/money/allocation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   class Allocation
     # Splits a given amount in parts. The allocation is based on the parts' proportions

--- a/lib/money/money/arithmetic.rb
+++ b/lib/money/money/arithmetic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   module Arithmetic
     # Wrapper for coerced numeric values to distinguish

--- a/lib/money/money/constructors.rb
+++ b/lib/money/money/constructors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   module Constructors
 

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/money/formatting_rules'
 
 class Money
@@ -315,17 +317,19 @@ class Money
 
     def append_currency_symbol(formatted_number)
       if rules[:with_currency]
-        formatted_number << " "
+        currency_part =
+          if rules[:html]
+            "<span class=\"currency\">#{currency}</span>"
+          elsif rules[:html_wrap]
+            html_wrap(currency.to_s, "currency")
+          else
+            currency.to_s
+          end
 
-        if rules[:html]
-          formatted_number << "<span class=\"currency\">#{currency.to_s}</span>"
-        elsif rules[:html_wrap]
-          formatted_number << html_wrap(currency.to_s, "currency")
-        else
-          formatted_number << currency.to_s
-        end
+        "#{formatted_number} #{currency_part}"
+      else
+        formatted_number
       end
-      formatted_number
     end
 
     def show_free_text?

--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   class FormattingRules
     def initialize(currency, *raw_rules)

--- a/lib/money/money/locale_backend.rb
+++ b/lib/money/money/locale_backend.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'money/locale_backend/errors'
 require 'money/locale_backend/legacy'
 require 'money/locale_backend/i18n'

--- a/lib/money/rates_store/memory.rb
+++ b/lib/money/rates_store/memory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'monitor'
 
 class Money

--- a/lib/money/version.rb
+++ b/lib/money/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Money
   VERSION = '6.19.0'.freeze
 end

--- a/money.gemspec
+++ b/money.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "money/version"

--- a/spec/bank/base_spec.rb
+++ b/spec/bank/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::Bank::Base do
 
   describe ".instance" do

--- a/spec/bank/single_currency_spec.rb
+++ b/spec/bank/single_currency_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::Bank::SingleCurrency do
   describe "#exchange_with" do
     it "raises when called" do

--- a/spec/bank/variable_exchange_spec.rb
+++ b/spec/bank/variable_exchange_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'yaml'
 

--- a/spec/currency/heuristics_spec.rb
+++ b/spec/currency/heuristics_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::Currency::Heuristics do
   describe "#analyze_string" do
     it "it raises deprecation error" do

--- a/spec/currency/loader_spec.rb
+++ b/spec/currency/loader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::Currency::Loader do
   it "returns a currency table hash" do
     expect(subject.load_currencies).to be_a Hash

--- a/spec/currency_spec.rb
+++ b/spec/currency_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::Currency do
   FOO = '{ "priority": 1, "iso_code": "FOO", "iso_numeric": "840", "name": "United States Dollar", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 1000, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "smallest_denomination": 1 }'
 

--- a/spec/locale_backend/currency_spec.rb
+++ b/spec/locale_backend/currency_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::LocaleBackend::Currency do
   describe '#lookup' do
     let(:currency) { Money::Currency.new('EUR') }

--- a/spec/locale_backend/i18n_spec.rb
+++ b/spec/locale_backend/i18n_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::LocaleBackend::I18n do
   describe '#initialize' do
     it 'raises an error when I18n is not defined' do

--- a/spec/locale_backend/legacy_spec.rb
+++ b/spec/locale_backend/legacy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::LocaleBackend::Legacy do
   after { Money.use_i18n = true }
 

--- a/spec/money/allocation_spec.rb
+++ b/spec/money/allocation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::Allocation do
    describe 'given number as argument' do
      it 'raises an error when invalid argument is given' do

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::Arithmetic do
   describe "-@" do
     it "changes the sign of a number" do

--- a/spec/money/constructors_spec.rb
+++ b/spec/money/constructors_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::Constructors do
 
   describe "::empty" do

--- a/spec/money/formatting_rules_spec.rb
+++ b/spec/money/formatting_rules_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::FormattingRules do
   it 'does not modify frozen rules in place' do
     expect {

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money, "formatting" do
 
   BAR = '{ "priority": 1, "iso_code": "BAR", "iso_numeric": "840", "name": "Dollar with 4 decimal places", "symbol": "$", "subunit": "Cent", "subunit_to_unit": 10000, "symbol_first": true, "html_entity": "$", "decimal_mark": ".", "thousands_separator": ",", "smallest_denomination": 1 }'

--- a/spec/money/locale_backend_spec.rb
+++ b/spec/money/locale_backend_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::LocaleBackend do
   describe '.find' do
     it 'returns an initialized backend' do

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money do
   describe '.locale_backend' do
     after { Money.locale_backend = :legacy }

--- a/spec/rates_store/memory_spec.rb
+++ b/spec/rates_store/memory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Money::RatesStore::Memory do
   let(:subject) { described_class.new }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.dirname(__FILE__)
 require "rspec"
 require "money"

--- a/spec/support/shared_examples/money_examples.rb
+++ b/spec/support/shared_examples/money_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples 'instance with custom bank' do |operation, value|
   let(:custom_bank) { Money::Bank::VariableExchange.new }
   let(:instance) { Money.new(1, :usd, custom_bank) }


### PR DESCRIPTION
The only method that may potentially be affected is
`Money::Formatter#append_currency_symbol`.

This method has been refactored to avoid any potential side effect
with string mutations

Additionally, a `Lint/RedundantStringCoercion` offense has been fixed

Close #1108