### PR TITLE
remove deprecated formatting rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Upcoming 7.0.0.alpha
 
 - **Breaking change**: Require Ruby >= 3.1 and i18n ~> 1.9
+- **Breaking change**: Remove deprecated formatting rules:
+  - `:html`
+  - `:html_wrap_symbol`
+  - `:symbol_position`
+  - `:symbol_before_without_space`
+  - `:symbol_after_without_space`
 - **Breaking change**: Remove deprecated methods:
   - `Money.infinite_precision`.
   - `Money.infinite_precision=`.

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -83,33 +83,6 @@ class Money
     #   Money.new(10000000, "INR").format(south_asian_number_formatting: true) #=> "1,00,000.00"
     #   Money.new(10000000).format(south_asian_number_formatting: true) #=> "$1,00,000.00"
     #
-    # @option rules [Boolean, nil] :symbol_before_without_space (true) Whether
-    #   a space between the money symbol and the amount should be inserted when
-    #   +:symbol_position+ is +:before+. The default is true (meaning no space). Ignored
-    #   if +:symbol+ is false or +:symbol_position+ is not +:before+.
-    #
-    # @example
-    #   # Default is to not insert a space.
-    #   Money.new(100, "USD").format #=> "$1.00"
-    #
-    #   # Same thing.
-    #   Money.new(100, "USD").format(symbol_before_without_space: true) #=> "$1.00"
-    #
-    #   # If set to false, will insert a space.
-    #   Money.new(100, "USD").format(symbol_before_without_space: false) #=> "$ 1.00"
-    #
-    # @option rules [Boolean, nil] :symbol_after_without_space (false) Whether
-    #   a space between the amount and the money symbol should be inserted when
-    #   +:symbol_position+ is +:after+. The default is false (meaning space). Ignored
-    #   if +:symbol+ is false or +:symbol_position+ is not +:after+.
-    #
-    # @example
-    #   # Default is to insert a space.
-    #   Money.new(100, "USD").format(symbol_position: :after) #=> "1.00 $"
-    #
-    #   # If set to true, will not insert a space.
-    #   Money.new(100, "USD").format(symbol_position: :after, symbol_after_without_space: true) #=> "1.00$"
-    #
     # @option rules [Boolean, String, nil] :decimal_mark (true) Whether the
     #  currency should be separated by the specified character or '.'
     #
@@ -139,13 +112,6 @@ class Money
     #   # If the thousands_separator for a given currency isn't known, then it will
     #   # default to "," as thousands_separator.
     #   Money.new(100000, "FOO").format #=> "$1,000.00"
-    #
-    # @option rules [Boolean] :html (false) Whether the currency should be
-    #  HTML-formatted. Only useful in combination with +:with_currency+.
-    #
-    # @example
-    #   Money.ca_dollar(570).format(html: true, with_currency: true)
-    #   #=> "$5.70 <span class=\"currency\">CAD</span>"
     #
     # @option rules [Boolean] :html_wrap (false) Whether all currency parts should be HTML-formatted.
     #
@@ -181,20 +147,6 @@ class Money
     #   Money.new(10000, "CAD").format(disambiguate: false)   #=> "$100.00"
     #   Money.new(10000, "USD").format(disambiguate: true)    #=> "$100.00"
     #   Money.new(10000, "CAD").format(disambiguate: true)    #=> "C$100.00"
-    #
-    # @option rules [Boolean] :html_wrap_symbol (false) Wraps the currency symbol
-    #  in a html <span> tag.
-    #
-    # @example
-    #   Money.new(10000, "USD").format(html_wrap_symbol: true)
-    #   #=> "<span class=\"currency_symbol\">$100.00</span>
-    #
-    # @option rules [Symbol] :symbol_position (:before) `:before` if the currency
-    #   symbol goes before the amount, `:after` if it goes after.
-    #
-    # @example
-    #   Money.new(10000, "USD").format(symbol_position: :before) #=> "$100.00"
-    #   Money.new(10000, "USD").format(symbol_position: :after)  #=> "100.00 $"
     #
     # @option rules [Boolean] :translate (true) `true` Checks for custom
     #   symbol definitions using I18n.
@@ -301,9 +253,7 @@ class Money
       symbol_value = symbol_value_from(rules)
 
       if symbol_value && !symbol_value.empty?
-        if rules[:html_wrap_symbol]
-          symbol_value = "<span class=\"currency_symbol\">#{symbol_value}</span>"
-        elsif rules[:html_wrap]
+        if rules[:html_wrap]
           symbol_value = html_wrap(symbol_value, "currency-symbol")
         end
 
