### PR TITLE
Add money-unirate-api to implementations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ implementations.
 - [money-historical-bank](https://github.com/atwam/money-historical-bank)
 - [russian_central_bank](https://github.com/rmustafin/russian_central_bank)
 - [money-uphold-bank](https://github.com/subvisual/money-uphold-bank)
+- [money-unirate-api](https://github.com/UniRate-API/money-unirate-api)
 
 ## Formatting
 


### PR DESCRIPTION
## Summary

Adds [money-unirate-api](https://github.com/UniRate-API/money-unirate-api) to the Implementations list.

`money-unirate-api` is a `Money::Bank::VariableExchange` subclass that fetches live exchange rates from the [UniRate API](https://unirateapi.com). It pulls a single-base snapshot from `/api/rates` and derives every cross-pair on demand (`rate(FROM, TO) = base→TO / base→FROM`), so derived pairs are never stale-cached.

**Features:**
- Lazy fetch on first conversion + optional `ttl_in_seconds` auto-refresh + `flush_rates`
- Zero runtime dependencies beyond `money` (>= 6.13, < 7) — pure `net/http` + `json`
- 22 RSpec/WebMock mock tests; CI matrix Ruby 3.0–3.4

Published on RubyGems: https://rubygems.org/gems/money-unirate-api

**Disclosure:** I'm the maintainer of the UniRate API and this gem.