### PR TITLE
Deprecate `Money#dollars` and `Money.from_dollars`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
 - Add Caribbean Guilder (XCG) as replacement for Netherlands Antillean Gulden (ANG)
 - Add `Money#to_nearest_cash_value` to return a rounded Money instance to the smallest denomination
 - Deprecate `Money#round_to_nearest_cash_value` in favor of calling `to_nearest_cash_value.fractional`
-- Deprecate `Money#dollars` in favor of `Money#amount` and `Money.from_dollars` in favor of `Money.from_amount`.
+- Deprecate `Money#dollars` in favor of `Money#amount`.
+- Deprecate `Money.from_dollars` in favor of `Money.from_amount`.
 - Add `Money::Currency#cents_based?` to check if currency is cents-based
 - Add ability to nest `Money.with_rounding_mode` blocks
 - Allow `nil` to be used as a default_currency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add Caribbean Guilder (XCG) as replacement for Netherlands Antillean Gulden (ANG)
 - Add `Money#to_nearest_cash_value` to return a rounded Money instance to the smallest denomination
 - Deprecate `Money#round_to_nearest_cash_value` in favor of calling `to_nearest_cash_value.fractional`
+- Deprecate `Money#dollars` when the currency is not USD, prefer calling `#amount`
 - Add `Money::Currency#cents_based?` to check if currency is cents-based
 - Add ability to nest `Money.with_rounding_mode` blocks
 - Allow `nil` to be used as a default_currency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Add Caribbean Guilder (XCG) as replacement for Netherlands Antillean Gulden (ANG)
 - Add `Money#to_nearest_cash_value` to return a rounded Money instance to the smallest denomination
 - Deprecate `Money#round_to_nearest_cash_value` in favor of calling `to_nearest_cash_value.fractional`
-- Deprecate `Money#dollars` when the currency is not USD, prefer calling `#amount`
+- Deprecate `Money#dollars` in favor of `Money#amount` and `Money.from_dollars` in favor of `Money.from_amount`.
 - Add `Money::Currency#cents_based?` to check if currency is cents-based
 - Add ability to nest `Money.with_rounding_mode` blocks
 - Allow `nil` to be used as a default_currency

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -365,34 +365,37 @@ class Money
   end
 
   # Assuming using a currency using dollars:
-  # Returns the value of the money in dollars,
-  # instead of in the fractional unit cents.
+  # Returns the value of the money in dollars, instead of in the fractional unit
+  # cents.
   #
   # Synonym of #amount
   #
   # @return [BigDecimal]
   #
   # @example
-  #   Money.new(1_00, "USD").dollars   # => BigDecimal("1.00")
+  #   Money.new(1_00, "USD").dollars # => BigDecimal("1.00")
   #
   # @see #amount
   # @see #to_d
   # @see #cents
-  #
   def dollars
+    unless currency == "USD"
+      warn "[DEPRECATION] `#dollars` was called on an instance of Money in " \
+           "#{currency}. Prefer calling `#amount` instead."
+    end
+
     amount
   end
 
-  # Returns the numerical value of the money
+  # Returns the numerical value of the money.
   #
   # @return [BigDecimal]
   #
   # @example
-  #   Money.new(1_00, "USD").amount    # => BigDecimal("1.00")
+  #   Money.new(1_00, "USD").amount # => BigDecimal("1.00")
   #
   # @see #to_d
   # @see #fractional
-  #
   def amount
     to_d
   end
@@ -595,9 +598,7 @@ class Money
   # @example
   #   Money.new(10.1, 'USD').round #=> Money.new(10, 'USD')
   #
-  # @see
-  #   Money.default_infinite_precision
-  #
+  # @see Money.default_infinite_precision
   def round(rounding_mode = self.class.rounding_mode, rounding_precision = 0)
     rounded_amount = as_d(@fractional).round(rounding_precision, rounding_mode)
     dup_with(fractional: rounded_amount)

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -373,25 +373,12 @@ class Money
     raise Currency::NoCurrency, 'must provide a currency' if @currency.nil?
   end
 
-  # Assuming using a currency using dollars:
-  # Returns the value of the money in dollars, instead of in the fractional unit
-  # cents.
-  #
-  # Synonym of #amount
-  #
-  # @return [BigDecimal]
-  #
-  # @example
-  #   Money.new(1_00, "USD").dollars # => BigDecimal("1.00")
+  # DEPRECATED.
   #
   # @see #amount
-  # @see #to_d
-  # @see #cents
   def dollars
-    unless currency == "USD"
-      warn "[DEPRECATION] `#dollars` was called on an instance of Money in " \
-           "#{currency}. Prefer calling `#amount` instead."
-    end
+    warn "[DEPRECATION] `Money#dollars` is deprecated in favor of " \
+         "`Money#amount`."
 
     amount
   end