@@ -318,9 +268,7 @@ class Money
     def append_currency_symbol(formatted_number)
       if rules[:with_currency]
         currency_part =
-          if rules[:html]
-            "<span class=\"currency\">#{currency}</span>"
-          elsif rules[:html_wrap]
+          if rules[:html_wrap]
             html_wrap(currency.to_s, "currency")
           else
             currency.to_s
@@ -401,7 +349,7 @@ class Money
         else
           ""
         end
-      elsif rules[:html] || rules[:html_wrap]
+      elsif rules[:html_wrap]
         currency.html_entity == '' ? currency.symbol : currency.html_entity
       elsif rules[:disambiguate] && currency.disambiguate_symbol
         currency.disambiguate_symbol

--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -12,8 +12,6 @@ class Money
       @rules = translate_formatting_rules(@rules) if @rules[:translate]
       @rules[:format] ||= determine_format_from_formatting_rules(@rules)
       @rules[:delimiter_pattern] ||= delimiter_pattern_rule(@rules)
-
-      warn_about_deprecated_rules(@rules)
     end
 
     def [](key)
@@ -71,14 +69,10 @@ class Money
     end
 
     def determine_format_from_formatting_rules(rules)
-      return currency.format if currency.format && !rules.has_key?(:symbol_position)
-
-      symbol_position = symbol_position_from(rules)
-
-      if symbol_position == :before
-        rules.fetch(:symbol_before_without_space, true) ? '%u%n' : '%u %n'
+      if currency.format
+        currency.format
       else
-        rules[:symbol_after_without_space] ? '%n%u' : '%n %u'
+        currency.symbol_first? ? "%u%n" : "%n %u"
       end
     end
 
@@ -88,45 +82,6 @@ class Money
         /(\d+?)(?=(\d\d)+(\d)(?!\d))(\.\d+)?/
       else
         /(\d)(?=(?:\d{3})+(?:[^\d]{1}|$))/
-      end
-    end
-
-    def symbol_position_from(rules)
-      if rules.has_key?(:symbol_position)
-        if [:before, :after].include?(rules[:symbol_position])
-          return rules[:symbol_position]
-        else
-          raise ArgumentError, ":symbol_position must be ':before' or ':after'"
-        end
-      elsif currency.symbol_first?
-        :before
-      else
-        :after
-      end
-    end
-
-    def warn_about_deprecated_rules(rules)
-      if rules.has_key?(:symbol_position)
-        position = rules[:symbol_position]
-        template = position == :before ? '%u%n' : '%n%u'
-
-        warn "[DEPRECATION] `symbol_position: :#{position}` is deprecated - you can replace it with `format: #{template}`"
-      end
-
-      if rules.has_key?(:symbol_before_without_space)
-        warn "[DEPRECATION] `symbol_before_without_space:` option is deprecated - you can replace it with `format: '%u%n'`"
-      end
-
-      if rules.has_key?(:symbol_after_without_space)
-        warn "[DEPRECATION] `symbol_after_without_space:` option is deprecated - you can replace it with `format: '%n%u'`"
-      end
-
-      if rules.has_key?(:html)
-        warn "[DEPRECATION] `html` is deprecated - use `html_wrap` instead. Please note that `html_wrap` will wrap all parts of currency and if you use `with_currency` option, currency element class changes from `currency` to `money-currency`."
-      end
-
-      if rules.has_key?(:html_wrap_symbol)
-        warn "[DEPRECATION] `html_wrap_symbol` is deprecated - use `html_wrap` instead. Please note that `html_wrap` will wrap all parts of currency."
       end
     end
   end

--- a/sig/lib/money/money/formatter.rbs
+++ b/sig/lib/money/money/formatter.rbs
@@ -76,33 +76,6 @@ class Money
     #   Money.new(10000000, "INR").format(south_asian_number_formatting: true) #=> "1,00,000.00"
     #   Money.new(10000000).format(south_asian_number_formatting: true) #=> "$1,00,000.00"
     #
