### PR TITLE
Fix JRuby 10 CI failure by restricting rdoc to MRI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "rubocop-rspec", "~> 3.8.0", require: false
 
 # Documentation
 gem "yard", "~> 0.9.38"
-gem "rdoc"
+gem "rdoc", platforms: [:mri, :windows] # rdoc >= 8 depends on rbs, which has no JRuby build
 gem "redcarpet" unless RUBY_PLATFORM == "java"
 
 gemspec


### PR DESCRIPTION
@sunny this is the same thing I fixed in `money-rails` https://github.com/RubyMoney/money-rails/pull/785

Hopefully [the issue](https://github.com/ruby/rbs/issues/3041) is resolved soonish and we can unpin the version and/or the platforms. For now, let's have our CI back to green to unlock https://github.com/RubyMoney/money/pull/1217