### PR TITLE
Adjust formatting rules to use i18n translations for `:format`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,6 +30,7 @@ Dave Kroondyk
 Diego Aguir Selzlein
 Doug Droper
 Douglas Miller
+Drew Bragg
 Ed Saunders
 Edwin Vlieg
 Eloy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **Potential breaking change**: Fix USDC decimals places from 2 to 6
 - **Potential breaking change**: Fix MGA (Malagasy Ariary) to be a zero-decimal currency (changing subunit_to_unit from 5 to 1)
 - **Potential breaking change**: Remove special handling for Japanese language only
+- **Potential breaking change**: Adjust formatting rules to use i18n translations for `:format`
 - Updated Armenian Dram sign and HTML entity
 - Updated the Turkmen Manat symbol and HTML entity and added disambiguation symbol for TMM
 - Expose Money::VERSION

--- a/lib/money/locale_backend/i18n.rb
+++ b/lib/money/locale_backend/i18n.rb
@@ -8,7 +8,8 @@ class Money
       KEY_MAP = {
         thousands_separator: :delimiter,
         decimal_mark: :separator,
-        symbol: :unit
+        symbol: :unit,
+        format: :format,
       }.freeze
 
       def initialize

--- a/lib/money/money/formatting_rules.rb
+++ b/lib/money/money/formatting_rules.rb
@@ -10,7 +10,7 @@ class Money
 
       @rules = default_formatting_rules.merge(@rules) unless @rules[:ignore_defaults]
       @rules = translate_formatting_rules(@rules) if @rules[:translate]
-      @rules[:format] ||= determine_format_from_formatting_rules(@rules)
+      @rules[:format] ||= determine_format
       @rules[:delimiter_pattern] ||= delimiter_pattern_rule(@rules)
     end
 
@@ -68,7 +68,11 @@ class Money
       rules
     end
 
-    def determine_format_from_formatting_rules(rules)
+    def determine_format
+      Money.locale_backend&.lookup(:format, @currency) || default_format
+    end
+
+    def default_format
       if currency.format
         currency.format
       else

--- a/spec/locale_backend/currency_spec.rb
+++ b/spec/locale_backend/currency_spec.rb
@@ -11,5 +11,9 @@ RSpec.describe Money::LocaleBackend::Currency do
     it 'returns decimal_mark based as defined in currency' do
       expect(subject.lookup(:decimal_mark, currency)).to eq(',')
     end
+
+    it 'returns format based as defined in currency' do
+      expect(subject.lookup(:format, currency)).to eq(nil)
+    end
   end
 end

--- a/spec/locale_backend/i18n_spec.rb
+++ b/spec/locale_backend/i18n_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Money::LocaleBackend::I18n do
       before do
         I18n.locale = :de
         I18n.backend.store_translations(:de, number: {
-          currency: { format: { delimiter: '.', separator: ',', unit: '$' } }
+          currency: { format: { delimiter: '.', separator: ',', unit: '$', format: '%u%n' } }
         })
       end
 
@@ -35,6 +35,10 @@ RSpec.describe Money::LocaleBackend::I18n do
 
       it 'returns symbol based on the current locale' do
         expect(subject.lookup(:symbol, nil)).to eq('$')
+      end
+
+      it 'returns format based on the current locale' do
+        expect(subject.lookup(:format, nil)).to eq('%u%n')
       end
     end
 
@@ -64,6 +68,10 @@ RSpec.describe Money::LocaleBackend::I18n do
 
       it 'returns symbol based on the current locale' do
         expect(subject.lookup(:symbol, nil)).to eq(nil)
+      end
+
+      it 'returns format based on the current locale' do
+        expect(subject.lookup(:format, nil)).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
What's changing?
Allow the default format for a language be configured via I18n.

Why?
Fixes https://github.com/RubyMoney/money/issues/233 (which was closed with no solution).

This is an updated version of #1115 