-    # @option rules [Boolean, nil] :symbol_before_without_space (true) Whether
-    #   a space between the money symbol and the amount should be inserted when
-    #   +:symbol_position+ is +:before+. The default is true (meaning no space). Ignored
-    #   if +:symbol+ is false or +:symbol_position+ is not +:before+.
-    #
-    # @example
-    #   # Default is to not insert a space.
-    #   Money.new(100, "USD").format #=> "$1.00"
-    #
-    #   # Same thing.
-    #   Money.new(100, "USD").format(symbol_before_without_space: true) #=> "$1.00"
-    #
-    #   # If set to false, will insert a space.
-    #   Money.new(100, "USD").format(symbol_before_without_space: false) #=> "$ 1.00"
-    #
-    # @option rules [Boolean, nil] :symbol_after_without_space (false) Whether
-    #   a space between the amount and the money symbol should be inserted when
-    #   +:symbol_position+ is +:after+. The default is false (meaning space). Ignored
-    #   if +:symbol+ is false or +:symbol_position+ is not +:after+.
-    #
-    # @example
-    #   # Default is to insert a space.
-    #   Money.new(100, "USD").format(symbol_position: :after) #=> "1.00 $"
-    #
-    #   # If set to true, will not insert a space.
-    #   Money.new(100, "USD").format(symbol_position: :after, symbol_after_without_space: true) #=> "1.00$"
-    #
     # @option rules [Boolean, String, nil] :decimal_mark (true) Whether the
     #  currency should be separated by the specified character or '.'
     #
@@ -133,27 +106,11 @@ class Money
     #   # default to "," as thousands_separator.
     #   Money.new(100000, "FOO").format #=> "$1,000.00"
     #
-    # @option rules [Boolean] :html (false) Whether the currency should be
-    #  HTML-formatted. Only useful in combination with +:with_currency+.
-    #
-    # @example
-    #   Money.ca_dollar(570).format(html: true, with_currency: true)
-    #   #=> "$5.70 <span class=\"currency\">CAD</span>"
-    #
     # @option rules [Boolean] :html_wrap (false) Whether all currency parts should be HTML-formatted.
     #
     # @example
     #   Money.ca_dollar(570).format(html_wrap: true, with_currency: true)
     #   #=> "<span class=\"money-currency-symbol\">$</span><span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">.</span><span class=\"money-decimal\">70</span> <span class=\"money-currency\">CAD</span>"
-    #
-    # @option rules [Boolean] :sign_before_symbol (false) Whether the sign should be
-    #  before the currency symbol.
-    #
-    # @example
-    #   # You can specify to display the sign before the symbol for negative numbers
-    #   Money.new(-100, "GBP").format(sign_before_symbol: true)  #=> "-£1.00"
-    #   Money.new(-100, "GBP").format(sign_before_symbol: false) #=> "£-1.00"
-    #   Money.new(-100, "GBP").format                               #=> "£-1.00"
     #
     # @option rules [Boolean] :sign_positive (false) Whether positive numbers should be
     #  signed, too.
@@ -174,20 +131,6 @@ class Money
     #   Money.new(10000, "CAD").format(disambiguate: false)   #=> "$100.00"
     #   Money.new(10000, "USD").format(disambiguate: true)    #=> "$100.00"
     #   Money.new(10000, "CAD").format(disambiguate: true)    #=> "C$100.00"
-    #
-    # @option rules [Boolean] :html_wrap_symbol (false) Wraps the currency symbol
-    #  in a html <span> tag.
-    #
-    # @example
-    #   Money.new(10000, "USD").format(disambiguate: false)
-    #   #=> "<span class=\"currency_symbol\">$100.00</span>
-    #
-    # @option rules [Symbol] :symbol_position (:before) `:before` if the currency
-    #   symbol goes before the amount, `:after` if it goes after.
-    #
-    # @example
-    #   Money.new(10000, "USD").format(symbol_position: :before) #=> "$100.00"
-    #   Money.new(10000, "USD").format(symbol_position: :after)  #=> "100.00 $"
     #
     # @option rules [Boolean] :translate (true) `true` Checks for custom
     #   symbol definitions using I18n.

--- a/sig/lib/money/money/formatting_rules.rbs
+++ b/sig/lib/money/money/formatting_rules.rbs
@@ -28,9 +28,5 @@ class Money
     def determine_format_from_formatting_rules: (Hash[Symbol, untyped] rules) -> Hash[Symbol, untyped]
 
     def delimiter_pattern_rule: (Hash[Symbol, untyped] rules) -> ::Regexp
-
-    def symbol_position_from: (Hash[Symbol, untyped] rules) -> (Hash[Symbol, untyped] | :before | :after)
-
-    def warn_about_deprecated_rules: (Hash[Symbol, untyped] rules) -> void
   end
 end

--- a/spec/money/formatting_rules_spec.rb
+++ b/spec/money/formatting_rules_spec.rb
@@ -14,22 +14,4 @@ RSpec.describe Money::FormattingRules do
     expect(rules).to eq(separator: '.')
     expect(rules).not_to eq(new_rules)
   end
