### PR TITLE
Parse imported JSON rates with JSON.parse

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,7 +64,6 @@ James Hunt
 Jean-Louis Giordano
 Jean-Philippe Doyle
 Jell
-Jérémy Lecour
 Jeremy McNevin
 Jesse Cooke
 Jim Kingdon
@@ -78,13 +77,14 @@ Joshua Clayton
 Julia Aalbers
 Julia López
 Julien Boyer
+Jérémy Lecour
 Kaleem Ullah
 Kenichi Kamiya
 Kenn Ejima
 Kenneth Salomon
 kirillian
 Laurynas Butkus
-Łukasz Wójcik
+lenamonj
 Marcel Scherf
 Marco Otte-Witte
 Mateus Gomes
@@ -152,4 +152,5 @@ Yok
 Yuri Sidorov
 Yuusuke Takizawa
 Zubin Henner
+Łukasz Wójcik
 Бродяной Александр

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix `Money::Bank::VariableExchange#import_rates` parsing `:json` with `JSON.load`, which instantiates any class named by a `json_class` key; it now uses `JSON.parse`
+
 ## 7.1.1
 
 - Fix `sig/manifest.yaml` declaring `set` as a dependency, which made `rbs -r money` and Steep's `library "money"` fail with `UnknownLibraryError` on every RBS >= 3.0.0

--- a/lib/money/bank/variable_exchange.rb
+++ b/lib/money/bank/variable_exchange.rb
@@ -267,7 +267,7 @@ class Money
         end
 
         store.transaction do
-          data = FORMAT_SERIALIZERS[format].load(string)
+          data = format == :json ? JSON.parse(string) : FORMAT_SERIALIZERS[format].load(string)
 
           data.each do |key, rate|
             from, to = key.split(SERIALIZER_SEPARATOR)

--- a/spec/money/bank/variable_exchange_spec.rb
+++ b/spec/money/bank/variable_exchange_spec.rb
@@ -225,6 +225,19 @@ RSpec.describe Money::Bank::VariableExchange do
         expect(bank.get_rate("USD", "EUR")).to eq 1.25
         expect(bank.get_rate("USD", "JPY")).to eq 2.55
       end
+
+      it "does not instantiate objects named by a json_class key" do
+        gadget = Class.new do
+          def self.json_create(_object)
+            raise "json_create must never be called while importing rates"
+          end
+        end
+        stub_const("JsonGadget", gadget)
+
+        bank.import_rates(:json, '{"USD_TO_EUR":{"json_class":"JsonGadget"}}')
+
+        expect(bank.get_rate("USD", "EUR")).to eq({ "json_class" => "JsonGadget" })
+      end
     end
 
     context "with format == :ruby" do


### PR DESCRIPTION
`import_rates(:json, ...)` parsed with `JSON.load`, which honours `json_class` keys and instantiates any class carrying a `json_create` hook, while the method's own warning offers `:json` as a safe alternative to `:ruby`.

It now parses with `JSON.parse`. The new spec fails on main and passes with the change; rspec and rubocop are clean. CHANGELOG and AUTHORS updated.