--- a/lib/money/money.rb
+++ b/lib/money/money.rb
@@ -321,9 +321,18 @@ class Money
     new(value, currency, options)
   end
 
+  # DEPRECATED.
+  #
+  # @see Money.from_amount
+  def self.from_dollars(amount, currency = default_currency, options = {})
+    warn "[DEPRECATION] `Money.from_dollars` is deprecated in favor of " \
+         "`Money.from_amount`."
+
+    from_amount(amount, currency, options)
+  end
+
   class << self
     alias_method :from_cents, :new
-    alias_method :from_dollars, :from_amount
   end
 
   # Creates a new Money object of value given in the

--- a/sig/lib/money/money.rbs
+++ b/sig/lib/money/money.rbs
@@ -320,20 +320,9 @@ class Money
   #
   def initialize: (Object obj, ?(Money::Currency | string | Symbol) currency, ?::Hash[untyped, untyped] options) -> Money
 
-  # Assuming using a currency using dollars:
-  # Returns the value of the money in dollars, instead of in the fractional unit
-  # cents.
-  #
-  # Synonym of #amount
-  #
-  # @return [BigDecimal]
-  #
-  # @example
-  #   Money.new(1_00, "USD").dollars # => BigDecimal("1.00")
+  # DEPRECATED.
   #
   # @see #amount
-  # @see #to_d
-  # @see #cents
   def dollars: () -> BigDecimal
 
   # Returns the numerical value of the money.

--- a/sig/lib/money/money.rbs
+++ b/sig/lib/money/money.rbs
@@ -290,9 +290,12 @@ class Money
   # @see #initialize
   def self.from_amount: (Numeric amount, ?(Money::Currency | string | Symbol) currency, ?::Hash[untyped, untyped] options) -> Money
 
-  alias self.from_cents self.new
+  # DEPRECATED.
+  #
+  # @see Money.from_amount
+  def self.from_amount: (Numeric amount, ?(Money::Currency | string | Symbol) currency, ?::Hash[untyped, untyped] options) -> Money
 
-  alias self.from_dollars self.from_amount
+  alias self.from_cents self.new
 
   # Creates a new Money object of value given in the
   # +fractional unit+ of the given +currency+.

--- a/sig/lib/money/money.rbs
+++ b/sig/lib/money/money.rbs
@@ -318,32 +318,30 @@ class Money
   def initialize: (Object obj, ?(Money::Currency | string | Symbol) currency, ?::Hash[untyped, untyped] options) -> Money
 
   # Assuming using a currency using dollars:
-  # Returns the value of the money in dollars,
-  # instead of in the fractional unit cents.
+  # Returns the value of the money in dollars, instead of in the fractional unit
+  # cents.
   #
   # Synonym of #amount
   #
   # @return [BigDecimal]
   #
   # @example
-  #   Money.new(1_00, "USD").dollars   # => BigDecimal("1.00")
+  #   Money.new(1_00, "USD").dollars # => BigDecimal("1.00")
   #
   # @see #amount
   # @see #to_d
   # @see #cents
-  #
   def dollars: () -> BigDecimal
 
-  # Returns the numerical value of the money
+  # Returns the numerical value of the money.
   #
   # @return [BigDecimal]
   #
   # @example
-  #   Money.new(1_00, "USD").amount    # => BigDecimal("1.00")
+  #   Money.new(1_00, "USD").amount # => BigDecimal("1.00")
   #
   # @see #to_d
   # @see #fractional
-  #
   def amount: () -> BigDecimal
 
   # Returns a Integer hash value based on the +fractional+ and +currency+ attributes
@@ -498,9 +496,7 @@ class Money
   # @example
   #   Money.new(10.1, 'USD').round #=> Money.new(10, 'USD')
   #
-  # @see
-  #   Money.default_infinite_precision
-  #
+  # @see Money.default_infinite_precision
   def round: (?untyped rounding_mode, ?::Integer rounding_precision) -> Money
 
   # Creates a formatted price string according to several rules.

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Money do
     context 'initializing with .from_dollars' do
       subject(:money) { Money.from_dollars(initializing_value) }
 
-      it 'works like .from_amount but warns' do
+      it "is a deprecated .from_amount" do
         allow(Money).to receive(:warn)
         expect(money.amount).to eq initializing_value
         expect(Money).to have_received(:warn).with(/DEPRECATION/)
@@ -616,11 +616,7 @@ YAML
   end
 
   describe "#dollars" do
-    it "is a synonym of #amount" do
-      expect(Money.new(1_23, "USD").dollars).to eq(1.23)
-    end
-
-    it "warns" do
+    it "is a deprecated synonym of #amount" do
       money = Money.new(1_23)
 
       allow(money).to receive(:warn)

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Money do
       subject(:money) { Money.from_dollars(initializing_value) }
 
       it 'works just as with .from_amount' do