-
-  context 'when the position is :before' do
-    it 'warns about deprecated :symbol_position' do
-      expect_any_instance_of(Money::FormattingRules).to receive(:warn)
-        .with('[DEPRECATION] `symbol_position: :before` is deprecated - you can replace it with `format: %u%n`')
-
-      Money::FormattingRules.new(Money::Currency.new('USD'), symbol_position: :before)
-    end
-  end
-
-  context "when the position is :after" do
-    it 'warns about deprecated :symbol_position' do
-      expect_any_instance_of(Money::FormattingRules).to receive(:warn)
-        .with('[DEPRECATION] `symbol_position: :after` is deprecated - you can replace it with `format: %n%u`')
-
-      Money::FormattingRules.new(Money::Currency.new('USD'), symbol_position: :after)
-    end
-  end
 end

--- a/spec/money/formatting_spec.rb
+++ b/spec/money/formatting_spec.rb
@@ -282,12 +282,6 @@ RSpec.describe Money, "formatting" do
         expect(Money.new(100000000, "RUB").format(no_cents: true)).to eq "1.000.000 ₽"
       end
 
-      it "doesn't incorrectly format HTML" do
-        money = ::Money.new(1999, "RUB")
-        output = money.format(html: true, no_cents: true)
-        expect(output).to eq "19 &#x20BD;"
-      end
-
       it "doesn't incorrectly format HTML (html_wrap)" do
         money = ::Money.new(1999, "RUB")
         output = money.format(html_wrap: true, no_cents: true)
@@ -503,25 +497,6 @@ RSpec.describe Money, "formatting" do
       end
     end
 
-    describe ":html option" do
-      specify "(html: true) works as documented" do
-        string = Money.ca_dollar(570).format(html: true, with_currency: true)
-        expect(string).to eq "$5.70 <span class=\"currency\">CAD</span>"
-      end
-
-      specify "should fallback to symbol if entity is not available" do
-        string = Money.new(570, 'DKK').format(html: true)
-        expect(string).to eq "5,70 kr."
-      end
-    end
-
-    describe ":html_wrap_symbol option" do
-      specify "(html_wrap_symbol: true) works as documented" do
-        string = Money.ca_dollar(570).format(html_wrap_symbol: true)
-        expect(string).to eq "<span class=\"currency_symbol\">$</span>5.70"
-      end
-    end
-
     describe ":html_wrap option" do
       specify "(html_wrap: true) works as documented" do
         string = Money.ca_dollar(570).format(html_wrap: true)
@@ -536,59 +511,6 @@ RSpec.describe Money, "formatting" do
       specify "should fallback to symbol if entity is not available" do
         string = Money.new(570, 'DKK').format(html_wrap: true)
         expect(string).to eq "<span class=\"money-whole\">5</span><span class=\"money-decimal-mark\">,</span><span class=\"money-decimal\">70</span> <span class=\"money-currency-symbol\">kr.</span>"
-      end
-    end
-
-    describe ":symbol_position option" do
-      it "inserts currency symbol before the amount when set to :before" do
-        expect(Money.euro(1_234_567_12).format(symbol_position: :before)).to eq "€1.234.567,12"
-      end
-
-      it "inserts currency symbol after the amount when set to :after" do
-        expect(Money.us_dollar(1_000_000_000_12).format(symbol_position: :after)).to eq "1,000,000,000.12 $"
-      end
-
-      it "raises an ArgumentError when passed an invalid option" do
-        expect{Money.euro(0).format(symbol_position: :befor)}.to raise_error(ArgumentError)
-      end
-    end
-
-    describe ":sign_before_symbol option" do
-      specify "(sign_before_symbol: true) works as documented" do
-        expect(Money.us_dollar(-100000).format(sign_before_symbol: true)).to eq "-$1,000.00"
-      end
-
-      specify "(sign_before_symbol: false) works as documented" do
-        expect(Money.us_dollar(-100000).format(sign_before_symbol: false)).to eq "$-1,000.00"
-        expect(Money.us_dollar(-100000).format(sign_before_symbol: nil)).to eq "$-1,000.00"
-      end
-    end
-
-    describe ":symbol_before_without_space option" do
-      it "does not insert space between currency symbol and amount when set to true" do
-        expect(Money.euro(1_234_567_12).format(symbol_position: :before, symbol_before_without_space: true)).to eq "€1.234.567,12"
-      end
-
-      it "inserts space between currency symbol and amount when set to false" do
-        expect(Money.euro(1_234_567_12).format(symbol_position: :before, symbol_before_without_space: false)).to eq "€ 1.234.567,12"
-      end
-
-      it "defaults to true" do
-        expect(Money.euro(1_234_567_12).format(symbol_position: :before)).to eq "€1.234.567,12"
-      end
-    end
-
-    describe ":symbol_after_without_space option" do
-      it "does not insert space between amount and currency symbol when set to true" do
-        expect(Money.euro(1_234_567_12).format(symbol_position: :after, symbol_after_without_space: true)).to eq "1.234.567,12€"
-      end
-
-      it "inserts space between amount and currency symbol when set to false" do
-        expect(Money.euro(1_234_567_12).format(symbol_position: :after, symbol_after_without_space: false)).to eq "1.234.567,12 €"
-      end
-
-      it "defaults to false" do
-        expect(Money.euro(1_234_567_12).format(symbol_position: :after)).to eq "1.234.567,12 €"
       end
     end
 
