### PR TITLE
stop setting USD as default currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Breaking change**: Remove deprecated methods:
   - `Money.infinite_precision`
   - `Money.infinite_precision=`
+- **Breaking change**: Default currency is now `nil` instead of `USD`. If you want to keep the previous behavior, set `Money.default_currency = Money::Currency.find("USD")` in your initializer. Initializing a Money object will raise a `Currency::NoCurrency` if no currency is set.
 - **Potential breaking change**: Fix RSD (Serbian Dinar) formatting to be like `12.345,42 RSD`
 - **Potential breaking change**: Fix USDC decimals places from 2 to 6
 - **Potential breaking change**: Fix MGA (Malagasy Ariary) to be a zero-decimal currency (changing subunit_to_unit from 5 to 1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **Breaking change**: Remove deprecated methods:
   - `Money.infinite_precision`
   - `Money.infinite_precision=`
-- **Breaking change**: Default currency is now `nil` instead of `USD`. If you want to keep the previous behavior, set `Money.default_currency = Money::Currency.find("USD")` in your initializer. Initializing a Money object will raise a `Currency::NoCurrency` if no currency is set.
+- **Breaking change**: Default currency is now `nil` instead of `USD`. If you want to keep the previous behavior, set `Money.default_currency = Money::Currency.new("USD")` in your initializer. Initializing a Money object will raise a `Currency::NoCurrency` if no currency is set.
 - **Potential breaking change**: Fix RSD (Serbian Dinar) formatting to be like `12.345,42 RSD`
 - **Potential breaking change**: Fix USDC decimals places from 2 to 6
 - **Potential breaking change**: Fix MGA (Malagasy Ariary) to be a zero-decimal currency (changing subunit_to_unit from 5 to 1)

--- a/README.md
+++ b/README.md
@@ -192,8 +192,7 @@ all_currencies(Money::Currency.table)
 
 ### Default Currency
 
-By default `Money` defaults to USD as its currency. This can be overwritten
-using:
+A default currency is not set by default. If a default currency is not set, it will raise an error when you try to initialize a `Money` object without explicitly passing a currency or parse a string that does not contain a currency. You can set a default currency for your application by using:
 
 ``` ruby
 Money.default_currency = Money::Currency.new("CAD")

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -141,12 +141,6 @@ class Money
   #     default value is Currency.new("USD"). The value must be a valid
   #     +Money::Currency+ instance.
   def self.default_currency
-    if @using_deprecated_default_currency
-      warn '[WARNING] The default currency will change from `USD` to `nil` in the next major release. Make ' \
-           'sure to set it explicitly using `Money.default_currency=` to avoid potential issues'
-      @using_deprecated_default_currency = false
-    end
-
     if @default_currency.nil?
       nil
     elsif @default_currency.respond_to?(:call)
@@ -157,7 +151,6 @@ class Money
   end
 
   def self.default_currency=(currency)
-    @using_deprecated_default_currency = false
     @default_currency = currency
   end
 
@@ -192,10 +185,6 @@ class Money
   def self.setup_defaults
     # Set the default bank for creating new +Money+ objects.
     self.default_bank = Bank::VariableExchange.instance
-
-    # Set the default currency for creating new +Money+ object.
-    self.default_currency = Currency.new("USD")
-    @using_deprecated_default_currency = true
 
     # Default to using i18n
     @use_i18n = true
@@ -334,7 +323,7 @@ class Money
   #   Money.new(100, "USD") #=> #<Money @fractional=100 @currency="USD">
   #   Money.new(100, "EUR") #=> #<Money @fractional=100 @currency="EUR">
   #
-  def initialize(obj, currency = Money.default_currency, options = {})
+  def initialize(obj, currency = nil, options = {})
     # For backwards compatibility, if options is not a Hash, treat it as a bank parameter
     unless options.is_a?(Hash)
       options = { bank: options }

--- a/sig/lib/money/money.rbs
+++ b/sig/lib/money/money.rbs
@@ -20,7 +20,6 @@ class Money
 
   @default_currency: Money::Currency
   @fractional: BigDecimal
-  @using_deprecated_default_currency: bool
 
   # Convenience method for fractional part of the amount. Synonym of #fractional
   #

--- a/spec/money/arithmetic_spec.rb
+++ b/spec/money/arithmetic_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe Money::Arithmetic do
       expect { Money.new(10_00) + nil }.to raise_error(TypeError, "Unsupported argument type: NilClass")
     end
 
-    it_behaves_like 'instance with custom bank', :+, Money.new(1)
+    it_behaves_like 'instance with custom bank', :+, -> { Money.new(1) }
   end
 
   describe "#-" do
@@ -270,7 +270,7 @@ RSpec.describe Money::Arithmetic do
       expect { Money.new(10_00) - nil }.to raise_error(TypeError, "Unsupported argument type: NilClass")
     end
 
-    it_behaves_like 'instance with custom bank', :-, Money.new(1)
+    it_behaves_like 'instance with custom bank', :-, -> { Money.new(1) }
   end
 
   describe "#*" do
@@ -519,7 +519,7 @@ RSpec.describe Money::Arithmetic do
       expect(special_money_class.new(10_00, "USD").divmod(special_money_class.new(4_00)).last).to be_a special_money_class
     end
 
-    it_behaves_like 'instance with custom bank', :divmod, Money.new(1)
+    it_behaves_like 'instance with custom bank', :divmod, -> { Money.new(1) }
     it_behaves_like 'instance with custom bank', :divmod, 1
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -72,16 +72,9 @@ RSpec.describe Money do
       end
 
       context 'without a default' do
-        around do |example|
-          default_currency = Money.default_currency
+        it 'should throw an NoCurrency Error' do
           Money.default_currency = nil
 
-          example.run
-
-          Money.default_currency = default_currency
-        end
-
-        it 'should throw an NoCurrency Error' do
           expect { money }.to raise_error(Money::Currency::NoCurrency)
         end
       end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -1031,15 +1031,6 @@ YAML
       expect(Money.default_currency).to eq Money::Currency.new(:eur)
     end
 
-    it 'warns about changing default_currency value' do
-      expect(Money)
-        .to receive(:warn)
-        .with('[WARNING] The default currency will change from `USD` to `nil` in the next major release. ' \
-              'Make sure to set it explicitly using `Money.default_currency=` to avoid potential issues')
-
-      Money.default_currency
-    end
-
     it 'does not warn if the default_currency has been changed' do
       Money.default_currency = Money::Currency.new(:usd)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -112,6 +112,11 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  # Code to run once before the entire test suite
+  config.before(:suite) do
+    Money.default_currency = Money::Currency.new("USD")
+  end
 end
 
 def reset_i18n

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -113,8 +113,7 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 
-  # Code to run once before the entire test suite
-  config.before(:suite) do
+  config.before(:each) do
     Money.default_currency = Money::Currency.new("USD")
   end
 end

--- a/spec/support/shared_examples/money_examples.rb
+++ b/spec/support/shared_examples/money_examples.rb
@@ -3,8 +3,9 @@
 RSpec.shared_examples 'instance with custom bank' do |operation, value|
   let(:custom_bank) { Money::Bank::VariableExchange.new }
   let(:instance) { Money.new(1, :usd, custom_bank) }
+  let(:evaluated_value) { value.respond_to?(:call) ? value.call : value }
 
-  subject { value ? instance.send(operation, value) : instance.send(operation) }
+  subject { evaluated_value ? instance.send(operation, evaluated_value) : instance.send(operation) }
 
   it "returns custom bank from new instance" do
     new_money_instances = Array(subject).select { |el| el.is_a?(Money) }


### PR DESCRIPTION
Hello @RubyMoney/core and everyone watching this 👀

Time for another round of deprecation cleanup 🧹🧹🧹

Now that [this PR](https://github.com/RubyMoney/money/pull/1095) has been merged, we can stop setting USD as the default currency, which was already anticipated back in [2019](https://github.com/RubyMoney/money/pull/882). 

It's about time we finally pull the trigger 💪🏻