### PR TITLE
remove deprecations related with rounding mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   - `Money.infinite_precision`
   - `Money.infinite_precision=`
 - **Breaking change**: Default currency is now `nil` instead of `USD`. If you want to keep the previous behavior, set `Money.default_currency = Money::Currency.new("USD")` in your initializer. Initializing a Money object will raise a `Currency::NoCurrency` if no currency is set.
-- **Breaking change**: The default rounding mode has change from `BigDecimal::ROUND_HALF_EVEN` to `BigDecimal::ROUND_HALF_UP`. Set it explicitly using `Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN` to keep the previous behavior.
+- **Breaking change**: The default rounding mode has changed from `BigDecimal::ROUND_HALF_EVEN` to `BigDecimal::ROUND_HALF_UP`. Set it explicitly using `Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN` to keep the previous behavior.
 - **Potential breaking change**: Fix RSD (Serbian Dinar) formatting to be like `12.345,42 RSD`
 - **Potential breaking change**: Fix USDC decimals places from 2 to 6
 - **Potential breaking change**: Fix MGA (Malagasy Ariary) to be a zero-decimal currency (changing subunit_to_unit from 5 to 1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - `Money.infinite_precision`
   - `Money.infinite_precision=`
 - **Breaking change**: Default currency is now `nil` instead of `USD`. If you want to keep the previous behavior, set `Money.default_currency = Money::Currency.new("USD")` in your initializer. Initializing a Money object will raise a `Currency::NoCurrency` if no currency is set.
+- **Breaking change**: The default rounding mode has change from `BigDecimal::ROUND_HALF_EVEN` to `BigDecimal::ROUND_HALF_UP`. Set it explicitly using `Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN` to keep the previous behavior.
 - **Potential breaking change**: Fix RSD (Serbian Dinar) formatting to be like `12.345,42 RSD`
 - **Potential breaking change**: Fix USDC decimals places from 2 to 6
 - **Potential breaking change**: Fix MGA (Malagasy Ariary) to be a zero-decimal currency (changing subunit_to_unit from 5 to 1)

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ You can set the default rounding mode by passing one of the `BigDecimal` mode en
 ```ruby
 Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN
 ```
-See [BigDecimal::ROUND_MODE](https://ruby-doc.org/stdlib-2.5.1/libdoc/bigdecimal/rdoc/BigDecimal.html#ROUND_MODE) for more information
+See [BigDecimal::ROUND_MODE](https://ruby-doc.org/3.4.1/gems/bigdecimal/BigDecimal.html#ROUND_MODE) for more information
 
 ## Ruby on Rails
 

--- a/README.md
+++ b/README.md
@@ -478,9 +478,9 @@ To round to the nearest cent (or anything more precise), you can use the `round`
 
 # Money
 Money.default_infinite_precision = true
-Money.from_cents(2.34567).format       #=> "$0.0234567"
+Money.from_cents(2.34567).format #=> "$0.0234567"
 Money.from_cents(2.34567).round.format #=> "$0.02"
-Money.from_cents(2.34567).round(BigDecimal::ROUND_HALF_UP, 2).format #=> "$0.0235"
+Money.from_cents(2.34567).round(BigDecimal::ROUND_DOWN, 2).format #=> "$0.0234"
 ```
 
 You can set the default rounding mode by passing one of the `BigDecimal` mode enumerables like so:

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -168,7 +168,6 @@ class Money
 
   # @attr_writer rounding_mode Use this to specify the rounding mode
   def self.rounding_mode=(new_rounding_mode)
-    @using_deprecated_default_rounding_mode = false
     @rounding_mode = new_rounding_mode
   end
 
@@ -196,8 +195,7 @@ class Money
     self.default_infinite_precision = false
 
     # Default to bankers rounding
-    self.rounding_mode = BigDecimal::ROUND_HALF_EVEN
-    @using_deprecated_default_rounding_mode = true
+    self.rounding_mode = BigDecimal::ROUND_HALF_UP
 
     # Default the conversion of Rationals precision to 16
     self.conversion_precision = 16
@@ -211,22 +209,9 @@ class Money
 
   # Use this to return the rounding mode.
   #
-  # @param [BigDecimal::ROUND_MODE] mode
-  #
   # @return [BigDecimal::ROUND_MODE] rounding mode
-  def self.rounding_mode(mode = nil)
-    if mode
-      warn "[DEPRECATION] calling `rounding_mode` with a block is deprecated. Please use `.with_rounding_mode` instead."
-      return with_rounding_mode(mode) { yield }
-    end
-
+  def self.rounding_mode
     return Thread.current[:money_rounding_mode] if Thread.current[:money_rounding_mode]
-
-    if @using_deprecated_default_rounding_mode
-      warn '[WARNING] The default rounding mode will change from `ROUND_HALF_EVEN` to `ROUND_HALF_UP` in the ' \
-           'next major release. Set it explicitly using `Money.rounding_mode=` to avoid potential problems.'
-      @using_deprecated_default_rounding_mode = false
-    end
 
     @rounding_mode
   end
@@ -241,7 +226,7 @@ class Money
   # @return [Object] block results
   #
   # @example
-  #   fee = Money.with_rounding_mode(BigDecimal::ROUND_HALF_UP) do
+  #   fee = Money.with_rounding_mode(BigDecimal::ROUND_HALF_DOWN) do
   #     Money.new(1200) * BigDecimal('0.029')
   #   end
   def self.with_rounding_mode(mode)

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -194,7 +194,7 @@ class Money
     # Default to not using infinite precision cents
     self.default_infinite_precision = false
 
-    # Default to bankers rounding
+    # Default rounding mode toward the nearest neighbor; if the neighbors are equidistant, round away from zero
     self.rounding_mode = BigDecimal::ROUND_HALF_UP
 
     # Default the conversion of Rationals precision to 16

--- a/sig/lib/money/money.rbs
+++ b/sig/lib/money/money.rbs
@@ -215,10 +215,8 @@ class Money
 
   # Use this to return the rounding mode.
   #
-  # @param [BigDecimal::ROUND_MODE] mode
-  #
   # @return [BigDecimal::ROUND_MODE] rounding mode
-  def self.rounding_mode: (?untyped? mode) { () -> untyped } -> untyped
+  def self.rounding_mode: () -> untyped
 
   # Temporarily changes the rounding mode in a given block.
   #
@@ -230,7 +228,7 @@ class Money
   # @return [Object] block results
   #
   # @example
-  #   fee = Money.with_rounding_mode(BigDecimal::ROUND_HALF_UP) do
+  #   fee = Money.with_rounding_mode(BigDecimal::ROUND_HALF_DOWN) do
   #     Money.new(1200) * BigDecimal('0.029')
   #   end
   def self.with_rounding_mode: (untyped mode) { () -> untyped } -> untyped

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -229,23 +229,6 @@ RSpec.describe Money do
   end
 
   describe '.with_rounding_mode' do
-    it 'sets the .rounding_mode method deprecated' do
-      allow(Money).to receive(:warn)
-      allow(Money).to receive(:with_rounding_mode).and_call_original
-
-      rounding_block = lambda do
-        Money.from_amount(1.999).to_d
-      end
-
-      expect(Money.from_amount(1.999).to_d).to eq 2
-      expect(Money.rounding_mode(BigDecimal::ROUND_DOWN, &rounding_block)).to eq 1.99
-      expect(Money)
-        .to have_received(:warn)
-        .with('[DEPRECATION] calling `rounding_mode` with a block is deprecated. ' \
-              'Please use `.with_rounding_mode` instead.')
-      expect(Money).to have_received(:with_rounding_mode).with(BigDecimal::ROUND_DOWN, &rounding_block)
-    end
-
     it 'rounds using with_rounding_mode' do
       expect(Money.from_amount(1.999).to_d).to eq 2
       expect(Money.with_rounding_mode(BigDecimal::ROUND_DOWN) do
@@ -270,7 +253,7 @@ RSpec.describe Money do
 
       expect(
         Money.rounding_mode
-      ).to eq(BigDecimal::ROUND_HALF_EVEN), 'Original mode should be restored after outer block'
+      ).to eq(BigDecimal::ROUND_HALF_UP), 'Original mode should be restored after outer block'
       expect(Money.from_amount(2.137).to_d).to eq 2.14
     end
 
@@ -323,7 +306,7 @@ RSpec.describe Money do
         expect(result[:result]).to eq(expected_up)
       end
 
-      expect(Money.rounding_mode).to eq(BigDecimal::ROUND_HALF_EVEN)
+      expect(Money.rounding_mode).to eq(BigDecimal::ROUND_HALF_UP)
     end
   end
 
@@ -417,7 +400,7 @@ YAML
             Money.new(1.1).fractional
           end).to eq 2
 
-          expect(Money.rounding_mode).to eq BigDecimal::ROUND_HALF_EVEN
+          expect(Money.rounding_mode).to eq BigDecimal::ROUND_HALF_UP
         end
 
         it "works for multiplication within a block" do
@@ -429,7 +412,7 @@ YAML
             expect((Money.new(1_00) * "0.011".to_d).fractional).to eq 2
           end
 
-          expect(Money.rounding_mode).to eq BigDecimal::ROUND_HALF_EVEN
+          expect(Money.rounding_mode).to eq BigDecimal::ROUND_HALF_UP
         end
       end
     end
@@ -1029,27 +1012,6 @@ YAML
 
       expect(Money).not_to receive(:warn)
       Money.default_currency
-    end
-  end
-
-  describe ".rounding_mode" do
-    before { Money.setup_defaults }
-    after { Money.setup_defaults }
-
-    it 'warns about changing default rounding_mode value' do
-      expect(Money)
-        .to receive(:warn)
-        .with('[WARNING] The default rounding mode will change from `ROUND_HALF_EVEN` to `ROUND_HALF_UP` in ' \
-              'the next major release. Set it explicitly using `Money.rounding_mode=` to avoid potential problems.')
-
-      Money.rounding_mode
-    end
-
-    it 'does not warn if the default rounding_mode has been changed' do
-      Money.rounding_mode = BigDecimal::ROUND_HALF_UP
-
-      expect(Money).not_to receive(:warn)
-      Money.rounding_mode
     end
   end
 


### PR DESCRIPTION
Hello @RubyMoney/core and contributors!

Another deprecation out of the way before releasing a new major version! 🎉  This one was originally introduced in [this PR](https://github.com/RubyMoney/money/pull/883).

As explained in [this comment](https://github.com/RubyMoney/money/pull/883#issuecomment-562847214), the rationale for changing the default rounding mode is:

> the default rounding mode is ROUND_HALF_EVEN and they way it works might not be expected by people using this gem. It works best when aggregating with bigger amount of data and has an effect of minimizing rounding error, however when dealing with one off cases (for example rounding the result of a currency exchange) it's probably not as useful.

Out of curiosity – and to make sure we’re making the right call! – I asked ChatGPT for a summary of the different rounding modes. Besides summarizing them, it also brought up two interesting points:

- As of Ruby 3.2, the default rounding mode is now `BigDecimal::ROUND_HALF_UP`. I am always down on using the defaults. I double-checked it in [the official docs](https://ruby-doc.org/3.4.1/gems/bigdecimal/BigDecimal.html#method-c-mode):  
  <img width="2048" height="132" alt="CleanShot 2025-07-14 at 19 55 48@2x" src="https://github.com/user-attachments/assets/31259288-fa13-4425-a5b1-17c612011403" />
  
- It also noted: "Use `ROUND_HALF_EVEN` when doing financial calculations to reduce cumulative rounding error". This had me thinking because, after all, this gem is called `money`. But as @antstorm pointed out, many users might not be doing large-scale aggregations and could get unexpected results with `ROUND_HALF_EVEN` because of the way it behaves (more about that at the bottom).

I’m inclined to go ahead and change the default to `ROUND_HALF_UP`, especially since it's easy to override if someone needs the previous behavior. Plus, [this comment](https://github.com/mysociety/alaveteli/pull/5563#discussion_r378122248) mentions that Stripe uses `ROUND_HALF_UP` so I am convinced 💪🏻

PS: Quick ChatGPT summary of the difference between the two modes and a table with examples:

> - With `ROUND_HALF_UP`, every `.5` always rounds up. This can introduce a small upward bias over time.  
> - With `ROUND_HALF_EVEN`, `.5` values sometimes round up, sometimes down — helping cancel out rounding bias in large datasets. This is ideal for financial, banking, and accounting software.

<img width="1934" height="736" alt="CleanShot 2025-07-14 at 20 11 56@2x" src="https://github.com/user-attachments/assets/11760f8b-2ef2-48a3-bd97-68d92cc7b25b" />
