### PR TITLE
remove Money#currency_as_string and Money#currency_as_string= deprecated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Upcoming 7.0.0.alpha
 
-- **Breaking change**: Require Ruby >= 3.1 and I18n ~> 1.9
+- **Breaking change**: Require Ruby >= 3.1 and i18n ~> 1.9
 - **Breaking change**: Remove deprecated methods:
-  - `Money.infinite_precision`
-  - `Money.infinite_precision=`
+  - `Money.infinite_precision`.
+  - `Money.infinite_precision=`.
+  - `Money#currency_as_string`.
+  - `Money#currency_as_string=`.
 - **Breaking change**: Default currency is now `nil` instead of `USD`. If you want to keep the previous behavior, set `Money.default_currency = Money::Currency.new("USD")` in your initializer. Initializing a Money object will raise a `Currency::NoCurrency` if no currency is set.
 - **Breaking change**: The default rounding mode has changed from `BigDecimal::ROUND_HALF_EVEN` to `BigDecimal::ROUND_HALF_UP`. Set it explicitly using `Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN` to keep the previous behavior.
 - **Potential breaking change**: Fix RSD (Serbian Dinar) formatting to be like `12.345,42 RSD`

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -397,31 +397,6 @@ class Money
     to_d
   end
 
-  # Return string representation of currency object
-  #
-  # @return [String]
-  #
-  # @example
-  #   Money.new(100, :USD).currency_as_string #=> "USD"
-  def currency_as_string
-    warn "[DEPRECATION] `currency_as_string` is deprecated. Please use `.currency.to_s` instead."
-    currency.to_s
-  end
-
-  # Set currency object using a string
-  #
-  # @param [String] val The currency string.
-  #
-  # @return [Money::Currency]
-  #
-  # @example
-  #   Money.new(100).currency_as_string("CAD") #=> #<Money::Currency id: cad>
-  def currency_as_string=(val)
-    warn "[DEPRECATION] `currency_as_string=` is deprecated - Money instances are immutable." \
-      " Please use `with_currency` instead."
-    @currency = Currency.wrap(val)
-  end
-
   # Returns a Integer hash value based on the +fractional+ and +currency+ attributes
   # in order to use functions like & (intersection), group_by, etc.
   #

--- a/sig/lib/money/money.rbs
+++ b/sig/lib/money/money.rbs
@@ -346,24 +346,6 @@ class Money
   #
   def amount: () -> BigDecimal
 
-  # Return string representation of currency object
-  #
-  # @return [String]
-  #
-  # @example
-  #   Money.new(100, :USD).currency_as_string #=> "USD"
-  def currency_as_string: () -> string
-
-  # Set currency object using a string
-  #
-  # @param [String] val The currency string.
-  #
-  # @return [Money::Currency]
-  #
-  # @example
-  #   Money.new(100).currency_as_string("CAD") #=> #<Money::Currency id: cad>
-  def currency_as_string=: (string val) -> Currency
-
   # Returns a Integer hash value based on the +fractional+ and +currency+ attributes
   # in order to use functions like & (intersection), group_by, etc.
   #

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -632,27 +632,6 @@ YAML
     end
   end
 
-  describe "#currency_as_string" do
-    it "returns the iso_code of the currency object" do
-      expect(Money.new(1_00, "USD").currency_as_string).to eq "USD"
-      expect(Money.new(1_00, "EUR").currency_as_string).to eq "EUR"
-    end
-  end
-
-  describe "#currency_as_string=" do
-    it "sets the currency object using the provided string leaving cents intact" do
-      money = Money.new(100_00, "USD")
-
-      money.currency_as_string = "EUR"
-      expect(money.currency).to eq Money::Currency.new("EUR")
-      expect(money.cents).to eq 100_00
-
-      money.currency_as_string = "YEN"
-      expect(money.currency).to eq Money::Currency.new("YEN")
-      expect(money.cents).to eq 100_00
-    end
-  end
-
   describe "#hash=" do
     it "returns the same value for equal objects" do
       expect(Money.new(1_00, "EUR").hash).to eq Money.new(1_00, "EUR").hash


### PR DESCRIPTION
Hello @RubyMoney/core and contributors!

Another day, another deprecation remove that gets us closer to the release of 7.0.0!

This deprecation was introduced [here](https://github.com/RubyMoney/money/pull/776) in 2018!!!!! ABOUT TIME WE 🧹 .