### PR TITLE
Clear the cached currency keys in Currency.reset!

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,7 +64,6 @@ James Hunt
 Jean-Louis Giordano
 Jean-Philippe Doyle
 Jell
-Jérémy Lecour
 Jeremy McNevin
 Jesse Cooke
 Jim Kingdon
@@ -78,13 +77,14 @@ Joshua Clayton
 Julia Aalbers
 Julia López
 Julien Boyer
+Jérémy Lecour
 Kaleem Ullah
 Kenichi Kamiya
 Kenn Ejima
 Kenneth Salomon
 kirillian
 Laurynas Butkus
-Łukasz Wójcik
+lenamonj
 Marcel Scherf
 Marco Otte-Witte
 Mateus Gomes
@@ -152,4 +152,5 @@ Yok
 Yuri Sidorov
 Yuusuke Takizawa
 Zubin Henner
+Łukasz Wójcik
 Бродяной Александр

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix `Money::Currency.reset!` keeping the cached key set, so a currency registered before the reset was still accepted by `Money::Currency.new` and raised `NoMethodError` instead of `UnknownCurrency`
+
 ## 7.1.1
 
 - Fix `sig/manifest.yaml` declaring `set` as a dependency, which made `rbs -r money` and Steep's `library "money"` fail with `UnknownLibraryError` on every RBS >= 3.0.0

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -217,6 +217,7 @@ class Money
       def reset!
         @@instances = {}
         @table = Loader.load_currencies
+        @stringified_keys = nil
         clear_iso_numeric_cache
       end
 

--- a/spec/money/currency_spec.rb
+++ b/spec/money/currency_spec.rb
@@ -533,5 +533,16 @@ RSpec.describe Money::Currency do
       described_class.reset!
       expect(described_class.find(:cad).decimal_mark).not_to eq modified_mark
     end
+
+    it "drops a registered currency it no longer holds" do
+      described_class.register(iso_code: "ZZZ", subunit_to_unit: 100, priority: 1)
+      described_class.new("ZZZ")
+
+      described_class.reset!
+
+      expect(described_class.find(:zzz)).to be_nil
+      expect { described_class.new("ZZZ") }
+        .to raise_error(described_class::UnknownCurrency)
+    end
   end
 end


### PR DESCRIPTION
`Currency.reset!` reloads the table and clears the instance and iso_numeric caches, but not the memoized key set that `Currency.new` gates on. After `register`, a lookup, then `reset!`, `Currency.new` still admitted the removed id and raised `NoMethodError` from `initialize_data!` instead of `UnknownCurrency`, which `find` does not rescue.

`reset!` now clears the key set as well. The new spec fails on main and passes with the change; rspec and rubocop are clean. CHANGELOG and AUTHORS updated.