-        expect(money.dollars).to eq initializing_value
+        expect(money.amount).to eq initializing_value
       end
 
       it "warns" do
@@ -601,7 +601,7 @@ YAML
   end
 
   describe "#amount" do
-    it "returns the amount of cents as dollars" do
+    it "returns the amount of cents as the full unit" do
       expect(Money.new(1_00).amount).to eq 1
     end
 
@@ -626,14 +626,12 @@ YAML
       expect(Money.new(1_23, "USD").dollars).to eq(1.23)
     end
 
-    context "when using another currency" do
-      it "warns" do
-        amount = Money.new(1_23, "EUR")
+    it "warns" do
+      money = Money.new(1_23)
 
-        allow(amount).to receive(:warn)
-        expect(amount.dollars).to eq(1.23)
-        expect(amount).to have_received(:warn).with(/DEPRECATION/)
-      end
+      allow(money).to receive(:warn)
+      expect(money.dollars).to eq(1.23)
+      expect(money).to have_received(:warn).with(/DEPRECATION/)
     end
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -614,15 +614,18 @@ YAML
   end
 
   describe "#dollars" do
-    it "is synonym of #amount" do
-      m = Money.new(0)
+    it "is a synonym of #amount" do
+      expect(Money.new(1_23, "USD").dollars).to eq(1.23)
+    end
 
-      # Make a small expectation
-      def m.amount
-        5
+    context "when using another currency" do
+      it "warns" do
+        amount = Money.new(1_23, "EUR")
+
+        allow(amount).to receive(:warn)
+        expect(amount.dollars).to eq(1.23)
+        expect(amount).to have_received(:warn).with(/DEPRECATION/)
       end
-
-      expect(m.dollars).to eq 5
     end
   end
 
@@ -648,14 +651,16 @@ YAML
   end
 
   describe "#symbol" do
-    it "works as documented" do
-      currency = Money::Currency.new("EUR")
-      expect(currency).to receive(:symbol).and_return("€")
-      expect(Money.new(0, currency).symbol).to eq "€"
+    it "returns the currency’s symbol" do
+      expect(Money.new(0, "EUR").symbol).to eq("€")
+    end
 
-      currency = Money::Currency.new("EUR")
-      expect(currency).to receive(:symbol).and_return(nil)
-      expect(Money.new(0, currency).symbol).to eq "¤"
+    context "when the currency has no symbol" do
+      it "returns a generic currency symbol" do
+        currency = Money::Currency.new("EUR")
+        expect(currency).to receive(:symbol).and_return(nil)
+        expect(Money.new(0, currency).symbol).to eq "¤"
+      end
     end
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -138,6 +138,14 @@ RSpec.describe Money do
       it 'works just as with .from_amount' do
         expect(money.dollars).to eq initializing_value
       end
+
+      it "warns" do
+        allow(Money).to receive(:warn)
+
+        money
+
+        expect(Money).to have_received(:warn).with(/DEPRECATION/)
+      end
     end
   end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Money do
     context 'initializing with .from_dollars' do
       subject(:money) { Money.from_dollars(initializing_value) }
 
-      it "is a deprecated .from_amount" do
+      it "is a deprecated synonym of .from_amount" do
         allow(Money).to receive(:warn)
         expect(money.amount).to eq initializing_value
         expect(Money).to have_received(:warn).with(/DEPRECATION/)
@@ -652,9 +652,13 @@ YAML
     end
 
     context "when the currency has no symbol" do
-      it "returns a generic currency symbol" do
-        currency = Money::Currency.new("EUR")
+      let(:currency) { Money::Currency.new("EUR") }
+
+      before do
         expect(currency).to receive(:symbol).and_return(nil)
+      end
+
+      it "returns a generic currency symbol" do
         expect(Money.new(0, currency).symbol).to eq "¤"
       end
     end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -135,15 +135,9 @@ RSpec.describe Money do
     context 'initializing with .from_dollars' do
       subject(:money) { Money.from_dollars(initializing_value) }
 
-      it 'works just as with .from_amount' do
-        expect(money.amount).to eq initializing_value
-      end
-
-      it "warns" do
+      it 'works like .from_amount but warns' do
         allow(Money).to receive(:warn)
-
-        money
-
+        expect(money.amount).to eq initializing_value
         expect(Money).to have_received(:warn).with(/DEPRECATION/)
       end
     end


### PR DESCRIPTION
The `#dollars` method assumes the amount is in `USD` but does nothing to verify that.

```rb
Money.new(1_23, "USD").dollars # => 1.23 ✅
Money.new(1_23, "EUR").dollars # => 1.23 🤔
```

~I would like to add a warning to let people know that something is wrong here and so that in the future we can actually raise an error here.~

*Edit: Calling `#dollars` and `.from_dollars` are both now deprecated in favor of `#amount` and `.from_amount`.*