@@ -703,21 +625,6 @@ RSpec.describe Money, "formatting" do
         expect(money.format(format: 'Your balance is: %u%n')).to eq('Your balance is: $99.99')
       end
 
-      it 'ignores :symbol_position in favour of format' do
-        expect(money.format(format: '%u%n', symbol_position: :after)).to eq('$99.99')
-        expect(money.format(format: '%n%u', symbol_position: :before)).to eq('99.99$')
-      end
-
-      it 'ignores :symbol_before_without_space in favour of format' do
-        expect(money.format(format: '%u %n', symbol_position: :before, symbol_before_without_space: true)).to eq('$ 99.99')
-        expect(money.format(format: '%u%n', symbol_position: :before, symbol_before_without_space: false)).to eq('$99.99')
-      end
-
-      it 'ignores :symbol_after_without_space in favour of format' do
-        expect(money.format(format: '%n %u', symbol_position: :after, symbol_after_without_space: true)).to eq('99.99 $')
-        expect(money.format(format: '%n%u', symbol_position: :after, symbol_after_without_space: false)).to eq('99.99$')
-      end
-
       it 'works with sign' do
         money = Money.new(-99_99, 'USD')
 
@@ -758,52 +665,12 @@ RSpec.describe Money, "formatting" do
         expect(Money.new(100_00, 'CHF').format).to eq "CHF 100.00"
       end
     end
-
-    context 'when symbol_position is passed' do
-      it "inserts currency symbol before the amount when set to :before" do
-        expect(Money.new(100_00, 'CHF').format(symbol_position: :before)).to eq "CHF100.00"
-      end
-
-      it "inserts currency symbol after the amount when set to :after" do
-        expect(Money.new(100_00, 'CHF').format(symbol_position: :after)).to eq "100.00 CHF"
-      end
-    end
-
-    context 'when :symbol_before_without_space is passed' do
-      it "does not insert space between currency symbol and amount when set to true" do
-        expect(Money.new(100_00, 'CHF').format(symbol_position: :before, symbol_before_without_space: true)).to eq "CHF100.00"
-      end
-
-      it "insert space between currency symbol and amount when set to false" do
-        expect(Money.new(100_00, 'CHF').format(symbol_position: :before, symbol_before_without_space: false)).to eq "CHF 100.00"
-      end
-    end
   end
 
   describe ':format to "%n %u" for currency with :symbol_first to false' do
     context 'when rules are not passed' do
       it "insert space between symbol and number" do
         expect(Money.new(100_00, 'AED').format).to eq "100.00 د.إ"
-      end
-    end
-
-    context 'when symbol_position is passed' do
-      it "inserts currency symbol before the amount when set to :before" do
-        expect(Money.new(100_00, 'AED').format(symbol_position: :before)).to eq "د.إ100.00"
-      end
-
-      it "inserts currency symbol after the amount when set to :after" do
-        expect(Money.new(100_00, 'AED').format(symbol_position: :after)).to eq "100.00 د.إ"
-      end
-    end
-
-    context 'when :symbol_before_without_space is passed' do
-      it "does not insert space between currency symbol and amount when set to true" do
-        expect(Money.new(100_00, 'AED').format(symbol_position: :before, symbol_before_without_space: true)).to eq "د.إ100.00"
-      end
-
-      it "insert space between currency symbol and amount when set to false" do
-        expect(Money.new(100_00, 'AED').format(symbol_position: :before, symbol_before_without_space: false)).to eq "د.إ 100.00"
       end
     end
   end


### PR DESCRIPTION
Hello @RubyMoney/core and contributors (@sunny 😉)!

More cleanup of long-deprecated stuff 🔥 These formatting rules were deprecated in 2018! https://github.com/RubyMoney/money/pull/798 and https://github.com/RubyMoney/money/pull/777

PS: I am very close to have all long deprecated things 🧹 Thanks for your patience 🙏🏻 