### PR TITLE
remove deprecated Money.infinite_precision method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Upcoming 7.0.0.alpha
 
 - **Breaking change**: Require Ruby >= 3.1 and I18n ~> 1.9
+- **Breaking change**: Remove deprecated methods:
+  - `Money.infinite_precision`
+  - `Money.infinite_precision=`
 - **Potential breaking change**: Fix RSD (Serbian Dinar) formatting to be like `12.345,42 RSD`
 - **Potential breaking change**: Fix USDC decimals places from 2 to 6
 - **Potential breaking change**: Fix MGA (Malagasy Ariary) to be a zero-decimal currency (changing subunit_to_unit from 5 to 1)

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -133,16 +133,6 @@ class Money
     attr_accessor :default_formatting_rules, :default_infinite_precision, :conversion_precision
     attr_reader :use_i18n, :locale_backend
     attr_writer :default_bank
-
-    def infinite_precision
-      warn '[DEPRECATION] `Money.infinite_precision` is deprecated - use `Money.default_infinite_precision` instead'
-      default_infinite_precision
-    end
-
-    def infinite_precision=(value)
-      warn '[DEPRECATION] `Money.infinite_precision=` is deprecated - use `Money.default_infinite_precision= ` instead'
-      self.default_infinite_precision = value
-    end
   end
 
   # @!attribute default_currency

--- a/sig/lib/money/money.rbs
+++ b/sig/lib/money/money.rbs
@@ -24,10 +24,10 @@ class Money
 
   # Convenience method for fractional part of the amount. Synonym of #fractional
   #
-  # @return [Integer] when infinite_precision is false
-  # @return [BigDecimal] when infinite_precision is true
+  # @return [Integer] when Money.default_infinite_precision is false
+  # @return [BigDecimal] when Money.default_infinite_precision is true
   #
-  # @see infinite_precision
+  # @see Money.default_infinite_precision
   def cents: () -> (Integer | BigDecimal)
 
   # The value of the monetary amount represented in the fractional or subunit
@@ -42,10 +42,10 @@ class Money
   # Money representation of one Kuwaiti dinar, the fractional interpretation is
   # 1000.
   #
-  # @return [Integer] when infinite_precision is false
-  # @return [BigDecimal] when infinite_precision is true
+  # @return [Integer] when Money.default_infinite_precision is false
+  # @return [BigDecimal] when Money.default_infinite_precision is true
   #
-  # @see infinite_precision
+  # @see Money.default_infinite_precision
   def fractional: () -> (Integer | BigDecimal)
 
   # Round a given amount of money to the nearest possible amount in cash value. For
@@ -53,10 +53,10 @@ class Money
   # CHF 0.05. Therefore, this method rounds CHF 0.07 to CHF 0.05, and CHF 0.08 to
   # CHF 0.10.
   #
-  # @return [Integer] when infinite_precision is false
-  # @return [BigDecimal] when infinite_precision is true
+  # @return [Integer] when Money.default_infinite_precision is false
+  # @return [BigDecimal] when Money.default_infinite_precision is true
   #
-  # @see infinite_precision
+  # @see Money.default_infinite_precision
   def round_to_nearest_cash_value: () -> (Integer | BigDecimal)
 
   attr_reader currency: Currency
@@ -191,10 +191,6 @@ class Money
   attr_reader self.locale_backend: untyped
 
   attr_writer self.default_bank: untyped
-
-  def self.infinite_precision: () -> untyped
-
-  def self.infinite_precision=: (untyped value) -> untyped
 
   # @!attribute default_currency
   #   @return [Money::Currency] The default currency, which is used when
@@ -494,8 +490,8 @@ class Money
   # Round the monetary amount to smallest unit of coinage.
   #
   # @note
-  #   This method is only useful when operating with infinite_precision turned
-  #   on. Without infinite_precision values are rounded to the smallest unit of
+  #   This method is only useful when operating with Money.default_infinite_precision turned
+  #   on. Without Money.default_infinite_precision values are rounded to the smallest unit of
   #   coinage automatically.
   #
   # @return [Money]


### PR DESCRIPTION
Hello @RubyMoney/core and everyone else 👋🏻

Every major release deserves some sweet breaking changes (and we already have a few lined up 😬 ). We're prepping for version 7, and I’ll start by removing some methods that were deprecated a loooong time ago.

This PR removes `Money.infinite_precision=`, which was deprecated back in 2020 [see here](https://github.com/RubyMoney/money/commit/cf4e178ae59eab5d4eec83e36dfcf2aadaf3fd51)