### PR TITLE
Change Saudi Riyal symbol to new official character

### DIFF
--- a/config/currency_iso.json
+++ b/config/currency_iso.json
@@ -1857,7 +1857,7 @@
     "priority": 100,
     "iso_code": "SAR",
     "name": "Saudi Riyal",
-    "symbol": "ر.س",
+    "symbol": "⃁",
     "alternate_symbols": ["SR", "﷼"],
     "subunit": "Hallallah",
     "subunit_to_unit": 100,


### PR DESCRIPTION
The new Saudi Riyal symbol scheduled to be released with Unicode 17.0

Raw symbol: `⃁`
Unicode codepoint: `U+20C1`

References:
- https://blog.unicode.org/2025/03/support-for-new-saudi-riyal-currency.html
- https://unicode-explorer.com/c/20C1

NOTE:
It probably isn't a good idea to merge or release this without widespread adoption of Unicode 17, I just made the PR to have it ready.