### PR TITLE
Fix O(n2) to be O(n) for generate method

### DIFF
--- a/lib/money/money/allocation.rb
+++ b/lib/money/money/allocation.rb
@@ -35,9 +35,9 @@ class Money
 
       result = []
       remaining_amount = amount
-
+      parts_sum = parts.sum
+    
       until parts.empty? do
-        parts_sum = parts.inject(0, :+)
         part = parts.pop
 
         current_split = 0
@@ -48,6 +48,7 @@ class Money
 
         result.unshift current_split
         remaining_amount -= current_split
+        parts_sum -= part
       end
 
       result


### PR DESCRIPTION
```bash
ruby 3.3.3 (2024-06-12 revision f1c7b6f435) [arm64-darwin23]
Warming up --------------------------------------
        generate_old   144.000 i/100ms
        generate_new   570.000 i/100ms
Calculating -------------------------------------
        generate_old      1.441k (± 0.7%) i/s  (693.93 μs/i) -      4.464k in   3.097879s
        generate_new      5.576k (± 1.4%) i/s  (179.34 μs/i) -     17.100k in   3.067351s

Comparison:
        generate_new:     5576.0 i/s
        generate_old:     1441.1 i/s - 3.87x  slower
```