### PR TITLE
Update documentation of USD disambiguation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix symbol for XPF (CFP Franc) currency to use "₣"
 - Fix name for ANG currency
 - Change disambiguate symbol for ARS from historical to international format 
+- Update documentation of disambiguate feature
 
 ## 7.0.2
 

--- a/lib/money/money/formatter.rb
+++ b/lib/money/money/formatter.rb
@@ -149,7 +149,7 @@ class Money
     # @example
     #   Money.new(10000, "USD").format(disambiguate: false)   #=> "$100.00"
     #   Money.new(10000, "CAD").format(disambiguate: false)   #=> "$100.00"
-    #   Money.new(10000, "USD").format(disambiguate: true)    #=> "$100.00"
+    #   Money.new(10000, "USD").format(disambiguate: true)    #=> "US$100.00"
     #   Money.new(10000, "CAD").format(disambiguate: true)    #=> "C$100.00"
     #
     # @option rules [Boolean] :translate (true) `true` Checks for custom

--- a/sig/lib/money/money/formatter.rbs
+++ b/sig/lib/money/money/formatter.rbs
@@ -129,7 +129,7 @@ class Money
     # @example
     #   Money.new(10000, "USD").format(disambiguate: false)   #=> "$100.00"
     #   Money.new(10000, "CAD").format(disambiguate: false)   #=> "$100.00"
-    #   Money.new(10000, "USD").format(disambiguate: true)    #=> "$100.00"
+    #   Money.new(10000, "USD").format(disambiguate: true)    #=> "US$100.00"
     #   Money.new(10000, "CAD").format(disambiguate: true)    #=> "C$100.00"
     #
     # @option rules [Boolean] :translate (true) `true` Checks for custom


### PR DESCRIPTION
This is related to #1120. There it was discussed to update [the documentation of the disambiguate feature](https://github.com/RubyMoney/money/blob/main/lib/money/money/formatter.rb#L152) to correctly reflect the behavior for USD.

Since nothing happened in #1120 for a few months, I took the liberty of giving this a shot.