### PR TITLE
Release RBS files along with the gem package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix name for ANG currency
 - Change disambiguate symbol for ARS from historical to international format 
 - Update documentation of disambiguate feature
+- Include RBS type signatures (`sig/`) in the released gem
 
 ## 7.0.2
 

--- a/money.gemspec
+++ b/money.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 3.1"
 
-  s.files         = `git ls-files -z -- config/* lib/* CHANGELOG.md LICENSE money.gemspec README.md`.split("\x0")
+  s.files         = `git ls-files -z -- config/* lib/* sig/* CHANGELOG.md LICENSE money.gemspec README.md`.split("\x0")
   s.require_paths = ["lib"]
 
   if s.respond_to?(:metadata)


### PR DESCRIPTION
As per [docs](https://github.com/ruby/gem_rbs_collection/blob/e7a9964da22a610305173770e36871b1163faaa7/docs/CONTRIBUTING.md#before-you-start), we should include the sig directory in the gem package.

Fixes #1216 